### PR TITLE
Prevent event listeners from processing some events twice on restart

### DIFF
--- a/apps/omg_api/lib/ethereum_event_listener.ex
+++ b/apps/omg_api/lib/ethereum_event_listener.ex
@@ -54,13 +54,7 @@ defmodule OMG.API.EthereumEventListener do
     _ = Logger.info(fn -> "Starting EthereumEventListener for #{service_name}" end)
 
     {:ok,
-     {%Core{
-        synced_height_update_key: update_key,
-        next_event_height_lower_bound: last_event_block_height,
-        synced_height: last_event_block_height,
-        service_name: service_name,
-        block_finality_margin: finality_margin
-      },
+     {Core.init(update_key, service_name, last_event_block_height, finality_margin),
       %{
         get_ethereum_events_callback: get_events_callback,
         process_events_callback: process_events_callback

--- a/apps/omg_api/lib/ethereum_event_listener/core.ex
+++ b/apps/omg_api/lib/ethereum_event_listener/core.ex
@@ -61,7 +61,7 @@ defmodule OMG.API.EthereumEventListener.Core do
         next_event_height_lower_bound: next_event_height_upper_bound + 1
     }
 
-    db_updates = [{:put, update_key, next_event_height_upper_bound}]
+    db_updates = [{:put, update_key, next_sync_height}]
 
     {:get_events, {next_event_height_lower_bound, next_event_height_upper_bound}, new_state, db_updates}
   end

--- a/apps/omg_api/lib/ethereum_event_listener/core.ex
+++ b/apps/omg_api/lib/ethereum_event_listener/core.ex
@@ -33,6 +33,16 @@ defmodule OMG.API.EthereumEventListener.Core do
           block_finality_margin: non_neg_integer()
         }
 
+  def init(update_key, service_name, last_synced_ethereum_height, block_finality_margin) do
+    %__MODULE__{
+      synced_height_update_key: update_key,
+      next_event_height_lower_bound: max(last_synced_ethereum_height - block_finality_margin + 1, 0),
+      synced_height: last_synced_ethereum_height,
+      service_name: service_name,
+      block_finality_margin: block_finality_margin
+    }
+  end
+
   @doc """
   Returns next Ethereum height to get events from.
   """

--- a/apps/omg_api/lib/root_chain_coordinator/core.ex
+++ b/apps/omg_api/lib/root_chain_coordinator/core.ex
@@ -72,10 +72,10 @@ defmodule OMG.API.RootChainCoordinator.Core do
 
   defp allowed?(allowed_services, service_name), do: MapSet.member?(allowed_services, service_name)
 
-  defp update_service_synced_height(state, pid, service_current_sync_height, service_name) do
-    service = %Service{synced_height: service_current_sync_height, pid: pid}
+  defp update_service_synced_height(state, pid, service_reported_sync_height, service_name) do
+    service = %Service{synced_height: service_reported_sync_height, pid: pid}
 
-    if valid_sync_height_update?(state, service, service_current_sync_height, service_name) do
+    if valid_sync_height_update?(state, service, service_reported_sync_height, service_name) do
       services = Map.put(state.services, service_name, service)
       state = %{state | services: services}
       {:ok, state}
@@ -84,9 +84,9 @@ defmodule OMG.API.RootChainCoordinator.Core do
     end
   end
 
-  defp valid_sync_height_update?(state, synced_service, service_current_sync_height, service_name) do
+  defp valid_sync_height_update?(state, synced_service, service_reported_sync_height, service_name) do
     service = Map.get(state.services, service_name, synced_service)
-    service.synced_height <= service_current_sync_height and state.root_chain_height >= service_current_sync_height
+    service.synced_height <= service_reported_sync_height and state.root_chain_height >= service_reported_sync_height
   end
 
   defp get_services_to_sync(state, previous_synced_height) do

--- a/apps/omg_api/test/ethereum_event_listener/core_test.exs
+++ b/apps/omg_api/test/ethereum_event_listener/core_test.exs
@@ -36,14 +36,14 @@ defmodule OMG.API.EthereumEventListener.CoreTest do
       Core.get_events_height_range_for_next_sync(state, next_sync_height)
 
     assert next_sync_height == upper_bound + state.block_finality_margin
-    assert lower_bound < upper_bound
+    assert lower_bound <= upper_bound
 
     {:dont_get_events, ^state} = Core.get_events_height_range_for_next_sync(state, next_sync_height)
 
     next_sync_height = next_sync_height + 1
     expected_lower_bound = upper_bound + 1
 
-    {
+    assert {
       :get_events,
       {^expected_lower_bound, expected_upper_bound},
       state,

--- a/apps/omg_api/test/ethereum_event_listener/core_test.exs
+++ b/apps/omg_api/test/ethereum_event_listener/core_test.exs
@@ -18,18 +18,15 @@ defmodule OMG.API.EthereumEventListener.CoreTest do
 
   alias OMG.API.EthereumEventListener.Core
 
-  deffixture initial_state() do
-    %Core{
-      block_finality_margin: 10,
-      service_name: :event_listener,
-      synced_height_update_key: :event_listener_height,
-      next_event_height_lower_bound: 80,
-      synced_height: 100
-    }
+  @finality_margin 10
+
+  defp create_state, do: create_state(100)
+  defp create_state(height) do
+    Core.init(:event_listener_height, :event_listener, height, @finality_margin)
   end
 
-  @tag fixtures: [:initial_state]
-  test "produces next ethereum height range to get events from", %{initial_state: state} do
+  test "produces next ethereum height range to get events from" do
+    state = create_state()
     next_sync_height = 101
 
     {:get_events, {lower_bound, upper_bound}, state, [{:put, :event_listener_height, ^next_sync_height}]} =
@@ -54,5 +51,29 @@ defmodule OMG.API.EthereumEventListener.CoreTest do
 
     {:dont_get_events, ^state} = Core.get_events_height_range_for_next_sync(state, next_sync_height)
     assert expected_upper_bound < next_sync_height
+  end
+
+  test "restart allows to continue with proper bounds" do
+    state = create_state(100)
+    next_sync_height = 105
+
+    {:get_events, {lower_bound, upper_bound}, _state, [{:put, :event_listener_height, ^next_sync_height}]} =
+      Core.get_events_height_range_for_next_sync(state, next_sync_height)
+    assert lower_bound == 100 - @finality_margin + 1
+
+    # simulate restart:
+    state = create_state(next_sync_height)
+
+    next_sync_height = next_sync_height + 3
+    expected_lower_bound = upper_bound + 1
+    expected_upper_bound = next_sync_height - @finality_margin
+    assert 3 == expected_upper_bound - expected_lower_bound + 1
+
+    assert {
+      :get_events,
+      {^expected_lower_bound, ^expected_upper_bound},
+      _,
+      [{:put, :event_listener_height, ^next_sync_height}]
+    } = Core.get_events_height_range_for_next_sync(state, next_sync_height)
   end
 end

--- a/apps/omg_api/test/ethereum_event_listener/core_test.exs
+++ b/apps/omg_api/test/ethereum_event_listener/core_test.exs
@@ -32,10 +32,10 @@ defmodule OMG.API.EthereumEventListener.CoreTest do
   test "produces next ethereum height range to get events from", %{initial_state: state} do
     next_sync_height = 101
 
-    {:get_events, {lower_bound, upper_bound}, state, [{:put, :event_listener_height, synced_height}]} =
+    {:get_events, {lower_bound, upper_bound}, state, [{:put, :event_listener_height, ^next_sync_height}]} =
       Core.get_events_height_range_for_next_sync(state, next_sync_height)
 
-    assert synced_height == upper_bound
+    assert next_sync_height == upper_bound + state.block_finality_margin
     assert lower_bound < upper_bound
 
     {:dont_get_events, ^state} = Core.get_events_height_range_for_next_sync(state, next_sync_height)
@@ -47,10 +47,10 @@ defmodule OMG.API.EthereumEventListener.CoreTest do
       :get_events,
       {^expected_lower_bound, expected_upper_bound},
       state,
-      [{:put, :event_listener_height, synced_height}]
+      [{:put, :event_listener_height, ^next_sync_height}]
     } = Core.get_events_height_range_for_next_sync(state, next_sync_height)
 
-    assert synced_height == expected_upper_bound
+    assert next_sync_height == expected_upper_bound + state.block_finality_margin
 
     {:dont_get_events, ^state} = Core.get_events_height_range_for_next_sync(state, next_sync_height)
     assert expected_upper_bound < next_sync_height

--- a/apps/omg_api/test/ethereum_event_listener/core_test.exs
+++ b/apps/omg_api/test/ethereum_event_listener/core_test.exs
@@ -21,6 +21,7 @@ defmodule OMG.API.EthereumEventListener.CoreTest do
   @finality_margin 10
 
   defp create_state, do: create_state(100)
+
   defp create_state(height) do
     Core.init(:event_listener_height, :event_listener, height, @finality_margin)
   end
@@ -41,11 +42,11 @@ defmodule OMG.API.EthereumEventListener.CoreTest do
     expected_lower_bound = upper_bound + 1
 
     assert {
-      :get_events,
-      {^expected_lower_bound, expected_upper_bound},
-      state,
-      [{:put, :event_listener_height, ^next_sync_height}]
-    } = Core.get_events_height_range_for_next_sync(state, next_sync_height)
+             :get_events,
+             {^expected_lower_bound, expected_upper_bound},
+             state,
+             [{:put, :event_listener_height, ^next_sync_height}]
+           } = Core.get_events_height_range_for_next_sync(state, next_sync_height)
 
     assert next_sync_height == expected_upper_bound + state.block_finality_margin
 
@@ -59,6 +60,7 @@ defmodule OMG.API.EthereumEventListener.CoreTest do
 
     {:get_events, {lower_bound, upper_bound}, _state, [{:put, :event_listener_height, ^next_sync_height}]} =
       Core.get_events_height_range_for_next_sync(state, next_sync_height)
+
     assert lower_bound == 100 - @finality_margin + 1
 
     # simulate restart:
@@ -70,10 +72,10 @@ defmodule OMG.API.EthereumEventListener.CoreTest do
     assert 3 == expected_upper_bound - expected_lower_bound + 1
 
     assert {
-      :get_events,
-      {^expected_lower_bound, ^expected_upper_bound},
-      _,
-      [{:put, :event_listener_height, ^next_sync_height}]
-    } = Core.get_events_height_range_for_next_sync(state, next_sync_height)
+             :get_events,
+             {^expected_lower_bound, ^expected_upper_bound},
+             _,
+             [{:put, :event_listener_height, ^next_sync_height}]
+           } = Core.get_events_height_range_for_next_sync(state, next_sync_height)
   end
 end

--- a/apps/omg_db/lib/db.ex
+++ b/apps/omg_db/lib/db.ex
@@ -57,6 +57,9 @@ defmodule OMG.DB do
     GenServer.call(server_name, :child_top_block_number)
   end
 
+  # Note: *_eth_height values below denote actual Ethereum height service has processed.
+  # It might differ from "latest" Ethereum block.
+
   def last_fast_exit_eth_height(server_name \\ @server_name) do
     GenServer.call(server_name, :last_fast_exit_eth_height)
   end


### PR DESCRIPTION
By writing to db `current_ethereum_height - maturity_block` and reading value from db as if it was `current_ethereum_height` listener sets itself up for processing of the same events twice. This patch fixes it.