### PR TITLE
fix(watcher): fix returned txs in order & ensuring hard limit in 'tra…

### DIFF
--- a/apps/omg_watcher/lib/db/transaction.ex
+++ b/apps/omg_watcher/lib/db/transaction.ex
@@ -81,7 +81,7 @@ defmodule OMG.Watcher.DB.Transaction do
     query =
       from(
         tx in __MODULE__,
-        distinct: tx.txhash,
+        distinct: true,
         left_join: output in assoc(tx, :outputs),
         left_join: input in assoc(tx, :inputs),
         where: output.owner == ^address or input.owner == ^address,

--- a/apps/omg_watcher/lib/web/controllers/transaction.ex
+++ b/apps/omg_watcher/lib/web/controllers/transaction.ex
@@ -45,6 +45,10 @@ defmodule OMG.Watcher.Web.Controller.Transaction do
   def get_transactions(conn, params) do
     address = Map.get(params, "address")
     limit = Map.get(params, "limit", @default_transactions_limit)
+    {limit, ""} = limit |> Kernel.to_string() |> Integer.parse()
+
+    # TODO: implement pagination. Defend against fetching huge dataset.
+    limit = min(limit, @default_transactions_limit)
 
     transactions =
       if address == nil do


### PR DESCRIPTION
Testing transactions/ endpoint w/o parameters.
Fixed
 * txs returned in correct order (latest first)
 * better `limit` param handling & hard limit to 200 records