### PR TITLE
Docs: signedTxBytes is not a part of RLP encoded signed transaction

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ A developer instance of `geth` runs Ethereum locally and prefunds an account.
 However, when `geth` terminates, the state of the Ethereum network is lost.
 
 ```
-geth --dev --dev.period 1 --rpc --rpcapi personal,web3,eth,net  --rpcaddr 0.0.0.0 
+geth --dev --dev.period 1 --rpc --rpcapi personal,web3,eth,net  --rpcaddr 0.0.0.0
 ```
 
 ##### Persistent developer `geth` instance
@@ -278,6 +278,8 @@ Request:
   "id":0
 }
 ```
+
+See the [step by step transaction generation specs here](docs/tesuji_tx_integration.md).
 
 Response:
 

--- a/docs/tesuji_blockchain_design.md
+++ b/docs/tesuji_blockchain_design.md
@@ -250,6 +250,8 @@ We have two currency fields to allow for atomic swaps to occur between two parti
 
 **NOTE** To create a valid transaction, a user needs to have access to positions of all the UTXOs that they own.
 
+For a hands-on specs of transaction format see [here](docs/tesuji_tx_integration.md).
+
 ### Fees
 
 #### Accepting fees by the child chain server

--- a/docs/tesuji_tx_integration.md
+++ b/docs/tesuji_tx_integration.md
@@ -82,7 +82,7 @@ signedTxBytes = rlpEncode(txArray)
 
 Rlp encoding the entire array from previous step
 ```
-tx_for_encode = { blknum1, txindex1, oindex1, blknum2, txindex2, oindex2, cur12, newowner1, amount1, newowner2, amount2, signature1, signature2, signedTxBytes}
+tx_for_encode = { blknum1, txindex1, oindex1, blknum2, txindex2, oindex2, cur12, newowner1, amount1, newowner2, amount2, signature1, signature2 }
 
 rlp_encoded = rlpEncode(tx_for_encode)
 ```

--- a/docs/tesuji_tx_integration.md
+++ b/docs/tesuji_tx_integration.md
@@ -1,22 +1,22 @@
 ## Tesuji Plasma Transaction Format
 
-*Motivation*
+### Motivation
 
-To be able to make an alternative implementation of a library and allowing for generation of a plasma transaction without referring to reference elixir-omg source code.
+To be able to make an alternative implementation of a library and allowing for generation of a plasma transaction without referring to reference `elixir-omg` source code.
 
 As long as RLP encoding is available, Plasma transaction could be implemented in any programming language
 
-*High Level Process*
+### High Level Process
 
 On a high level, completing plasma transaction requires the following process:
 
 1. Create the transaction Object/Struct
-2. Sign the transaction 
-3. Encode the transaction in RLP 
+2. Sign the transaction
+3. Encode the transaction in RLP
 4. Encode the transaction in Base16
-5. Submit the transaction to childchain server via JSON RPC
+5. Submit the transaction to child chain server via JSON RPC
 
-*Caveats*
+### Caveats
 
 Current implementation of Tesuji Plasma as of this writing is capable of only taking 2 inputs, 2 outputs and 2 signatures. This is subject to changes in the future
 
@@ -26,82 +26,73 @@ Each programming language comes with its own unique type systems. Ie. in elixir 
 ## 1. Create the Transaction Object/Struct
 
 Firstly, a transaction object/struct needs to be created with the following array structure:
-	
+
 ```
-rawTransactionInput = [ blknum1, txindex1, oindex1, blknum2, txindex2, oindex2, cur12, newowner1, amount1, newowner2, amount2,]
+rawTransactionInput = [blknum1, txindex1, oindex1, blknum2, txindex2, oindex2, cur12, newowner1, amount1, newowner2, amount2]
 ```
 
-**blknum**: the Block number of the transaction within the childchain  
+**`blknum`**: the Block number of the transaction within the child chain  
 
-**Txindex**: the transaction index within the block 
-  
-**oindex**: the transaction output index
+**`txindex`**: the transaction index within the block
 
-**cur12**: the currency of the transaction (all zeroes for ETH)
+**`oindex`**: the transaction output index
 
-**newowner**: the address of the new owner of the utxo
+**`cur12`**: the currency of the transaction - Ethereum address (20 bytes) (all zeroes for ETH)
 
-**amount**: the amount belongs to the new owner of the utxo
+**`newowner`**: the address of the new owner of the utxo - Ethereum address (20 bytes)
 
-## 2. Sign the transaction 
+**`amount`**: the amount belongs to the new owner of the utxo
 
-2.1 Signature 
+## 2. Sign the transaction
+
+### 2.1 Signature
+
 A Signature  `signature1` of the rawTransactionInput will then be created by:
-Encoding the transaction with RLP
-Signing the transaction with a private key via ECDSA Signing Algorithm 
+
+- Encoding the transaction with RLP
+- Signing the transaction with a private key via ECDSA Signing Algorithm
 
 ```
-signature1 = ecsign(rawTransactionInput, privatekey1)
+signature1 = ecsign(rlpEncode(rawTransactionInput), privatekey1)
 ```
 
-The implementation of this step is crucial, given that it dictates how key management process is done. For the sake of simplicity- we assume that transaction is signed by raw privatekey input
+The implementation of this step is crucial, given that it dictates how key management process is done.
+For the sake of simplicity - we assume that transaction is signed by raw `privatekey1`.
 
-2.2 Generate transaction array - `txArray`
-We will need to create another array containing the signature and all of the elements from rawTransactionInputRefer to the following:
+### 2.2 Generate transaction array - `txArray`
+
+We will need to create another array containing the signature and all of the elements from `rawTransactionInput`.
+Refer to the following:
 
 ```
-Let txArray = [ blknum1, txindex1, oindex1, blknum2, txindex2, oindex2, cur12, newowner1, amount1, newowner2, amount2, signature1, signature2 ]
+Let txArray = [blknum1, txindex1, oindex1, blknum2, txindex2, oindex2, cur12, newowner1, amount1, newowner2, amount2, signature1, signature2]
 ```
 
-Note: signature2 is derived by the same process as signature1, given that we only need 1 signature to make this transaction, the input for signature2 will be byte array of `0`
+Note: `signature2` is derived by the same process as `signature1`, given that we only need 1 signature to make this transaction, the input for `signature2` will be 65-byte array of zeroes.
 
-2.3. RLP Encode txArray
+### 2.3. RLP Encode txArray
 
-Encode txArray with `RLP` encoding algorithm
+Encode `txArray` with `RLP` encoding algorithm.
+The end output of the signed transaction is:
 
 ```
 signedTxBytes = rlpEncode(txArray)
 ```
 
-2.4 The end output of the signed transaction should look as follows:
-```
-{rawTransactionInput, signature1, signature2, signedTxBytes}
-```
-
-## 3. Encode the transaction in RLP
-
-Rlp encoding the entire array from previous step
-```
-tx_for_encode = { blknum1, txindex1, oindex1, blknum2, txindex2, oindex2, cur12, newowner1, amount1, newowner2, amount2, signature1, signature2 }
-
-rlp_encoded = rlpEncode(tx_for_encode)
-```
-
-## 4. Encode the  transaction in Base 16
+## 4. Encode the transaction in Base 16
 
 Encode the RLP encoded input with Base16 into a string.
 IMPORTANT: ensure that the value to be Base16 encoded is lowercase, as current  implementation of Tesuji Plasma will reject capital case
 
 ```
-base16Encoded = base16Encode(rlp_encoded)
+base16Encoded = base16Encode(signedTxBytes)
 ```
 
-## 5. Submit the transaction to childchain server via JSON RPC
+## 5. Submit the transaction to child chain server via JSON RPC
 
-Submitting the Base16 encoded transaction as String to childchain server via JSON RPC
+Submitting the Base16 encoded transaction as String to child chain server via JSON RPC
 
-illustrated using curl command:
+Illustrated using curl command:
 ```
 curl “http://localhost:9656” -d ‘{“params”:{“transaction”: <base16Encoded> }, “method”: “submit”, “jsonrpc”: “2.0",“id”:0}’
 ```
-


### PR DESCRIPTION
Fixing error in docs: signedTxBytes is not a part of RLP encoded signed transaction - it can always be recreated, if needed.