### PR TITLE
Fix geth kill timeouts for OS X

### DIFF
--- a/apps/omisego_eth/lib/dev_geth.ex
+++ b/apps/omisego_eth/lib/dev_geth.ex
@@ -41,7 +41,7 @@ defmodule OmiseGO.Eth.DevGeth do
     _ = Logger.debug(fn -> "Starting geth" end)
 
     {:ok, geth_proc, _ref, [{:stream, geth_out, _stream_server}]} =
-      Exexec.run(cmd, stdout: :stream, kill_command: "kill -9 $(pidof geth)")
+      Exexec.run(cmd, stdout: :stream, kill_command: "pkill -9 geth")
 
     wait_for_geth_start(geth_out)
 


### PR DESCRIPTION
I was getting these timeout errors on OS X:

```
  1) test child block increment after add block (OmiseGO.EthTest)
     test/eth_test.exs:63
     ** (MatchError) no match of right hand side value: {:error, :timeout}
     stacktrace:
       lib/dev_geth.ex:29: OmiseGO.Eth.DevGeth.stop/1
       (ex_unit) lib/ex_unit/on_exit_handler.ex:140: ExUnit.OnExitHandler.exec_callback/1
       (ex_unit) lib/ex_unit/on_exit_handler.ex:126: ExUnit.OnExitHandler.on_exit_runner_loop/0
```

`pidof` does not work on OS X. Working with @pdobacz, we tried removing the `kill_command:` argument from Execxec.run, which returns `:normal`. We also changed the left hand side in `stop()` and it failed every other test.

`pkill -9 geth` works but open to better options.

