### PR TITLE
Feature/omg 241 2 add information about exit to watcher db

### DIFF
--- a/apps/omg_watcher/lib/application.ex
+++ b/apps/omg_watcher/lib/application.ex
@@ -53,7 +53,7 @@ defmodule OMG.Watcher.Application do
             synced_height_update_key: :last_fast_exit_eth_height,
             service_name: :fast_validator,
             get_events_callback: &OMG.Eth.RootChain.get_exits/2,
-            process_events_callback: OMG.Watcher.ExitValidator.Validator.challenge_invalid_exits(fn _ -> :ok end),
+            process_events_callback: &exit_events_callback/1,
             get_last_synced_height_callback: &OMG.DB.last_fast_exit_eth_height/0
           }
         ],
@@ -113,6 +113,12 @@ defmodule OMG.Watcher.Application do
   defp deposit_events_callback(deposits) do
     :ok = OMG.API.State.deposit(deposits)
     _ = OMG.Watcher.DB.EthEventDB.insert_deposits(deposits)
+    :ok
+  end
+
+  defp exit_events_callback(exits) do
+    :ok = OMG.Watcher.ExitValidator.Validator.challenge_invalid_exits(fn _ -> :ok end).(exits)
+    _ = OMG.Watcher.DB.EthEventDB.insert_exits(exits)
     :ok
   end
 end

--- a/apps/omg_watcher/lib/db/eth_event_db.ex
+++ b/apps/omg_watcher/lib/db/eth_event_db.ex
@@ -18,14 +18,18 @@ defmodule OMG.Watcher.DB.EthEventDB do
   """
   use Ecto.Schema
 
+  alias OMG.API.Crypto
+  alias OMG.API.Utxo
   alias OMG.Watcher.DB.Repo
   alias OMG.Watcher.DB.TxOutputDB
+
+  require Utxo
 
   @primary_key {:hash, :binary, []}
   @derive {Phoenix.Param, key: :hash}
   schema "ethevents" do
-    field(:deposit_blknum, :integer)
-    field(:deposit_txindex, :integer)
+    field(:blknum, :integer)
+    field(:txindex, :integer)
     field(:event_type, OMG.Watcher.DB.Types.AtomType)
 
     has_one(:created_utxo, TxOutputDB, foreign_key: :creating_deposit)
@@ -46,8 +50,8 @@ defmodule OMG.Watcher.DB.EthEventDB do
     {:ok, _} =
       %__MODULE__{
         hash: deposit_key(blknum),
-        deposit_blknum: blknum,
-        deposit_txindex: 0,
+        blknum: blknum,
+        txindex: 0,
         event_type: :deposit,
         created_utxo: %TxOutputDB{
           owner: owner,
@@ -57,10 +61,6 @@ defmodule OMG.Watcher.DB.EthEventDB do
       }
       |> Repo.insert()
   end
-
-  alias OMG.API.Crypto
-  alias OMG.API.Utxo
-  require Utxo
 
   @doc """
   Good candidate for deposit/exit primary key is a pair (Utxo.position, event_type).
@@ -73,4 +73,5 @@ defmodule OMG.Watcher.DB.EthEventDB do
   end
 
   defp deposit_key(blknum), do: generate_unique_key(Utxo.position(blknum, 0, 0), :deposit)
+  defp exit_key(position), do: generate_unique_key(position, :exit)
 end

--- a/apps/omg_watcher/lib/db/eth_event_db.ex
+++ b/apps/omg_watcher/lib/db/eth_event_db.ex
@@ -66,8 +66,8 @@ defmodule OMG.Watcher.DB.EthEventDB do
   def insert_exits(exits) do
     exits
     |> Enum.map(fn %{utxo_pos: utxo_pos} ->
-          position = Utxo.Position.decode(utxo_pos)
-          {:ok, _} = insert_exit(position)
+      position = Utxo.Position.decode(utxo_pos)
+      {:ok, _} = insert_exit(position)
     end)
   end
 

--- a/apps/omg_watcher/lib/db/txoutput_db.ex
+++ b/apps/omg_watcher/lib/db/txoutput_db.ex
@@ -96,7 +96,7 @@ defmodule OMG.Watcher.DB.TxOutputDB do
     query =
       from(
         evnt in EthEventDB,
-        where: evnt.deposit_blknum == ^blknum and evnt.deposit_txindex == 0 and evnt.event_type == ^:deposit,
+        where: evnt.blknum == ^blknum and evnt.txindex == 0 and evnt.event_type == ^:deposit,
         preload: [:created_utxo]
       )
 

--- a/apps/omg_watcher/lib/exit_validator/validator.ex
+++ b/apps/omg_watcher/lib/exit_validator/validator.ex
@@ -20,7 +20,7 @@ defmodule OMG.Watcher.ExitValidator.Validator do
   alias OMG.API.Utxo
   require Utxo
 
-  @spec challenge_invalid_exits(fun()) :: (fun() -> :ok)
+  @spec challenge_invalid_exits(fun()) :: ([OMG.API.State.Core.exit_t()] -> :ok)
   def challenge_invalid_exits(utxo_exists_callback) do
     fn utxo_exits ->
       for utxo_exit <- utxo_exits do

--- a/apps/omg_watcher/lib/web/views/utxo.ex
+++ b/apps/omg_watcher/lib/web/views/utxo.ex
@@ -45,7 +45,7 @@ defmodule OMG.Watcher.Web.View.Utxo do
 
   defp get_position(
          tx,
-         %EthEventDB{deposit_blknum: blknum, deposit_txindex: txindex}
+         %EthEventDB{blknum: blknum, txindex: txindex}
        )
        when is_nil(tx) do
     {blknum, txindex}

--- a/apps/omg_watcher/priv/repo/migrations/20180813133000_create_ethevent_table.exs
+++ b/apps/omg_watcher/priv/repo/migrations/20180813133000_create_ethevent_table.exs
@@ -4,8 +4,8 @@ defmodule OMG.Watcher.Repo.Migrations.CreateEtheventTable do
   def change do
     create table(:ethevents, primary_key: false) do
       add :hash, :binary, primary_key: true
-      add :deposit_blknum, :bigint
-      add :deposit_txindex, :integer
+      add :blknum, :bigint
+      add :txindex, :integer
       add :event_type, :string, size: 124, null: false
     end
   end

--- a/apps/omg_watcher/test/db/eth_event_db_test.exs
+++ b/apps/omg_watcher/test/db/eth_event_db_test.exs
@@ -34,7 +34,7 @@ defmodule OMG.Watcher.DB.EthEventDBTest do
       EthEventDB.insert_deposits([%{blknum: 1, owner: owner, currency: @eth, amount: 1}])
 
       [event] = EthEventDB.get_all()
-      assert %EthEventDB{deposit_blknum: 1, deposit_txindex: 0, event_type: :deposit, hash: ^expected_hash} = event
+      assert %EthEventDB{blknum: 1, txindex: 0, event_type: :deposit, hash: ^expected_hash} = event
 
       [utxo] = TxOutputDB.get_all()
       assert %TxOutputDB{owner: ^owner, currency: @eth, amount: 1, creating_deposit: ^expected_hash} = utxo
@@ -51,20 +51,42 @@ defmodule OMG.Watcher.DB.EthEventDBTest do
 
       hash1 = EthEventDB.generate_unique_key(Utxo.position(1, 0, 0), :deposit)
 
-      assert %EthEventDB{deposit_blknum: 1, deposit_txindex: 0, event_type: :deposit, hash: ^hash1} =
-               EthEventDB.get(hash1)
+      assert %EthEventDB{blknum: 1, txindex: 0, event_type: :deposit, hash: ^hash1} = EthEventDB.get(hash1)
 
       hash2 = EthEventDB.generate_unique_key(Utxo.position(1000, 0, 0), :deposit)
 
-      assert %EthEventDB{deposit_blknum: 1000, deposit_txindex: 0, event_type: :deposit, hash: ^hash2} =
-               EthEventDB.get(hash2)
+      assert %EthEventDB{blknum: 1000, txindex: 0, event_type: :deposit, hash: ^hash2} = EthEventDB.get(hash2)
 
       hash3 = EthEventDB.generate_unique_key(Utxo.position(2013, 0, 0), :deposit)
 
-      assert %EthEventDB{deposit_blknum: 2013, deposit_txindex: 0, event_type: :deposit, hash: ^hash3} =
-               EthEventDB.get(hash3)
+      assert %EthEventDB{blknum: 2013, txindex: 0, event_type: :deposit, hash: ^hash3} = EthEventDB.get(hash3)
 
       assert [hash1, hash2, hash3] == TxOutputDB.get_utxos(alice.addr) |> Enum.map(& &1.creating_deposit)
     end
+  end
+
+  @tag fixtures: [:initial_blocks, :alice, :bob]
+  test "insert exits: creates exit event and marks utxo as spent", %{alice: alice, bob: bob} do
+    bobs_deposit_pos = Utxo.position(2, 0, 0)
+    bobs_deposit = %{utxo_pos: Utxo.Position.encode(bobs_deposit_pos), token: @eth, owner: bob.addr, amount: 100}
+    bobs_deposit_exit_hash = EthEventDB.generate_unique_key(bobs_deposit_pos, :exit)
+
+    alices_utxo_pos = Utxo.position(3000, 1, 1)
+    alices_utxo = %{utxo_pos: Utxo.Position.encode(alices_utxo_pos), token: @eth, owner: alice.addr, amount: 50}
+    alices_utxo_exit_hash = EthEventDB.generate_unique_key(alices_utxo_pos, :exit)
+
+    [{:ok, _exit1}, {:ok, _exit2}] = EthEventDB.insert_exits([bobs_deposit, alices_utxo])
+
+    assert %EthEventDB{blknum: 2, txindex: 0, event_type: :exit, hash: ^bobs_deposit_exit_hash} =
+             EthEventDB.get(bobs_deposit_exit_hash)
+
+    assert %EthEventDB{blknum: 3000, txindex: 1, event_type: :exit, hash: ^alices_utxo_exit_hash} =
+             EthEventDB.get(alices_utxo_exit_hash)
+
+    assert %TxOutputDB{amount: 100, spending_tx_oindex: nil, spending_exit: ^bobs_deposit_exit_hash} =
+             TxOutputDB.get_by_position(bobs_deposit_pos)
+
+    assert %TxOutputDB{amount: 50, spending_tx_oindex: nil, spending_exit: ^alices_utxo_exit_hash} =
+             TxOutputDB.get_by_position(alices_utxo_pos)
   end
 end

--- a/apps/omg_watcher/test/integration/watcher_api_test.exs
+++ b/apps/omg_watcher/test/integration/watcher_api_test.exs
@@ -17,18 +17,27 @@ defmodule OMG.Watcher.Integration.WatcherApiTest do
   use ExUnit.Case, async: false
   use OMG.API.Fixtures
   use OMG.API.Integration.Fixtures
-
   use Plug.Test
 
+  alias OMG.API
+  alias OMG.API.Crypto
+  alias OMG.API.Utxo
+  alias OMG.Eth
+  alias OMG.JSONRPC.Client
   alias OMG.Watcher.Integration.TestHelper, as: IntegrationTest
 
+  require Utxo
+
+  @timeout 40_000
+  @eth Crypto.zero_address()
   @eth_hex String.duplicate("00", 20)
 
   @moduletag :integration
 
-  @tag fixtures: [:watcher_sandbox, :child_chain, :token, :alice, :alice_deposits]
-  test "utxos from deposits on child chain are available in WatcherDB", %{
+  @tag fixtures: [:watcher_sandbox, :child_chain, :token, :alice, :bob, :alice_deposits]
+  test "utxos from deposits on child chain are available in WatcherDB until exited", %{
     alice: alice,
+    bob: bob,
     token: token,
     alice_deposits: {deposit_blknum, token_deposit_blknum}
   } do
@@ -55,5 +64,78 @@ defmodule OMG.Watcher.Integration.WatcherApiTest do
 
     # utxo from deposit should be available
     assert [eth_deposit, token_deposit] == IntegrationTest.get_utxos(alice)
+
+    tx = API.TestHelper.create_encoded([{deposit_blknum, 0, 0, alice}], @eth, [{alice, 7}, {bob, 3}])
+    {:ok, %{blknum: block_nr}} = Client.call(:submit, %{transaction: tx})
+
+    IntegrationTest.wait_until_block_getter_fetches_block(block_nr, @timeout)
+
+    encode_tx = Client.encode(tx)
+
+    assert [
+             %{
+               "amount" => 3,
+               "blknum" => ^block_nr,
+               "txindex" => 0,
+               "oindex" => 1,
+               "currency" => @eth_hex,
+               "txbytes" => ^encode_tx
+             }
+           ] = IntegrationTest.get_utxos(bob)
+
+    assert [
+             ^token_deposit,
+             %{
+               "amount" => 7,
+               "blknum" => ^block_nr,
+               "txindex" => 0,
+               "oindex" => 0,
+               "currency" => @eth_hex,
+               "txbytes" => ^encode_tx
+             }
+           ] = IntegrationTest.get_utxos(alice)
+
+    %{
+      "utxo_pos" => utxo_pos,
+      "txbytes" => txbytes,
+      "proof" => proof,
+      "sigs" => sigs
+    } = IntegrationTest.get_exit_data(block_nr, 0, 0)
+
+    {:ok, txhash1} =
+      Eth.RootChain.start_exit(
+        utxo_pos,
+        txbytes,
+        proof,
+        sigs,
+        alice.addr
+      )
+
+    {:ok, %{"status" => "0x1"}} = Eth.WaitFor.eth_receipt(txhash1, @timeout)
+
+    # exiting spends UTXO on child chain
+    # wait until the exit is recognized and attempt to spend the exited utxo
+    Process.sleep(4_000)
+
+    assert [token_deposit] == IntegrationTest.get_utxos(alice)
+
+    # finally alice exits her token deposit
+    deposit_pos = Utxo.position(token_deposit_blknum, 0, 0) |> Utxo.Position.encode()
+
+    {:ok, txhash2} =
+      Eth.RootChain.start_deposit_exit(
+        deposit_pos,
+        token,
+        10,
+        alice.addr
+      )
+
+    {:ok, %{"status" => "0x1"}} = Eth.WaitFor.eth_receipt(txhash2, @timeout)
+
+    # exiting spends UTXO on child chain
+    # wait until the exit is recognized and attempt to spend the exited utxo
+    Process.sleep(4_000)
+
+    assert [] == IntegrationTest.get_utxos(alice)
   end
 end

--- a/apps/omg_watcher/test/web/serializers/response_test.exs
+++ b/apps/omg_watcher/test/web/serializers/response_test.exs
@@ -56,8 +56,8 @@ defmodule OMG.Watcher.Web.Serializer.ResponseTest do
             currency: "0000000000000000000000000000000000000000",
             deposit: %{
               __meta__: %{context: nil, source: {nil, "txoutputs"}, state: :loaded},
-              deposit_blknum: 1,
-              deposit_txindex: 0,
+              blknum: 1,
+              txindex: 0,
               event_type: :deposit,
               hash: "hash1"
             },

--- a/apps/omg_watcher/test/web/serializers/response_test.exs
+++ b/apps/omg_watcher/test/web/serializers/response_test.exs
@@ -53,7 +53,7 @@ defmodule OMG.Watcher.Web.Serializer.ResponseTest do
             amount: 1,
             creating_deposit: "hash1",
             creating_transaction: nil,
-            currency: "0000000000000000000000000000000000000000",
+            currency: String.duplicate("00", 20),
             deposit: %{
               __meta__: %{context: nil, source: {nil, "txoutputs"}, state: :loaded},
               blknum: 1,


### PR DESCRIPTION
Implements a feature that marks utxo as spent in WatcherDB when exit is started for this utxo.
The utxo is marked as spend immediately after start_exit event appears on Root Chain (`fast_exitor`).