### PR TITLE
feature: add timestamp and eth_height to transaction endpoint

### DIFF
--- a/apps/omg_api/lib/root_chain_coordinator.ex
+++ b/apps/omg_api/lib/root_chain_coordinator.ex
@@ -79,7 +79,7 @@ defmodule OMG.API.RootChainCoordinator do
   end
 
   def handle_info(:timeout, state) do
-    Logger.warn(fn -> "No new activity for 60 seconds. Are we dead?" end)
+    _ = Logger.warn(fn -> "No new activity for 60 seconds. Are we dead?" end)
     {:noreply, state}
   end
 

--- a/apps/omg_watcher/lib/db/transaction.ex
+++ b/apps/omg_watcher/lib/db/transaction.ex
@@ -49,16 +49,10 @@ defmodule OMG.Watcher.DB.Transaction do
     belongs_to(:block, DB.Block, foreign_key: :blknum, references: :blknum, type: :integer)
   end
 
-  def get(hash, preload_block \\ false) do
-    transaction =
-      __MODULE__
-      |> Repo.get(hash)
-
-    if preload_block do
-      transaction |> Repo.preload(:block)
-    else
-      transaction
-    end
+  def get(hash) do
+    __MODULE__
+    |> Repo.get(hash)
+    |> Repo.preload(:block)
   end
 
   def get_last(limit) do
@@ -66,11 +60,11 @@ defmodule OMG.Watcher.DB.Transaction do
       from(
         __MODULE__,
         order_by: [desc: :blknum, desc: :txindex],
-        limit: ^limit
+        limit: ^limit,
+        preload: [:block]
       )
 
     Repo.all(query)
-    |> Repo.preload(:block)
   end
 
   def get_by_address(address, limit) do
@@ -82,11 +76,11 @@ defmodule OMG.Watcher.DB.Transaction do
         left_join: input in assoc(tx, :inputs),
         where: output.owner == ^address or input.owner == ^address,
         order_by: [desc: tx.blknum, desc: tx.txindex],
-        limit: ^limit
+        limit: ^limit,
+        preload: [:block]
       )
 
     Repo.all(query)
-    |> Repo.preload(:block)
   end
 
   def get_by_blknum(blknum) do
@@ -98,7 +92,7 @@ defmodule OMG.Watcher.DB.Transaction do
   end
 
   @doc """
-  Inserts complete and sorted enumberable of transactions for particular block number
+  Inserts complete and sorted enumerable of transactions for particular block number
   """
   @spec update_with(mined_block()) :: {:ok, any()}
   def update_with(%{

--- a/apps/omg_watcher/lib/db/transaction.ex
+++ b/apps/omg_watcher/lib/db/transaction.ex
@@ -49,9 +49,16 @@ defmodule OMG.Watcher.DB.Transaction do
     belongs_to(:block, DB.Block, foreign_key: :blknum, references: :blknum, type: :integer)
   end
 
-  def get(hash) do
-    __MODULE__
-    |> Repo.get(hash)
+  def get(hash, preload_block \\ false) do
+    transaction =
+      __MODULE__
+      |> Repo.get(hash)
+
+    if preload_block do
+      transaction |> Repo.preload(:block)
+    else
+      transaction
+    end
   end
 
   def get_last(limit) do
@@ -63,6 +70,7 @@ defmodule OMG.Watcher.DB.Transaction do
       )
 
     Repo.all(query)
+    |> Repo.preload(:block)
   end
 
   def get_by_address(address, limit) do
@@ -78,6 +86,7 @@ defmodule OMG.Watcher.DB.Transaction do
       )
 
     Repo.all(query)
+    |> Repo.preload(:block)
   end
 
   def get_by_blknum(blknum) do

--- a/apps/omg_watcher/lib/web/controllers/transaction.ex
+++ b/apps/omg_watcher/lib/web/controllers/transaction.ex
@@ -35,7 +35,7 @@ defmodule OMG.Watcher.Web.Controller.Transaction do
   def get_transaction(conn, %{"id" => id}) do
     id
     |> Base.decode16!()
-    |> DB.Transaction.get(true)
+    |> DB.Transaction.get()
     |> respond(conn)
   end
 
@@ -200,7 +200,7 @@ defmodule OMG.Watcher.Web.Controller.Transaction do
     summary("Gets a transaction with the given id")
 
     parameters do
-      id(:path, :integer, "Id of the transaction", required: true)
+      id(:path, :string, "Id of the transaction", required: true)
     end
 
     response(200, "OK", Schema.ref(:Transaction))

--- a/apps/omg_watcher/lib/web/controllers/transaction.ex
+++ b/apps/omg_watcher/lib/web/controllers/transaction.ex
@@ -35,7 +35,7 @@ defmodule OMG.Watcher.Web.Controller.Transaction do
   def get_transaction(conn, %{"id" => id}) do
     id
     |> Base.decode16!()
-    |> DB.Transaction.get()
+    |> DB.Transaction.get(true)
     |> respond(conn)
   end
 
@@ -128,6 +128,8 @@ defmodule OMG.Watcher.Web.Controller.Transaction do
             sig2(:string, "Signature of owner of the second input utxo", required: true)
             spender1(:string, "Address of owner of the first input utxo", required: true)
             spender2(:string, "Address of owner of the second input utxo", required: true)
+            timestamp(:integer, "Timestamp of a block which the transaction was included in", required: true)
+            eth_height(:integer, "Eth height where the block was submitted", required: true)
           end
 
           example(%{
@@ -150,7 +152,9 @@ defmodule OMG.Watcher.Web.Controller.Transaction do
             sig2:
               "0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
             spender1: "92EAD0DB732692FF887268DA965C311AC2C9005B",
-            spender2: "92EAD0DB732692FF887268DA965C311AC2C9005B"
+            spender2: "92EAD0DB732692FF887268DA965C311AC2C9005B",
+            timestamp: 1_540_365_586,
+            eth_height: 6_573_395
           })
         end,
       Transactions:

--- a/apps/omg_watcher/lib/web/controllers/transaction.ex
+++ b/apps/omg_watcher/lib/web/controllers/transaction.ex
@@ -35,7 +35,7 @@ defmodule OMG.Watcher.Web.Controller.Transaction do
   def get_transaction(conn, %{"id" => id}) do
     id
     |> Base.decode16!()
-    |> DB.Transaction.get()
+    |> DB.Transaction.get(true)
     |> respond(conn)
   end
 

--- a/apps/omg_watcher/lib/web/views/transaction.ex
+++ b/apps/omg_watcher/lib/web/views/transaction.ex
@@ -40,6 +40,8 @@ defmodule OMG.Watcher.Web.View.Transaction do
   end
 
   defp render_transaction(transaction) do
+    block = transaction.block
+
     {:ok,
      %Transaction.Signed{
        raw_tx: tx,
@@ -58,6 +60,8 @@ defmodule OMG.Watcher.Web.View.Transaction do
       txid: transaction.txhash,
       txblknum: transaction.blknum,
       txindex: transaction.txindex,
+      timestamp: block.timestamp,
+      eth_height: block.eth_height,
       sig1: sig1,
       sig2: sig2,
       spender1: spender1,

--- a/apps/omg_watcher/test/web/controllers/transaction_test.exs
+++ b/apps/omg_watcher/test/web/controllers/transaction_test.exs
@@ -302,14 +302,7 @@ defmodule OMG.Watcher.Web.Controller.TransactionTest do
                }
              ] ==
                txs
-               |> Enum.map(fn tx ->
-                 %{
-                   "txblknum" => tx["txblknum"],
-                   "txindex" => tx["txindex"],
-                   "eth_height" => tx["eth_height"],
-                   "timestamp" => tx["timestamp"]
-                 }
-               end)
+               |> Enum.map(&Map.take(&1, ["txblknum", "txindex", "eth_height", "timestamp"]))
     end
   end
 

--- a/apps/omg_watcher/test/web/controllers/transaction_test.exs
+++ b/apps/omg_watcher/test/web/controllers/transaction_test.exs
@@ -268,14 +268,8 @@ defmodule OMG.Watcher.Web.Controller.TransactionTest do
         TestHelper.rest_call(:get, "/transactions?address=#{address}&limit=#{limit}")
 
       assert expected_result ==
-               Enum.map(txs, fn tx ->
-                 %{
-                   "spender1" => tx["spender1"],
-                   "spender2" => tx["spender2"],
-                   "newowner1" => tx["newowner1"],
-                   "newowner2" => tx["newowner2"]
-                 }
-               end)
+               txs
+               |> Enum.map(&Map.take(&1, ["spender1", "spender2", "newowner1", "newowner2"]))
     end
   end
 

--- a/apps/omg_watcher/test/web/controllers/transaction_test.exs
+++ b/apps/omg_watcher/test/web/controllers/transaction_test.exs
@@ -68,6 +68,7 @@ defmodule OMG.Watcher.Web.Controller.TransactionTest do
     } do
       {blknum, txindex, txhash, _recovered_tx} = initial_blocks |> hd()
 
+      %DB.Block{timestamp: timestamp, eth_height: eth_height} = DB.Block.get(blknum)
       bob_addr = bob.addr |> TestHelper.to_response_address()
       alice_addr = alice.addr |> TestHelper.to_response_address()
       txhash = Base.encode16(txhash)
@@ -93,7 +94,9 @@ defmodule OMG.Watcher.Web.Controller.TransactionTest do
                  "sig1" => <<_sig1::binary-size(130)>>,
                  "sig2" => ^zero_sign,
                  "spender1" => ^alice_addr,
-                 "spender2" => nil
+                 "spender2" => nil,
+                 "eth_height" => ^eth_height,
+                 "timestamp" => ^timestamp
                },
                "result" => "success"
              } = TestHelper.rest_call(:get, "/transaction/#{txhash}")


### PR DESCRIPTION
Transaction endpoint now returns data from block the transaction is included in. The additional info is `eth_height` and `timestamp`