### PR TITLE
Feature/quick fix slow sync

### DIFF
--- a/apps/omg_api/lib/application.ex
+++ b/apps/omg_api/lib/application.ex
@@ -35,7 +35,7 @@ defmodule OMG.API.Application do
         OMG.API.EthereumEventListener,
         [
           %{
-            synced_height_update_key: :last_depositer_block_height,
+            synced_height_update_key: :last_depositer_eth_height,
             service_name: :depositer,
             block_finality_margin: block_finality_margin,
             get_events_callback: &OMG.Eth.RootChain.get_deposits/2,
@@ -49,7 +49,7 @@ defmodule OMG.API.Application do
         OMG.API.EthereumEventListener,
         [
           %{
-            synced_height_update_key: :last_exiter_block_height,
+            synced_height_update_key: :last_exiter_eth_height,
             service_name: :exiter,
             block_finality_margin: block_finality_margin,
             get_events_callback: &OMG.Eth.RootChain.get_exits/2,

--- a/apps/omg_api/lib/ethereum_event_listener.ex
+++ b/apps/omg_api/lib/ethereum_event_listener.ex
@@ -42,7 +42,12 @@ defmodule OMG.API.EthereumEventListener do
         process_events_callback: process_events_callback,
         get_last_synced_height_callback: last_event_block_height_callback
       }) do
+    {:ok, contract_deployment_height} = OMG.Eth.RootChain.get_root_deployment_height()
     {:ok, last_event_block_height} = last_event_block_height_callback.()
+
+    # we don't need to ever look at earlier than contract deployment
+    last_event_block_height = max(last_event_block_height, contract_deployment_height)
+
     {:ok, _} = schedule_get_events(Application.get_env(:omg_api, :rootchain_height_sync_interval_ms))
     :ok = RootchainCoordinator.check_in(last_event_block_height, service_name)
 

--- a/apps/omg_api/lib/state.ex
+++ b/apps/omg_api/lib/state.ex
@@ -64,7 +64,7 @@ defmodule OMG.API.State do
     GenServer.call(__MODULE__, {:exit_not_spent_utxo, utxo})
   end
 
-  @spec utxo_exists?(%{blknum: number, txindex: number, oindex: number}) :: boolean()
+  @spec utxo_exists?(Core.exit_t()) :: boolean()
   def utxo_exists?(utxo) do
     GenServer.call(__MODULE__, {:utxo_exists, utxo})
   end

--- a/apps/omg_api/lib/state.ex
+++ b/apps/omg_api/lib/state.ex
@@ -83,7 +83,7 @@ defmodule OMG.API.State do
   """
   def init(:ok) do
     {:ok, height_query_result} = DB.child_top_block_number()
-    {:ok, last_deposit_query_result} = DB.last_deposit_height()
+    {:ok, last_deposit_query_result} = DB.last_deposit_child_blknum()
     {:ok, utxos_query_result} = DB.utxos()
     {:ok, child_block_interval} = Eth.RootChain.get_child_block_interval()
 

--- a/apps/omg_api/lib/state/core.ex
+++ b/apps/omg_api/lib/state/core.ex
@@ -26,7 +26,7 @@ defmodule OMG.API.State.Core do
 
   @maximum_block_size 65_536
 
-  defstruct [:height, :last_deposit_height, :utxos, pending_txs: [], tx_index: 0]
+  defstruct [:height, :last_deposit_child_blknum, :utxos, pending_txs: [], tx_index: 0]
 
   alias OMG.API.Block
   alias OMG.API.Crypto
@@ -37,7 +37,7 @@ defmodule OMG.API.State.Core do
 
   @type t() :: %__MODULE__{
           height: non_neg_integer(),
-          last_deposit_height: non_neg_integer(),
+          last_deposit_child_blknum: non_neg_integer(),
           utxos: utxos,
           pending_txs: list(Transaction.Recovered.t()),
           tx_index: non_neg_integer()
@@ -75,23 +75,23 @@ defmodule OMG.API.State.Core do
           {:put, :utxo, {{pos_integer, non_neg_integer, non_neg_integer}, map}}
           | {:delete, :utxo, {pos_integer, non_neg_integer, non_neg_integer}}
           | {:put, :child_top_block_number, pos_integer}
-          | {:put, :last_deposit_block_height, pos_integer}
+          | {:put, :last_deposit_child_blknum, pos_integer}
           | {:put, :block, Block.t()}
 
   @spec extract_initial_state(
           utxos_query_result :: [utxos],
           height_query_result :: non_neg_integer,
-          last_deposit_height_query_result :: non_neg_integer,
+          last_deposit_child_blknum_query_result :: non_neg_integer,
           child_block_interval :: pos_integer
         ) :: {:ok, t()}
   def extract_initial_state(
         utxos_query_result,
         height_query_result,
-        last_deposit_height_query_result,
+        last_deposit_child_blknum_query_result,
         child_block_interval
       )
       when is_list(utxos_query_result) and is_integer(height_query_result) and
-             is_integer(last_deposit_height_query_result) and is_integer(child_block_interval) do
+             is_integer(last_deposit_child_blknum_query_result) and is_integer(child_block_interval) do
     # extract height, last deposit height and utxos from query result
     height = height_query_result + child_block_interval
 
@@ -106,7 +106,7 @@ defmodule OMG.API.State.Core do
 
     state = %__MODULE__{
       height: height,
-      last_deposit_height: last_deposit_height_query_result,
+      last_deposit_child_blknum: last_deposit_child_blknum_query_result,
       utxos: utxos
     }
 
@@ -317,8 +317,8 @@ defmodule OMG.API.State.Core do
   end
 
   @spec deposit(deposits :: [deposit()], state :: t()) :: {:ok, {[deposit_event], [db_update]}, new_state :: t()}
-  def deposit(deposits, %Core{utxos: utxos, last_deposit_height: last_deposit_height} = state) do
-    deposits = deposits |> Enum.filter(&(&1.blknum > last_deposit_height))
+  def deposit(deposits, %Core{utxos: utxos, last_deposit_child_blknum: last_deposit_child_blknum} = state) do
+    deposits = deposits |> Enum.filter(&(&1.blknum > last_deposit_child_blknum))
 
     new_utxos =
       deposits
@@ -328,20 +328,20 @@ defmodule OMG.API.State.Core do
       deposits
       |> Enum.map(fn %{owner: owner, amount: amount} -> %{deposit: %{amount: amount, owner: owner}} end)
 
-    last_deposit_height = get_last_deposit_height(deposits, last_deposit_height)
+    last_deposit_child_blknum = get_last_deposit_child_blknum(deposits, last_deposit_child_blknum)
 
     db_updates_new_utxos =
       new_utxos
       |> Enum.map(&utxo_to_db_put/1)
 
-    db_updates = db_updates_new_utxos ++ last_deposit_height_db_update(deposits, last_deposit_height)
+    db_updates = db_updates_new_utxos ++ last_deposit_child_blknum_db_update(deposits, last_deposit_child_blknum)
 
     _ = if deposits != [], do: Logger.info(fn -> "Recognized deposits #{inspect(deposits)}" end)
 
     new_state = %Core{
       state
       | utxos: Map.merge(utxos, Map.new(new_utxos)),
-        last_deposit_height: last_deposit_height
+        last_deposit_child_blknum: last_deposit_child_blknum
     }
 
     {:ok, {event_triggers, db_updates}, new_state}
@@ -354,7 +354,7 @@ defmodule OMG.API.State.Core do
     {Utxo.position(blknum, 0, 0), %Utxo{amount: amount, currency: cur, owner: owner}}
   end
 
-  defp get_last_deposit_height(deposits, current_height) do
+  defp get_last_deposit_child_blknum(deposits, current_height) do
     if Enum.empty?(deposits) do
       current_height
     else
@@ -364,11 +364,11 @@ defmodule OMG.API.State.Core do
     end
   end
 
-  defp last_deposit_height_db_update(deposits, last_deposit_height) do
+  defp last_deposit_child_blknum_db_update(deposits, last_deposit_child_blknum) do
     if Enum.empty?(deposits) do
       []
     else
-      [{:put, :last_deposit_block_height, last_deposit_height}]
+      [{:put, :last_deposit_child_blknum, last_deposit_child_blknum}]
     end
   end
 

--- a/apps/omg_api/lib/state/core.ex
+++ b/apps/omg_api/lib/state/core.ex
@@ -394,13 +394,13 @@ defmodule OMG.API.State.Core do
         %{exit: %{owner: owner, utxo_pos: Utxo.Position.decode(utxo_pos)}}
       end)
 
-    new_utxos_in_state =
-      exiting_utxos
-      |> Enum.reduce(utxos, fn %{utxo_pos: utxo_pos}, utxos ->
-        Map.delete(utxos, Utxo.Position.decode(utxo_pos))
-      end)
-
-    new_state = %{state | utxos: new_utxos_in_state}
+    new_state = %{
+      state
+      | utxos:
+          Enum.reduce(exiting_utxos, utxos, fn %{utxo_pos: utxo_pos}, utxos ->
+            Map.delete(utxos, Utxo.Position.decode(utxo_pos))
+          end)
+    }
 
     deletes =
       exiting_utxos

--- a/apps/omg_api/test/state/core_test.exs
+++ b/apps/omg_api/test/state/core_test.exs
@@ -131,7 +131,7 @@ defmodule OMG.API.State.CoreTest do
     state_empty: state
   } do
     deposits = [%{owner: alice.addr, currency: eth(), amount: 20, blknum: 2}]
-    assert {:ok, {_, [_, {:put, :last_deposit_block_height, 2}]}, state} = Core.deposit(deposits, state)
+    assert {:ok, {_, [_, {:put, :last_deposit_child_blknum, 2}]}, state} = Core.deposit(deposits, state)
 
     assert {:ok, {[], []}, ^state} = Core.deposit([%{owner: bob.addr, currency: eth(), amount: 20, blknum: 1}], state)
   end
@@ -466,7 +466,7 @@ defmodule OMG.API.State.CoreTest do
              Core.deposit([%{owner: alice.addr, currency: eth(), amount: 10, blknum: 1}], state)
 
     assert utxo_update == {:put, :utxo, {{1, 0, 0}, %{owner: alice.addr, currency: eth(), amount: 10}}}
-    assert height_update == {:put, :last_deposit_block_height, 1}
+    assert height_update == {:put, :last_deposit_child_blknum, 1}
 
     assert {:ok, {_, _, [{:put, :block, _}, {:put, :child_top_block_number, @child_block_interval}]}, _} =
              form_block_check(state, @child_block_interval)

--- a/apps/omg_api/test/state/core_test.exs
+++ b/apps/omg_api/test/state/core_test.exs
@@ -582,17 +582,17 @@ defmodule OMG.API.State.CoreTest do
 
   @tag fixtures: [:alice, :state_empty]
   test "tells if utxo exists", %{alice: alice, state_empty: state} do
-    assert not Core.utxo_exists?(%{blknum: 1, txindex: 0, oindex: 0}, state)
+    assert not Core.utxo_exists?(%{utxo_pos: Utxo.position(1, 0, 0) |> Utxo.Position.encode()}, state)
 
     state = state |> Test.do_deposit(alice, %{amount: 10, currency: eth(), blknum: 1})
-    assert Core.utxo_exists?(%{blknum: 1, txindex: 0, oindex: 0}, state)
+    assert Core.utxo_exists?(%{utxo_pos: Utxo.position(1, 0, 0) |> Utxo.Position.encode()}, state)
 
     state =
       state
       |> (&Core.exec(Test.create_recovered([{1, 0, 0, alice}], eth(), [{alice, 10}]), zero_fees_map(), &1)).()
       |> success?
 
-    assert not Core.utxo_exists?(%{blknum: 1, txindex: 0, oindex: 0}, state)
+    assert not Core.utxo_exists?(%{utxo_pos: Utxo.position(1, 0, 0) |> Utxo.Position.encode()}, state)
   end
 
   @tag fixtures: [:state_empty]

--- a/apps/omg_db/lib/db.ex
+++ b/apps/omg_db/lib/db.ex
@@ -43,32 +43,32 @@ defmodule OMG.DB do
     GenServer.call(server_name, {:block_hashes, block_numbers_to_fetch})
   end
 
-  def last_deposit_height(server_name \\ @server_name) do
-    GenServer.call(server_name, :last_deposit_block_height)
+  def last_deposit_child_blknum(server_name \\ @server_name) do
+    GenServer.call(server_name, :last_deposit_child_blknum)
   end
 
   def child_top_block_number(server_name \\ @server_name) do
     GenServer.call(server_name, :child_top_block_number)
   end
 
-  def last_fast_exit_block_height(server_name \\ @server_name) do
-    GenServer.call(server_name, :last_fast_exit_block_height)
+  def last_fast_exit_eth_height(server_name \\ @server_name) do
+    GenServer.call(server_name, :last_fast_exit_eth_height)
   end
 
-  def last_slow_exit_block_height(server_name \\ @server_name) do
-    GenServer.call(server_name, :last_slow_exit_block_height)
+  def last_slow_exit_eth_height(server_name \\ @server_name) do
+    GenServer.call(server_name, :last_slow_exit_eth_height)
   end
 
-  def last_block_getter_block_height(server_name \\ @server_name) do
-    GenServer.call(server_name, :last_block_getter_synced_height)
+  def last_block_getter_eth_height(server_name \\ @server_name) do
+    GenServer.call(server_name, :last_block_getter_eth_height)
   end
 
-  def last_depositer_block_height(server_name \\ @server_name) do
-    GenServer.call(server_name, :last_depositer_block_height)
+  def last_depositer_eth_height(server_name \\ @server_name) do
+    GenServer.call(server_name, :last_depositer_eth_height)
   end
 
-  def last_exiter_block_height(server_name \\ @server_name) do
-    GenServer.call(server_name, :last_exiter_block_height)
+  def last_exiter_eth_height(server_name \\ @server_name) do
+    GenServer.call(server_name, :last_exiter_eth_height)
   end
 
   def init do
@@ -80,13 +80,13 @@ defmodule OMG.DB do
 
       :ok =
         OMG.DB.multi_update([
-          {:put, :last_deposit_block_height, 0},
-          {:put, :last_fast_exit_block_height, 0},
-          {:put, :last_slow_exit_block_height, 0},
+          {:put, :last_deposit_child_blknum, 0},
+          {:put, :last_fast_exit_eth_height, 0},
+          {:put, :last_slow_exit_eth_height, 0},
           {:put, :child_top_block_number, 0},
-          {:put, :last_block_getter_synced_height, 0},
-          {:put, :last_depositer_block_height, 0},
-          {:put, :last_exiter_block_height, 0}
+          {:put, :last_block_getter_eth_height, 0},
+          {:put, :last_depositer_eth_height, 0},
+          {:put, :last_exiter_eth_height, 0}
         ])
 
       started_apps |> Enum.reverse() |> Enum.each(fn app -> :ok = Application.stop(app) end)

--- a/apps/omg_db/lib/leveldb_core.ex
+++ b/apps/omg_db/lib/leveldb_core.ex
@@ -100,12 +100,12 @@ defmodule OMG.DB.LevelDBCore do
 
   @single_value_parameter_names [
     :child_top_block_number,
-    :last_deposit_block_height,
-    :last_fast_exit_block_height,
-    :last_slow_exit_block_height,
-    :last_block_getter_synced_height,
-    :last_depositer_block_height,
-    :last_exiter_block_height
+    :last_deposit_child_blknum,
+    :last_fast_exit_eth_height,
+    :last_slow_exit_eth_height,
+    :last_block_getter_eth_height,
+    :last_depositer_eth_height,
+    :last_exiter_eth_height
   ]
 
   def key(parameter, _) when parameter in @single_value_parameter_names, do: Atom.to_string(parameter)

--- a/apps/omg_db/test/db_test.exs
+++ b/apps/omg_db/test/db_test.exs
@@ -131,13 +131,13 @@ defmodule OMG.DBTest do
     :ok =
       DB.multi_update(
         [
-          {:put, :last_fast_exit_block_height, 12},
-          {:put, :last_slow_exit_block_height, 10}
+          {:put, :last_fast_exit_eth_height, 12},
+          {:put, :last_slow_exit_eth_height, 10}
         ],
         TestDBServer
       )
 
-    assert {:ok, 12} == DB.last_fast_exit_block_height(TestDBServer)
-    assert {:ok, 10} == DB.last_slow_exit_block_height(TestDBServer)
+    assert {:ok, 12} == DB.last_fast_exit_eth_height(TestDBServer)
+    assert {:ok, 10} == DB.last_slow_exit_eth_height(TestDBServer)
   end
 end

--- a/apps/omg_watcher/config/dev.exs
+++ b/apps/omg_watcher/config/dev.exs
@@ -46,3 +46,12 @@ config :omg_watcher, OMG.Watcher.Repo,
   database: "omisego_dev",
   hostname: "localhost",
   pool_size: 10
+
+# TODO: these two are here to ensure swifter sync in `:dev` env, and are geared towards a 1-sec root chain block
+#       interval. They are taken to be equal to the `:test` env.
+#       Rethink properly the semantics of root chain coordinator
+config :omg_watcher,
+  block_getter_height_sync_interval_ms: 20
+
+config :omg_api,
+  rootchain_height_sync_interval_ms: 20

--- a/apps/omg_watcher/config/test.exs
+++ b/apps/omg_watcher/config/test.exs
@@ -13,12 +13,12 @@ config :omg_watcher, OMG.Watcher.Repo,
 
 config :omg_watcher, OMG.Watcher.Repo, pool: Ecto.Adapters.SQL.Sandbox
 
-config :omg_watcher, block_getter_height_sync_interval_ms: 100
+config :omg_watcher, block_getter_height_sync_interval_ms: 20
 
 config :omg_api,
   ethereum_event_block_finality_margin: 2,
   ethereum_event_check_height_interval_ms: 50,
   child_block_submit_period: 1,
-  rootchain_height_sync_interval_ms: 100
+  rootchain_height_sync_interval_ms: 20
 
 config :omg_eth, child_block_interval: 1_000

--- a/apps/omg_watcher/lib/application.ex
+++ b/apps/omg_watcher/lib/application.ex
@@ -38,12 +38,12 @@ defmodule OMG.Watcher.Application do
         OMG.API.EthereumEventListener,
         [
           %{
-            synced_height_update_key: :last_depositer_block_height,
+            synced_height_update_key: :last_depositer_eth_height,
             service_name: :depositer,
             block_finality_margin: block_finality_margin,
             get_events_callback: &OMG.Eth.RootChain.get_deposits/2,
             process_events_callback: &OMG.API.State.deposit/1,
-            get_last_synced_height_callback: &OMG.Eth.RootChain.get_root_deployment_height/0
+            get_last_synced_height_callback: &OMG.DB.last_depositer_eth_height/0
           }
         ],
         id: :depositer
@@ -53,11 +53,11 @@ defmodule OMG.Watcher.Application do
         [
           %{
             block_finality_margin: 0,
-            synced_height_update_key: :last_fast_exit_block_height,
+            synced_height_update_key: :last_fast_exit_eth_height,
             service_name: :fast_validator,
             get_events_callback: &OMG.Eth.RootChain.get_exits/2,
             process_events_callback: OMG.Watcher.ExitValidator.Validator.challenge_invalid_exits(fn _ -> :ok end),
-            get_last_synced_height_callback: &OMG.DB.last_fast_exit_block_height/0
+            get_last_synced_height_callback: &OMG.DB.last_fast_exit_eth_height/0
           }
         ],
         id: :fast_validator
@@ -67,12 +67,12 @@ defmodule OMG.Watcher.Application do
         [
           %{
             block_finality_margin: slow_exit_validator_block_margin,
-            synced_height_update_key: :last_slow_exit_block_height,
+            synced_height_update_key: :last_slow_exit_eth_height,
             service_name: :slow_validator,
             get_events_callback: &OMG.Eth.RootChain.get_exits/2,
             process_events_callback:
               OMG.Watcher.ExitValidator.Validator.challenge_invalid_exits(&slow_validator_utxo_exists_callback/1),
-            get_last_synced_height_callback: &OMG.DB.last_slow_exit_block_height/0
+            get_last_synced_height_callback: &OMG.DB.last_slow_exit_eth_height/0
           }
         ],
         id: :slow_validator

--- a/apps/omg_watcher/lib/block_getter.ex
+++ b/apps/omg_watcher/lib/block_getter.ex
@@ -80,7 +80,7 @@ defmodule OMG.Watcher.BlockGetter do
 
   def init(_opts) do
     {:ok, deployment_height} = Eth.RootChain.get_root_deployment_height()
-    {:ok, last_synced_height} = OMG.DB.last_block_getter_block_height()
+    {:ok, last_synced_height} = OMG.DB.last_block_getter_eth_height()
     synced_height = max(deployment_height, last_synced_height)
     :ok = RootchainCoordinator.check_in(synced_height, :block_getter)
 

--- a/apps/omg_watcher/lib/block_getter/core.ex
+++ b/apps/omg_watcher/lib/block_getter/core.ex
@@ -141,7 +141,7 @@ defmodule OMG.Watcher.BlockGetter.Core do
   def get_blocks_to_consume(%__MODULE__{} = state, [], coordinator_height) do
     next_synced_height = max(state.synced_height, coordinator_height)
     state = %{state | synced_height: next_synced_height}
-    db_updates = [{:put, :last_block_getter_synced_height, next_synced_height}]
+    db_updates = [{:put, :last_block_getter_eth_height, next_synced_height}]
     {[], next_synced_height, db_updates, state}
   end
 
@@ -174,7 +174,7 @@ defmodule OMG.Watcher.BlockGetter.Core do
     if blocks_to_process == MapSet.new() do
       next_synced_height = max(state.synced_height, coordinator_height)
       state = %{state | synced_height: next_synced_height, block_consume_batch: {:downloading, []}}
-      db_updates = [{:put, :last_block_getter_synced_height, next_synced_height}]
+      db_updates = [{:put, :last_block_getter_eth_height, next_synced_height}]
       {[], next_synced_height, db_updates, state}
     else
       {[], state.synced_height, [], state}

--- a/apps/omg_watcher/lib/exit_validator/validator.ex
+++ b/apps/omg_watcher/lib/exit_validator/validator.ex
@@ -36,7 +36,6 @@ defmodule OMG.Watcher.ExitValidator.Validator do
   end
 
   defp exists?(utxo_exit) do
-    Utxo.position(blknum, txindex, oindex) = Utxo.Position.decode(utxo_exit.utxo_pos)
-    OMG.API.State.utxo_exists?(%{blknum: blknum, txindex: txindex, oindex: oindex})
+    OMG.API.State.utxo_exists?(utxo_exit)
   end
 end

--- a/apps/omg_watcher/lib/exit_validator/validator.ex
+++ b/apps/omg_watcher/lib/exit_validator/validator.ex
@@ -24,7 +24,7 @@ defmodule OMG.Watcher.ExitValidator.Validator do
   def challenge_invalid_exits(utxo_exists_callback) do
     fn utxo_exits ->
       for utxo_exit <- utxo_exits do
-        if exists?(utxo_exit) do
+        if OMG.API.State.utxo_exists?(utxo_exit) do
           utxo_exists_callback.(utxo_exit)
         else
           :challenged = OMG.Watcher.Challenger.challenge(utxo_exit)
@@ -33,9 +33,5 @@ defmodule OMG.Watcher.ExitValidator.Validator do
 
       :ok
     end
-  end
-
-  defp exists?(utxo_exit) do
-    OMG.API.State.utxo_exists?(utxo_exit)
   end
 end

--- a/docs/demo_02.md
+++ b/docs/demo_02.md
@@ -78,7 +78,7 @@ to_charlist() |>
 :os.cmd() |>
 Poison.decode!()
 
-%{"utxos" => [%{"blknum" => exiting_utxo_blknum, "txindex" => 0, "oindex" => 0}]} =
+%{"data" => %{"utxos" => [%{"blknum" => exiting_utxo_blknum, "txindex" => 0, "oindex" => 0}]}} =
   "http GET 'localhost:4000/utxos?address=#{bob_enc}'" |>
   to_charlist() |>
   :os.cmd() |>
@@ -88,7 +88,7 @@ Poison.decode!()
 
 exiting_utxopos = OMG.API.Utxo.Position.encode({:utxo_position, exiting_utxo_blknum, 0, 0})
 
-composed_exit =
+%{"data" => composed_exit} =
   "http GET 'localhost:4000/utxo/#{exiting_utxopos}/exit_data'" |>
   to_charlist() |>
   :os.cmd() |>
@@ -113,8 +113,8 @@ tx2 =
   )
 Eth.WaitFor.eth_receipt(txhash)
 
-challenge =
-  "http GET 'localhost:4000/utxo/#{exiting_utxo_blknum}/challenge_data'" |>
+%{"data" => challenge} =
+  "http GET 'localhost:4000/utxo/#{exiting_utxopos}/challenge_data'" |>
   to_charlist() |>
   :os.cmd() |>
   Poison.decode!()
@@ -160,7 +160,7 @@ r(OMG.API.State.Core)
 # let's do a broken spend:
 
 # grab a utxo that bob can spend
-%{"utxos" => [%{"blknum" => spend_blknum, "txindex" => 0, "oindex" => 0}]} =
+%{"data" => %{"utxos" => [%{"blknum" => spend_blknum, "txindex" => 0, "oindex" => 0}]}} =
   "http GET 'localhost:4000/utxos?address=#{bob_enc}'" |>
   to_charlist() |>
   :os.cmd() |>


### PR DESCRIPTION
Composed out of various fixes that make the demos feasible again:

fix: proper Utxo decoding in exiting when called from exit validator  …
fix: new default polling intervals for `:dev` environment to fix demo
fix: adjust demo 02 to new Watcher's API
fix: allow depositer to start from last synced eth height + naming