### PR TITLE
Feature/fix incorrect watcher oindex

### DIFF
--- a/apps/omg_watcher/lib/utxo_db.ex
+++ b/apps/omg_watcher/lib/utxo_db.ex
@@ -47,13 +47,21 @@ defmodule OMG.Watcher.UtxoDB do
          block_number
        ) do
     make_utxo_db = fn transaction, number ->
+      # essentially number - 1 but to be extra safe let's limit the possible inputs according to the
+      # current tx format
+      new_oindex =
+        case number do
+          1 -> 0
+          2 -> 1
+        end
+
       %__MODULE__{
         address: Map.get(transaction, String.to_existing_atom("newowner#{number}")),
         currency: Map.get(transaction, :cur12),
         amount: Map.get(transaction, String.to_existing_atom("amount#{number}")),
         blknum: block_number,
         txindex: txindex,
-        oindex: Map.get(transaction, String.to_existing_atom("oindex#{number}")),
+        oindex: new_oindex,
         txbytes: signed_tx_bytes
       }
     end

--- a/apps/omg_watcher/test/integration/block_getter_test.exs
+++ b/apps/omg_watcher/test/integration/block_getter_test.exs
@@ -65,7 +65,7 @@ defmodule OMG.Watcher.Integration.BlockGetterTest do
                "currency" => @eth_hex,
                "amount" => 3,
                "blknum" => block_nr,
-               "oindex" => 0,
+               "oindex" => 1,
                "txindex" => 0,
                "txbytes" => encode_tx
              }

--- a/apps/omg_watcher/test/web/controllers/challenge_test.exs
+++ b/apps/omg_watcher/test/web/controllers/challenge_test.exs
@@ -24,8 +24,6 @@ defmodule OMG.Watcher.Web.Controller.ChallengeTest do
   alias OMG.Watcher.TestHelper
   alias OMG.Watcher.TransactionDB
 
-  @moduletag :integration
-
   @eth Crypto.zero_address()
 
   describe "Controller.ChallengeTest" do

--- a/apps/omg_watcher/test/web/controllers/fallback_test.exs
+++ b/apps/omg_watcher/test/web/controllers/fallback_test.exs
@@ -18,8 +18,6 @@ defmodule OMG.Watcher.Web.Controller.FallbackTest do
 
   alias OMG.Watcher.TestHelper
 
-  @moduletag :integration
-
   describe "Controller.FallbackTest" do
     @tag fixtures: [:phoenix_ecto_sandbox]
     test "fallback returns error for non existing endpoint" do

--- a/apps/omg_watcher/test/web/controllers/transaction_test.exs
+++ b/apps/omg_watcher/test/web/controllers/transaction_test.exs
@@ -22,8 +22,6 @@ defmodule OMG.Watcher.Web.Controller.TransactionTest do
   alias OMG.Watcher.TestHelper
   alias OMG.Watcher.TransactionDB
 
-  @moduletag :integration
-
   @eth Crypto.zero_address()
 
   describe "Controller.TransactionTest" do

--- a/apps/omg_watcher/test/web/controllers/utxo_test.exs
+++ b/apps/omg_watcher/test/web/controllers/utxo_test.exs
@@ -30,8 +30,6 @@ defmodule OMG.Watcher.Web.Controller.UtxoTest do
   @eth Crypto.zero_address()
   @eth_hex String.duplicate("00", 20)
 
-  @moduletag :integration
-
   describe "Controller.UtxoTest" do
     @tag fixtures: [:phoenix_ecto_sandbox, :alice]
     test "No utxo are returned for non-existing addresses.", %{alice: alice} do


### PR DESCRIPTION
reported by @jarindr. Synopsis ~= "follow `demo_01` and see that the result of `utxos/` endpoint has broken `oindex`