### PR TITLE
Ignore virtualenv directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ your_config_file.exs
 # results of perftesting and profiling with default arguments
 fprof.trace
 perf_result_*
+
+# Common virtualenv directory
+env/


### PR DESCRIPTION
Using `env/` for virtualenv is a convention we have in plasma-mvp and plasma-cash. Adding here.