### PR TITLE
bug: botched handle_info clause will cause root_coordinator_restart

### DIFF
--- a/apps/omg_api/lib/ethereum_event_listener.ex
+++ b/apps/omg_api/lib/ethereum_event_listener.ex
@@ -24,13 +24,13 @@ defmodule OMG.API.EthereumEventListener do
   use OMG.API.LoggerExt
 
   @type config() :: %{
-    block_finality_margin: non_neg_integer,
-    synced_height_update_key: atom,
-    service_name: atom,
-    get_events_callback: (non_neg_integer, non_neg_integer -> {:ok, [any]}),
-    process_events_callback: ([any] -> :ok),
-    get_last_synced_height_callback: (-> {:ok, non_neg_integer})
-  }
+          block_finality_margin: non_neg_integer,
+          synced_height_update_key: atom,
+          service_name: atom,
+          get_events_callback: (non_neg_integer, non_neg_integer -> {:ok, [any]}),
+          process_events_callback: ([any] -> :ok),
+          get_last_synced_height_callback: (() -> {:ok, non_neg_integer})
+        }
 
   ### Client
 

--- a/apps/omg_api/lib/root_chain_coordinator.ex
+++ b/apps/omg_api/lib/root_chain_coordinator.ex
@@ -79,7 +79,7 @@ defmodule OMG.API.RootChainCoordinator do
   end
 
   def handle_info(:timeout, state) do
-    Logger.warn(fn -> "No new activity for 60 seconds. Are we dead?" end)
+    _ = Logger.warn(fn -> "No new activity for 60 seconds. Are we dead?" end)
     {:noreply, state}
   end
 

--- a/apps/omg_api/lib/root_chain_coordinator.ex
+++ b/apps/omg_api/lib/root_chain_coordinator.ex
@@ -80,6 +80,7 @@ defmodule OMG.API.RootChainCoordinator do
 
   def handle_info(:timeout, state) do
     Logger.warn(fn -> "No new activity for 60 seconds. Are we dead?" end)
+    {:noreply, state}
   end
 
   defp schedule_get_ethereum_height(interval) do


### PR DESCRIPTION
Returning bad value from handle_info would cause a unneeded coordinator restart.