### PR TITLE
fix: figure out getter synced eth height based on persisted child blknum

### DIFF
--- a/apps/omg_watcher/lib/block_getter.ex
+++ b/apps/omg_watcher/lib/block_getter.ex
@@ -82,10 +82,14 @@ defmodule OMG.Watcher.BlockGetter do
     {:ok, deployment_height} = Eth.RootChain.get_root_deployment_height()
     {:ok, last_synced_height} = OMG.DB.last_block_getter_eth_height()
     synced_height = max(deployment_height, last_synced_height)
-    :ok = RootchainCoordinator.check_in(synced_height, :block_getter)
 
-    {:ok, block_number} = OMG.DB.child_top_block_number()
+    {:ok, child_top_block_number} = OMG.DB.child_top_block_number()
     child_block_interval = Application.get_env(:omg_eth, :child_block_interval)
+
+    {:ok, submissions} = Eth.RootChain.get_block_submitted_events({synced_height, synced_height + 1000})
+    exact_synced_height = Core.figure_out_exact_sync_height(submissions, synced_height, child_top_block_number)
+
+    :ok = RootchainCoordinator.check_in(exact_synced_height, :block_getter)
 
     height_sync_interval = Application.get_env(:omg_watcher, :block_getter_height_sync_interval_ms)
     {:ok, _} = schedule_sync_height(height_sync_interval)
@@ -96,9 +100,9 @@ defmodule OMG.Watcher.BlockGetter do
     {
       :ok,
       Core.init(
-        block_number,
+        child_top_block_number,
         child_block_interval,
-        synced_height,
+        exact_synced_height,
         maximum_block_withholding_time_ms: maximum_block_withholding_time_ms
       )
     }

--- a/apps/omg_watcher/lib/block_getter/core.ex
+++ b/apps/omg_watcher/lib/block_getter/core.ex
@@ -399,8 +399,11 @@ defmodule OMG.Watcher.BlockGetter.Core do
   end
 
   @doc """
-  Given a persited `synced_height` and actual child block number State reports to figure out the exact
-  eth height, which we should begin with, based on a list of block submission event logs.
+  Given:
+   - a persisted `synced_height` and
+   - the actual child block number from `OMG.API.State`
+  figures out the exact eth height, which we should begin with. Uses a list of block submission event logs,
+  which should contain the `child_top_block_number`'s respective submission.
 
   This is a workaround for the case where a child block is processed and block number advanced, and eth height isn't.
   This can be the case when the getter crashes after consuming a child block but before it's recognized as synced.

--- a/apps/omg_watcher/test/block_getter/core_test.exs
+++ b/apps/omg_watcher/test/block_getter/core_test.exs
@@ -380,4 +380,16 @@ defmodule OMG.Watcher.BlockGetter.CoreTest do
 
     assert {_state, [1_000, 2_000]} = Core.get_new_blocks_numbers(state, 20_000)
   end
+
+  test "figures out the proper synced height on init" do
+    assert 0 == Core.figure_out_exact_sync_height([], 0, 0)
+    assert 0 == Core.figure_out_exact_sync_height([], 0, 10)
+    assert 1 == Core.figure_out_exact_sync_height([], 1, 10)
+    assert 1 == Core.figure_out_exact_sync_height([%{eth_height: 100, blknum: 9}], 1, 10)
+    assert 100 == Core.figure_out_exact_sync_height([%{eth_height: 100, blknum: 10}], 1, 10)
+
+    assert 100 ==
+             [%{eth_height: 100, blknum: 10}, %{eth_height: 101, blknum: 11}, %{eth_height: 90, blknum: 9}]
+             |> Core.figure_out_exact_sync_height(1, 10)
+  end
 end


### PR DESCRIPTION
it used to rely on the persisted getter eth height which could remain un-updated
to quickly fix changed that to take persisted child block number into account