### PR TITLE
fix the way libsecp256k1 is included

### DIFF
--- a/apps/omisego_api/mix.exs
+++ b/apps/omisego_api/mix.exs
@@ -31,7 +31,6 @@ defmodule OmiseGO.API.MixProject do
       {:blockchain, "~> 0.1.6"},
       {:ex_unit_fixtures, "~> 0.3.1", only: [:test]},
       {:merkle_tree, git: "https://github.com/omisego/merkle_tree.git"},
-      {:libsecp256k1, "~> 0.1.2", compile: "${HOME}/.mix/rebar compile", override: true},
       #
       {:omisego_db, in_umbrella: true},
       {:omisego_eth, in_umbrella: true},

--- a/mix.exs
+++ b/mix.exs
@@ -22,7 +22,7 @@ defmodule OmiseGO.Umbrella.MixProject do
       {:excoveralls, "~> 0.8", only: [:test], runtime: false},
       # NOTE: we're overriding for the sake of `omisego_api` mix.exs deps. Otherwise the override is ignored
       # TODO: making it consistent is advised: maybe discuss with exth_crypto and submit pr there?
-      {:libsecp256k1, "~> 0.1.3", compile: "${HOME}/.mix/rebar compile", override: true},
+      {:libsecp256k1, "~> 0.1.3", compile: "rebar compile", override: true},
     ]
   end
 end


### PR DESCRIPTION
drop duplicated override directive; don't assume path to `rebar`