### PR TITLE
fix: clean `info` level logs, suggestion

### DIFF
--- a/apps/omg_api/lib/root_chain_coordinator.ex
+++ b/apps/omg_api/lib/root_chain_coordinator.ex
@@ -56,9 +56,9 @@ defmodule OMG.API.RootChainCoordinator do
   end
 
   def handle_call({:check_in, synced_height, service_name}, {pid, _}, state) do
-    _ = Logger.info(fn -> "#{inspect(service_name)} checks in on height #{inspect(synced_height)}" end)
+    _ = Logger.debug(fn -> "#{inspect(service_name)} checks in on height #{inspect(synced_height)}" end)
     {:ok, state, services_to_sync} = Core.check_in(state, pid, synced_height, service_name)
-    _ = length(services_to_sync) > 0 and Logger.info(fn -> "Services to sync: #{inspect(services_to_sync)}" end)
+    _ = length(services_to_sync) > 0 and Logger.debug(fn -> "Services to sync: #{inspect(services_to_sync)}" end)
     request_sync(services_to_sync)
     {:reply, :ok, state, 60_000}
   end

--- a/apps/omg_watcher/lib/block_getter.ex
+++ b/apps/omg_watcher/lib/block_getter.ex
@@ -162,7 +162,7 @@ defmodule OMG.Watcher.BlockGetter do
       {:ok, submissions} = Eth.RootChain.get_block_submitted_events(block_range)
 
       _ =
-        Logger.info(fn ->
+        Logger.debug(fn ->
           "Submitted #{length(submissions)} plasma blocks on Ethereum block range #{inspect(block_range)}"
         end)
 
@@ -170,7 +170,7 @@ defmodule OMG.Watcher.BlockGetter do
         Core.get_blocks_to_apply(state, submissions, next_synced_height)
 
       _ =
-        Logger.info(fn ->
+        Logger.debug(fn ->
           "Synced height is #{inspect(synced_height)}, got #{length(blocks_to_apply)} blocks to apply"
         end)
 

--- a/apps/omg_watcher/lib/block_getter/core.ex
+++ b/apps/omg_watcher/lib/block_getter/core.ex
@@ -142,7 +142,7 @@ defmodule OMG.Watcher.BlockGetter.Core do
   @spec apply_block(t(), pos_integer(), non_neg_integer()) :: {t(), non_neg_integer(), list()}
   def apply_block(%__MODULE__{} = state, applied_block_number, blk_eth_height) do
     _ =
-      Logger.info(fn ->
+      Logger.debug(fn ->
         "Applied block #{inspect(applied_block_number)}, syncing not applied blocks: #{
           inspect(state.height_sync_blknums)
         }"


### PR DESCRIPTION
please consider whether it doesn't go against your prior assumptions about logging, but without this `info` logs are too verbose to be useful