### PR TITLE
fix: improve LevelDB init - more verbose and fool proof

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,8 @@ config :omg_db,
 ```
 rm -rf ~/.omg/data_watcher
 cd apps/omg_watcher
-mix do ecto.reset --no-start, run --no-start -e 'OMG.DB.init()' --config ~/config_watcher.exs
+mix ecto.reset --no-start
+mix run --no-start -e 'OMG.DB.init()' --config ~/config_watcher.exs
 ```
 
 #### Start the Watcher

--- a/apps/omg_db/lib/leveldb_server.ex
+++ b/apps/omg_db/lib/leveldb_server.ex
@@ -27,6 +27,18 @@ defmodule OMG.DB.LevelDBServer do
 
   require Logger
 
+  @doc """
+  Initializes an empty LevelDB instance explicitly, so we can have control over it.
+  NOTE: `init` here is to init the GenServer and that assumes that `init_storage` has already been called
+  """
+  @spec init_storage(binary) :: :ok | {:error, atom}
+  def init_storage(db_path) do
+    # open and close with the create flag set to true to initialize the LevelDB itself
+    with {:ok, db_ref} <- Exleveldb.open(db_path, create_if_missing: true),
+         true <- Exleveldb.is_empty?(db_ref) || {:error, :leveldb_not_empty},
+         do: Exleveldb.close(db_ref)
+  end
+
   def start_link(name: name, db_path: db_path) do
     GenServer.start_link(__MODULE__, %{db_path: db_path}, name: name)
   end
@@ -35,7 +47,7 @@ defmodule OMG.DB.LevelDBServer do
     # needed so that terminate callback is called on normal close
     Process.flag(:trap_exit, true)
 
-    with {:ok, db_ref} <- Exleveldb.open(db_path) do
+    with {:ok, db_ref} <- Exleveldb.open(db_path, create_if_missing: false) do
       {:ok, %__MODULE__{db_ref: db_ref}}
     else
       error ->

--- a/apps/omg_db/test/db_test.exs
+++ b/apps/omg_db/test/db_test.exs
@@ -35,6 +35,8 @@ defmodule OMG.DBTest do
   setup do
     {:ok, dir} = Briefly.create(directory: true)
 
+    :ok = OMG.DB.LevelDBServer.init_storage(dir)
+
     {:ok, pid} =
       GenServer.start_link(
         OMG.DB.LevelDBServer,


### PR DESCRIPTION
- LevelDBServer.init won't ever create a leveldb instance
- a database-not-empty error isn't silenced out
- one shouldn't use `mix do` in elixir 1.6 for databases reset (updated README)

Thanks to @kevsul for reporting and tracking