### PR TITLE
chore: remove usages of `Supervisor.Spec`

### DIFF
--- a/apps/omg_api/lib/application.ex
+++ b/apps/omg_api/lib/application.ex
@@ -20,7 +20,6 @@ defmodule OMG.API.Application do
 
   use Application
   use OMG.API.LoggerExt
-  import Supervisor.Spec
 
   def start(_type, _args) do
     block_finality_margin = Application.get_env(:omg_api, :ethereum_event_block_finality_margin)
@@ -31,34 +30,36 @@ defmodule OMG.API.Application do
       {OMG.API.FreshBlocks, []},
       {OMG.API.FeeChecker, []},
       {OMG.API.RootChainCoordinator, MapSet.new([:depositer, :exiter])},
-      worker(
-        OMG.API.EthereumEventListener,
-        [
-          %{
-            synced_height_update_key: :last_depositor_eth_height,
-            service_name: :depositer,
-            block_finality_margin: block_finality_margin,
-            get_events_callback: &OMG.Eth.RootChain.get_deposits/2,
-            process_events_callback: &OMG.API.State.deposit/1,
-            get_last_synced_height_callback: &OMG.Eth.RootChain.get_root_deployment_height/0
-          }
-        ],
-        id: :depositer
-      ),
-      worker(
-        OMG.API.EthereumEventListener,
-        [
-          %{
-            synced_height_update_key: :last_exiter_eth_height,
-            service_name: :exiter,
-            block_finality_margin: block_finality_margin,
-            get_events_callback: &OMG.Eth.RootChain.get_exits/2,
-            process_events_callback: &OMG.API.State.exit_utxos/1,
-            get_last_synced_height_callback: &OMG.Eth.RootChain.get_root_deployment_height/0
-          }
-        ],
-        id: :exiter
-      )
+      %{
+        id: :depositor,
+        start:
+          {OMG.API.EthereumEventListener, :start_link,
+           [
+             %{
+               synced_height_update_key: :last_depositor_eth_height,
+               service_name: :depositer,
+               block_finality_margin: block_finality_margin,
+               get_events_callback: &OMG.Eth.RootChain.get_deposits/2,
+               process_events_callback: &OMG.API.State.deposit/1,
+               get_last_synced_height_callback: &OMG.Eth.RootChain.get_root_deployment_height/0
+             }
+           ]}
+      },
+      %{
+        id: :exiter,
+        start:
+          {OMG.API.EthereumEventListener, :start_link,
+           [
+             %{
+               synced_height_update_key: :last_exiter_eth_height,
+               service_name: :exiter,
+               block_finality_margin: block_finality_margin,
+               get_events_callback: &OMG.Eth.RootChain.get_exits/2,
+               process_events_callback: &OMG.API.State.exit_utxos/1,
+               get_last_synced_height_callback: &OMG.Eth.RootChain.get_root_deployment_height/0
+             }
+           ]}
+      }
     ]
 
     _ = Logger.info(fn -> "Started application OMG.API.Application" end)

--- a/apps/omg_performance/lib/performance.ex
+++ b/apps/omg_performance/lib/performance.ex
@@ -145,7 +145,7 @@ defmodule OMG.Performance do
     # select just necessary components to run the tests
     children = [
       %{
-        id: :phoenix_pg2,
+        id: Phoenix.PubSub.PG2,
         start: {Phoenix.PubSub.PG2, :start_link, [:eventer, []]},
         type: :supervisor
       },

--- a/apps/omg_performance/lib/performance.ex
+++ b/apps/omg_performance/lib/performance.ex
@@ -48,8 +48,6 @@ defmodule OMG.Performance do
 
   require Utxo
 
-  import Supervisor.Spec
-
   @eth Crypto.zero_address()
 
   @doc """
@@ -144,9 +142,13 @@ defmodule OMG.Performance do
 
     omg_port = Application.get_env(:omg_jsonrpc, :omg_api_rpc_port)
 
-    # select just neccessary components to run the tests
+    # select just necessary components to run the tests
     children = [
-      supervisor(Phoenix.PubSub.PG2, [:eventer, []]),
+      %{
+        id: :phoenix_pg2,
+        start: {Phoenix.PubSub.PG2, :start_link, [:eventer, []]},
+        type: :supervisor
+      },
       {OMG.API.State, []},
       {OMG.API.FreshBlocks, []},
       {OMG.API.FeeChecker, []},

--- a/apps/omg_watcher/lib/application.ex
+++ b/apps/omg_watcher/lib/application.ex
@@ -57,7 +57,7 @@ defmodule OMG.Watcher.Application do
     children = [
       # Start the Ecto repository
       %{
-        id: :omg_watcher_repo,
+        id: OMG.Watcher.DB.Repo,
         start: {OMG.Watcher.DB.Repo, :start_link, []},
         type: :supervisor
       },

--- a/apps/omg_watcher/lib/application.ex
+++ b/apps/omg_watcher/lib/application.ex
@@ -26,13 +26,13 @@ defmodule OMG.Watcher.Application do
 
     children = [
       %{
-        id: :watcher_supervisor,
+        id: OMG.Watcher.Supervisor,
         start: {__MODULE__, :start_watcher_supervisor, []},
         restart: :permanent,
         type: :supervisor
       },
       %{
-        id: :block_getter_supervisor,
+        id: OMG.Watcher.BlockGetter.Supervisor,
         start: {OMG.Watcher.BlockGetter.Supervisor, :start_link, []},
         restart: :permanent,
         type: :supervisor
@@ -65,7 +65,7 @@ defmodule OMG.Watcher.Application do
       {OMG.Watcher.Eventer, []},
       {
         OMG.API.RootChainCoordinator,
-        MapSet.new([:depositer, :fast_validator, :slow_validator, OMG.Watcher.BlockGetter])
+        MapSet.new([:depositor, :fast_validator, :slow_validator, OMG.Watcher.BlockGetter])
       },
       %{
         id: :depositor,
@@ -74,7 +74,7 @@ defmodule OMG.Watcher.Application do
            [
              %{
                synced_height_update_key: :last_depositor_eth_height,
-               service_name: :depositer,
+               service_name: :depositor,
                block_finality_margin: block_finality_margin,
                get_events_callback: &OMG.Eth.RootChain.get_deposits/2,
                process_events_callback: &deposit_events_callback/1,
@@ -114,7 +114,7 @@ defmodule OMG.Watcher.Application do
       },
       # Start the endpoint when the application starts
       %{
-        id: :watcher_endpoint,
+        id: OMG.Watcher.Web.Endpoint,
         start: {OMG.Watcher.Web.Endpoint, :start_link, []},
         type: :supervisor
       }

--- a/apps/omg_watcher/lib/block_getter/supervisor.ex
+++ b/apps/omg_watcher/lib/block_getter/supervisor.ex
@@ -20,7 +20,7 @@ defmodule OMG.Watcher.BlockGetter.Supervisor do
   use Supervisor
 
   def start_link do
-    Supervisor.start_link(__MODULE__, :ok)
+    Supervisor.start_link(__MODULE__, :ok, name: __MODULE__)
   end
 
   def init(:ok) do
@@ -30,13 +30,13 @@ defmodule OMG.Watcher.BlockGetter.Supervisor do
     children = [
       {OMG.API.State, []},
       %{
-        id: :block_getter,
+        id: OMG.Watcher.BlockGetter,
         start: {OMG.Watcher.BlockGetter, :start_link, [[]]},
         restart: :transient
       }
     ]
 
-    opts = [strategy: :one_for_all, max_restarts: 2, max_seconds: 3 * 60, name: __MODULE__]
+    opts = [strategy: :one_for_all, max_restarts: 2, max_seconds: 3 * 60]
     Supervisor.init(children, opts)
   end
 end

--- a/apps/omg_watcher/test/fixtures.exs
+++ b/apps/omg_watcher/test/fixtures.exs
@@ -138,11 +138,12 @@ defmodule OMG.Watcher.Fixtures do
 
   @doc "run only database in sandbox and endpoint to make request"
   deffixture phoenix_ecto_sandbox do
-    import Supervisor.Spec
-
     {:ok, pid} =
       Supervisor.start_link(
-        [supervisor(OMG.Watcher.DB.Repo, []), supervisor(OMG.Watcher.Web.Endpoint, [])],
+        [
+          %{id: :watcher_repo, start: {OMG.Watcher.DB.Repo, :start_link, []}, type: :supervisor},
+          %{id: :watcher_endpoint, start: {OMG.Watcher.Web.Endpoint, :start_link, []}, type: :supervisor}
+        ],
         strategy: :one_for_one,
         name: OMG.Watcher.Supervisor
       )

--- a/apps/omg_watcher/test/fixtures.exs
+++ b/apps/omg_watcher/test/fixtures.exs
@@ -141,8 +141,8 @@ defmodule OMG.Watcher.Fixtures do
     {:ok, pid} =
       Supervisor.start_link(
         [
-          %{id: :watcher_repo, start: {OMG.Watcher.DB.Repo, :start_link, []}, type: :supervisor},
-          %{id: :watcher_endpoint, start: {OMG.Watcher.Web.Endpoint, :start_link, []}, type: :supervisor}
+          %{id: OMG.Watcher.DB.Repo, start: {OMG.Watcher.DB.Repo, :start_link, []}, type: :supervisor},
+          %{id: OMG.Watcher.Web.Endpoint, start: {OMG.Watcher.Web.Endpoint, :start_link, []}, type: :supervisor}
         ],
         strategy: :one_for_one,
         name: OMG.Watcher.Supervisor


### PR DESCRIPTION
As of `Elixir 1.5` module `Supervisor.Spec` has been marked as deprecated, so the changes in this PR remove usages of `Supervisor.Spec` and use the new notation instead.