### PR TITLE
fix: restart policies of watcher's submodules

### DIFF
--- a/apps/omg_watcher/lib/application.ex
+++ b/apps/omg_watcher/lib/application.ex
@@ -21,7 +21,7 @@ defmodule OMG.Watcher.Application do
     start_root_supervisor()
   end
 
-  def start_root_supervisor() do
+  def start_root_supervisor do
     # root supervisor must stop whenever any of its children goes down
 
     children = [
@@ -49,7 +49,7 @@ defmodule OMG.Watcher.Application do
     Supervisor.start_link(children, opts)
   end
 
-  def start_watcher_supervisor() do
+  def start_watcher_supervisor do
     import Supervisor.Spec
 
     # Define workers and child supervisors to be supervised

--- a/apps/omg_watcher/lib/block_getter/supervisor.ex
+++ b/apps/omg_watcher/lib/block_getter/supervisor.ex
@@ -36,7 +36,7 @@ defmodule OMG.Watcher.BlockGetter.Supervisor do
       }
     ]
 
-    opts = [strategy: :one_for_all, name: __MODULE__]
+    opts = [strategy: :one_for_all, max_restarts: 2, max_seconds: 3 * 60, name: __MODULE__]
     Supervisor.init(children, opts)
   end
 end


### PR DESCRIPTION
This PR amends `Watcher`'s supervision hierarchy and its policy. 
`BlockGetter` and `State` will be allowed to die twice in 3 minutes - the third death kills the whole application.

This PR also includes some formatting alternations. 