### PR TITLE
docs: improve the explanations to build the dev environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Alternatively, a persistent developer instance that does not lose state can be s
 geth --dev --dev.period 1 --rpc --rpcapi personal,web3,eth --datadir ~/.geth
 ```
 
-#### Configure the `omg_eth` app
+#### Prepare and configure the root chain contract
 
 The following step will:
 - create, fund and unlock the authority address
@@ -119,6 +119,8 @@ The following step will:
 - create the config file
 
 Note that `geth` needs to already be running for this step to work!
+
+From the root dir of `elixir-omg`:
 ```
 mix compile
 mix run --no-start -e \

--- a/apps/omg_eth/mix.exs
+++ b/apps/omg_eth/mix.exs
@@ -51,7 +51,7 @@ defmodule OMG.Eth.MixProject do
   end
 
   defp contracts_compile do
-    mixfile_path = File.cwd!()
+    mixfile_path = __DIR__
     "cd #{mixfile_path}/../../ && py-solc-simple -i deps/plasma_contracts/contracts/ -o contracts/build/"
   end
 end

--- a/apps/omg_eth/test/support/dev_helpers.ex
+++ b/apps/omg_eth/test/support/dev_helpers.ex
@@ -32,6 +32,12 @@ defmodule OMG.Eth.DevHelpers do
 
   @one_hundred_eth trunc(:math.pow(10, 18) * 100)
 
+  @doc """
+  Prepares the developer's environment with respect to the root chain contract and its configuration within
+  the application.
+
+   - `root_path` should point to `elixir-omg` root or wherever where `./contracts/build` holds the compiled contracts
+  """
   def prepare_env!(root_path \\ "./") do
     {:ok, _} = Application.ensure_all_started(:ethereumex)
     {:ok, authority} = create_and_fund_authority_addr()
@@ -251,14 +257,16 @@ defmodule OMG.Eth.DevHelpers do
   defp read_contracts_json!(path_project_root, contract_name) do
     path = "contracts/build/#{contract_name}.json"
 
-    case File.read(Path.join(path_project_root, path)) do
+    full_path = path_project_root |> Path.join(path) |> Path.expand()
+
+    case File.read(full_path) do
       {:ok, contract_json} ->
         contract_json
 
       {:error, reason} ->
         raise(
           RuntimeError,
-          "Can't read #{path} because #{inspect(reason)}, try running mix deps.compile plasma_contracts"
+          "Can't read #{full_path} because #{inspect(reason)}, try running mix deps.compile plasma_contracts"
         )
     end
   end


### PR DESCRIPTION
the `prepare_env` step was frequently run from `apps/omg_eth` dir, which wouldn't work