### PR TITLE
style: add inspect to value interpolation in logged strings

### DIFF
--- a/apps/omg_api/lib/root_chain_coordinator.ex
+++ b/apps/omg_api/lib/root_chain_coordinator.ex
@@ -56,7 +56,7 @@ defmodule OMG.API.RootChainCoordinator do
   end
 
   def handle_call({:check_in, synced_height, service_name}, {pid, _}, state) do
-    _ = Logger.info(fn -> "#{service_name} checks in on height #{synced_height}" end)
+    _ = Logger.info(fn -> "#{inspect(service_name)} checks in on height #{inspect(synced_height)}" end)
     {:ok, state, services_to_sync} = Core.check_in(state, pid, synced_height, service_name)
     _ = length(services_to_sync) > 0 and Logger.info(fn -> "Services to sync: #{inspect(services_to_sync)}" end)
     request_sync(services_to_sync)

--- a/apps/omg_watcher/lib/block_getter.ex
+++ b/apps/omg_watcher/lib/block_getter.ex
@@ -161,12 +161,18 @@ defmodule OMG.Watcher.BlockGetter do
       block_range = Core.get_eth_range_for_block_submitted_events(state, next_synced_height)
       {:ok, submissions} = Eth.RootChain.get_block_submitted_events(block_range)
 
-      _ = Logger.info(fn -> "Submitted #{length(submissions)} plasma blocks on Ethereum block range #{block_range}" end)
+      _ =
+        Logger.info(fn ->
+          "Submitted #{length(submissions)} plasma blocks on Ethereum block range #{inspect(block_range)}"
+        end)
 
       {blocks_to_apply, synced_height, db_updates, state} =
         Core.get_blocks_to_apply(state, submissions, next_synced_height)
 
-      _ = Logger.info(fn -> "Synced height is #{synced_height}, got #{length(blocks_to_apply)} blocks to apply" end)
+      _ =
+        Logger.info(fn ->
+          "Synced height is #{inspect(synced_height)}, got #{length(blocks_to_apply)} blocks to apply"
+        end)
 
       Enum.each(blocks_to_apply, fn {block, eth_height} ->
         GenServer.cast(__MODULE__, {:apply_block, block, eth_height})

--- a/apps/omg_watcher/lib/block_getter/core.ex
+++ b/apps/omg_watcher/lib/block_getter/core.ex
@@ -143,7 +143,9 @@ defmodule OMG.Watcher.BlockGetter.Core do
   def apply_block(%__MODULE__{} = state, applied_block_number, blk_eth_height) do
     _ =
       Logger.info(fn ->
-        "Applied block #{applied_block_number}, syncing not applied blocks: #{inspect(state.height_sync_blknums)}"
+        "Applied block #{inspect(applied_block_number)}, syncing not applied blocks: #{
+          inspect(state.height_sync_blknums)
+        }"
       end)
 
     if MapSet.member?(state.height_sync_blknums, applied_block_number) do


### PR DESCRIPTION
Always use inspect() when interpolating strings in logs
**Critical fix: Broke Watcher**  while testing on mac
CC: @pgebal, @paulperegud 
