### PR TITLE
changed developer geth command and vagrant file path

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,13 +104,13 @@ A developer instance of `geth` runs Ethereum locally and prefunds an account.
 However, when `geth` terminates, the state of the Ethereum network is lost.
 
 ```
-geth --dev --dev.period 1 --rpc --rpcapi personal,web3,eth
+geth --dev --dev.period 1 --rpc --rpcapi personal,web3,eth,net  --rpcaddr 0.0.0.0 
 ```
 
 ##### Persistent developer `geth` instance
 Alternatively, a persistent developer instance that does not lose state can be started with the following command:
 ```
-geth --dev --dev.period 1 --rpc --rpcapi personal,web3,eth --datadir ~/.geth
+geth --dev --dev.period 1 --rpc --rpcapi personal,web3,eth,net  --rpcaddr 0.0.0.0 --datadir ~/.geth
 ```
 
 #### Prepare and configure the root chain contract

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,5 +1,5 @@
 # 1. Installation via Vagrant
-Refer to https://github.com/omisego/omg-vagrant.
+Refer to https://github.com/omisego/xomg-vagrant.
 
 # 2. Full installation
 


### PR DESCRIPTION
- changed developer's geth command to allow for remote interaction with Geth ie. through a truffle console, geth console or remix
- added the file path to the new vagrant file