### PR TITLE
feat: in :dev setting, stop beam if top-level supervisor dies

### DIFF
--- a/apps/omg_api/mix.exs
+++ b/apps/omg_api/mix.exs
@@ -11,7 +11,7 @@ defmodule OMG.API.MixProject do
       lockfile: "../../mix.lock",
       elixir: "~> 1.6",
       elixirc_paths: elixirc_paths(Mix.env()),
-      start_permanent: Mix.env() == :prod,
+      start_permanent: Mix.env() in [:dev, :prod],
       deps: deps(),
       test_coverage: [tool: ExCoveralls]
     ]

--- a/apps/omg_watcher/mix.exs
+++ b/apps/omg_watcher/mix.exs
@@ -12,7 +12,7 @@ defmodule OMG.Watcher.Mixfile do
       elixir: "~> 1.4",
       elixirc_paths: elixirc_paths(Mix.env()),
       compilers: [:phoenix, :phoenix_swagger] ++ Mix.compilers(),
-      start_permanent: Mix.env() == :prod,
+      start_permanent: Mix.env() in [:dev, :prod],
       aliases: aliases(),
       deps: deps(),
       test_coverage: [tool: ExCoveralls]


### PR DESCRIPTION
This is a demo only measure - since there is not enough time to
properly configure :prod mode.