### PR TITLE
add bulk insert chunking support

### DIFF
--- a/apps/omg_watcher/lib/db/transaction.ex
+++ b/apps/omg_watcher/lib/db/transaction.ex
@@ -64,7 +64,7 @@ defmodule OMG.Watcher.DB.Transaction do
   @doc """
   Inserts complete and sorted enumberable of transactions for particular block number
   """
-  @spec update_with(mined_block()) :: {:ok, __MODULE__}
+  @spec update_with(mined_block()) :: {:ok, any()}
   def update_with(%{transactions: transactions, blknum: block_number, eth_height: eth_height}) do
     [db_txs, db_outputs, db_inputs] =
       transactions
@@ -76,8 +76,8 @@ defmodule OMG.Watcher.DB.Transaction do
         &Repo.transaction/1,
         [
           fn ->
-            _ = Repo.insert_all(__MODULE__, db_txs)
-            _ = Repo.insert_all(DB.TxOutput, db_outputs)
+            _ = Repo.insert_all_chunked(__MODULE__, db_txs)
+            _ = Repo.insert_all_chunked(DB.TxOutput, db_outputs)
 
             # inputs are set as spent after outputs are inserted to support spending utxo from the same block
             DB.TxOutput.spend_utxos(db_inputs)


### PR DESCRIPTION
Implemented chunking while inserting significant amount of data.
*For instance*
Assuming Pg supports max 65535 parameters  
Each output has 7 fields, so we can bulk insert less than 9362 at once with std `Repo.insert_all/3`

With chunking I was able to insert successfully 11068 transactions (22136 outputs) in one block. 

**Testing whether it works**
Please send **more than 4682 txs per block**, which gives (9364 outputs, 65548 fields).