### PR TITLE
omisego/omisego#31

### DIFF
--- a/apps/omisego_eth/test/eth_test.exs
+++ b/apps/omisego_eth/test/eth_test.exs
@@ -2,6 +2,7 @@ defmodule OmiseGO.EthTest do
   alias OmiseGO.Eth, as: Eth
   alias OmiseGO.Eth.WaitFor, as: WaitFor
 
+  use ExUnitFixtures
   use ExUnit.Case, async: false
 
   @timeout 10_000
@@ -24,17 +25,14 @@ defmodule OmiseGO.EthTest do
 
   defp deposit(contract) do
     data = "deposit()" |> ABI.encode([]) |> Base.encode16()
-
-    {:ok, transaction_hash} =
-      Ethereumex.HttpClient.eth_send_transaction(%{
-        from: contract.from,
-        to: contract.address,
-        data: "0x#{data}",
-        gas: "0x2D0900",
-        gasPrice: "0x1",
-        value: "0x1"
-      })
-
+    {:ok, transaction_hash} = Ethereumex.HttpClient.eth_send_transaction(%{
+      from: contract.from,
+      to: contract.address,
+      data: "0x#{data}",
+      gas: "0x2D0900",
+      gasPrice: "0x1",
+      value: "0x1"
+    })
     {:ok, _} = WaitFor.eth_receipt(transaction_hash, @timeout)
   end
 
@@ -55,7 +53,8 @@ defmodule OmiseGO.EthTest do
 
   defp add_bloks(range, contract) do
     for nonce <- range do
-      {:ok, txhash} = Eth.submit_block(generate_transaction(nonce), contract.from, contract.address)
+      {:ok, txhash} =
+        Eth.submit_block(generate_transaction(nonce), contract.from, contract.address)
 
       {:ok, _} = WaitFor.eth_receipt(txhash, @timeout)
     end
@@ -85,9 +84,8 @@ defmodule OmiseGO.EthTest do
   test "gets deposits from a range of blocks", %{contract: contract} do
     deposit(contract)
     {:ok, height} = Eth.get_ethereum_height()
-
-    assert {:ok, [%{amount: 1, block_height: 1, owner: contract.from}]} ==
-             Eth.get_deposits(1, height, contract.address)
+    assert {:ok, [%{amount: 1, blknum: 1, owner: contract.from}]} ==
+      Eth.get_deposits(1, height, contract.address)
   end
 
   @tag fixtures: [:contract]

--- a/apps/omisego_eth/test/test_helper.exs
+++ b/apps/omisego_eth/test/test_helper.exs
@@ -1,5 +1,7 @@
 ExUnit.configure(exclude: [requires_geth: true])
 ExUnitFixtures.start()
+# need to do this in umbrella apps
+ExUnitFixtures.load_fixture_files()
 ExUnit.start()
 
 defmodule OmiseGO.Eth.TestHelpers do


### PR DESCRIPTION
Reverts omisego/omisego#31

Reverting since #31 breaks eth_test.ex, which depends on ExUnitFixtures. This also introduces a breaks a test by making it expect block_height instead of blknum which is being returned from Eth.get_deposits.