### PR TITLE
OMG-228: fix: clean performance test: fixtures and warning

### DIFF
--- a/apps/omg_api/test/integration/fixtures.exs
+++ b/apps/omg_api/test/integration/fixtures.exs
@@ -15,10 +15,30 @@
 defmodule OMG.API.Integration.Fixtures do
   use ExUnitFixtures.FixtureModule
   use OMG.Eth.Fixtures
+  use OMG.DB.Fixtures
 
   alias OMG.Eth
 
   import OMG.API.Integration.DepositHelper
+
+  deffixture omg_child_chain(root_chain_contract_config, token_contract_config, db_initialized) do
+    # match variables to hide "unused var" warnings (can't be fixed by underscoring in line above, breaks macro):
+    _ = root_chain_contract_config
+    _ = db_initialized
+    _ = token_contract_config
+    Application.put_env(:omg_api, :ethereum_event_block_finality_margin, 2, persistent: true)
+    # need to overide that to very often, so that many checks fall in between a single child chain block submission
+    {:ok, started_apps} = Application.ensure_all_started(:omg_api)
+    {:ok, started_jsonrpc} = Application.ensure_all_started(:omg_jsonrpc)
+
+    on_exit(fn ->
+      (started_apps ++ started_jsonrpc)
+      |> Enum.reverse()
+      |> Enum.map(fn app -> :ok = Application.stop(app) end)
+    end)
+
+    :ok
+  end
 
   deffixture alice_deposits(alice, token) do
     {:ok, alice_address} = Eth.DevHelpers.import_unlock_fund(alice)

--- a/apps/omg_api/test/integration/happy_path_test.exs
+++ b/apps/omg_api/test/integration/happy_path_test.exs
@@ -20,7 +20,6 @@ defmodule OMG.API.Integration.HappyPathTest do
   use ExUnitFixtures
   use ExUnit.Case, async: false
   use OMG.Eth.Fixtures
-  use OMG.DB.Fixtures
 
   alias OMG.API.BlockQueue
   alias OMG.API.Crypto
@@ -29,25 +28,6 @@ defmodule OMG.API.Integration.HappyPathTest do
   alias OMG.JSONRPC.Client
 
   @moduletag :integration
-
-  deffixture omg_child_chain(root_chain_contract_config, token_contract_config, db_initialized) do
-    # match variables to hide "unused var" warnings (can't be fixed by underscoring in line above, breaks macro):
-    _ = root_chain_contract_config
-    _ = db_initialized
-    _ = token_contract_config
-    Application.put_env(:omg_api, :ethereum_event_block_finality_margin, 2, persistent: true)
-    # need to overide that to very often, so that many checks fall in between a single child chain block submission
-    {:ok, started_apps} = Application.ensure_all_started(:omg_api)
-    {:ok, started_jsonrpc} = Application.ensure_all_started(:omg_jsonrpc)
-
-    on_exit(fn ->
-      (started_apps ++ started_jsonrpc)
-      |> Enum.reverse()
-      |> Enum.map(fn app -> :ok = Application.stop(app) end)
-    end)
-
-    :ok
-  end
 
   defp eth, do: Crypto.zero_address()
 

--- a/apps/omg_performance/lib/performance.ex
+++ b/apps/omg_performance/lib/performance.ex
@@ -25,6 +25,15 @@ defmodule OMG.Performance do
   ## start_extended_perftest runs test with 100 transactions for one specified account and default options.
     > mix run --no-start -e 'OMG.Performance.start_extended_perftest(100, [%{ addr: <<192, 206, 18, ...>>, priv: <<246, 22, 164, ...>>}], "0xbc5f ...")'
 
+  # Note:
+
+  `:fprof` will print a warning:
+  ```
+  Warning: {erlang,trace,3} called in "<0.514.0>" - trace may become corrupt!
+  ```
+  It is caused by using `procs: :all` in options. So far we're not using :erlang.trace/3 in our code,
+  so it has been ignored. Otherwise it's easy to reproduce and report if anyone has the nerve
+  (github.com/erlang/otp and the JIRA it points you to).
   """
 
   use OMG.API.LoggerExt

--- a/apps/omg_performance/test/performance_test.exs
+++ b/apps/omg_performance/test/performance_test.exs
@@ -15,10 +15,7 @@
 defmodule OMG.PerformanceTest do
   use ExUnitFixtures
   use ExUnit.Case, async: false
-  use OMG.Eth.Fixtures
-  use OMG.Eth.Fixtures
-  use OMG.Watcher.Fixtures
-  use OMG.API.Fixtures
+  use OMG.API.Integration.Fixtures
 
   import ExUnit.CaptureIO
 
@@ -44,7 +41,7 @@ defmodule OMG.PerformanceTest do
     smoke_test_statistics(Path.join(destdir, perf_result), ntxs * nsenders)
   end
 
-  @tag fixtures: [:destdir, :contract, :geth, :child_chain, :root_chain_contract_config, :alice, :bob]
+  @tag fixtures: [:destdir, :contract, :omg_child_chain, :alice, :bob]
   test "Smoke test - run start_extended_perf and see if it don't crash", %{
     destdir: destdir,
     contract: contract,
@@ -69,9 +66,6 @@ defmodule OMG.PerformanceTest do
       capture_io(fn ->
         assert :ok = OMG.Performance.start_simple_perftest(ntxs, nsenders, %{destdir: destdir, profile: true})
       end)
-
-    # TODO a warning is printed out in fprof_io - check it out and possibly test against that
-    if fprof_io =~ "Warning", do: _ = Logger.warn(fn -> "fprof prints warnings during test" end)
 
     assert fprof_io =~ "Done!"
 

--- a/apps/omg_performance/test/test_helper.exs
+++ b/apps/omg_performance/test/test_helper.exs
@@ -14,4 +14,6 @@
 
 ExUnit.configure(exclude: [integration: true])
 ExUnitFixtures.start()
+# loading all fixture files from the whole umbrella project
+ExUnitFixtures.load_fixture_files("../**/test/**/fixtures.exs")
 ExUnit.start()


### PR DESCRIPTION
the warning from :fprof about :erlang.trace/3 being called is a non-issue, ignoring
also made the performance extended test use the simpler API.Integration chain fixture

closes OMG-228