### PR TITLE
remove test flakiness (sequence of returend elements)

### DIFF
--- a/apps/omg_api/lib/application.ex
+++ b/apps/omg_api/lib/application.ex
@@ -29,7 +29,7 @@ defmodule OMG.API.Application do
       {OMG.API.BlockQueue.Server, []},
       {OMG.API.FreshBlocks, []},
       {OMG.API.FeeChecker, []},
-      {OMG.API.RootChainCoordinator, MapSet.new([:depositer, :exiter])},
+      {OMG.API.RootChainCoordinator, MapSet.new([:depositor, :exiter])},
       %{
         id: :depositor,
         start:
@@ -37,7 +37,7 @@ defmodule OMG.API.Application do
            [
              %{
                synced_height_update_key: :last_depositor_eth_height,
-               service_name: :depositer,
+               service_name: :depositor,
                block_finality_margin: block_finality_margin,
                get_events_callback: &OMG.Eth.RootChain.get_deposits/2,
                process_events_callback: &OMG.API.State.deposit/1,

--- a/apps/omg_api/test/root_chain_coordinator/core_test.exs
+++ b/apps/omg_api/test/root_chain_coordinator/core_test.exs
@@ -18,7 +18,7 @@ defmodule OMG.API.RootChainCoordinator.CoreTest do
   alias OMG.API.RootChainCoordinator.Core
 
   deffixture initial_state() do
-    %Core{allowed_services: MapSet.new([:exiter, :depositer]), root_chain_height: 10}
+    %Core{allowed_services: MapSet.new([:exiter, :depositor]), root_chain_height: 10}
   end
 
   @tag fixtures: [:initial_state]
@@ -28,57 +28,57 @@ defmodule OMG.API.RootChainCoordinator.CoreTest do
 
   @tag fixtures: [:initial_state]
   test "synchronizes services", %{initial_state: state} do
-    depositer_pid = :c.pid(0, 1, 0)
+    depositor_pid = :c.pid(0, 1, 0)
     exiter_pid = :c.pid(0, 2, 0)
 
     {:ok, state, []} = Core.check_in(state, exiter_pid, 1, :exiter)
     :nosync = Core.get_synced_height(state)
 
-    {:ok, state, [^depositer_pid, ^exiter_pid]} = Core.check_in(state, depositer_pid, 2, :depositer)
+    {:ok, state, [^depositor_pid, ^exiter_pid]} = Core.check_in(state, depositor_pid, 2, :depositor)
     {:sync, 2} = Core.get_synced_height(state)
 
     {:ok, state, []} = Core.check_in(state, exiter_pid, 1, :exiter)
     {:sync, 2} = Core.get_synced_height(state)
-    {:ok, state, [^depositer_pid, ^exiter_pid]} = Core.check_in(state, exiter_pid, 2, :exiter)
+    {:ok, state, [^depositor_pid, ^exiter_pid]} = Core.check_in(state, exiter_pid, 2, :exiter)
     {:sync, 3} = Core.get_synced_height(state)
   end
 
   @tag fixtures: [:initial_state]
   test "deregisters and registers a service", %{initial_state: state} do
-    depositer_pid = :c.pid(0, 1, 0)
+    depositor_pid = :c.pid(0, 1, 0)
     exiter_pid = :c.pid(0, 2, 0)
 
     {:ok, state, []} = Core.check_in(state, exiter_pid, 1, :exiter)
-    {:ok, state, [^depositer_pid, ^exiter_pid]} = Core.check_in(state, depositer_pid, 1, :depositer)
+    {:ok, state, [^depositor_pid, ^exiter_pid]} = Core.check_in(state, depositor_pid, 1, :depositor)
     {:sync, 2} = Core.get_synced_height(state)
 
-    {:ok, state} = Core.check_out(state, depositer_pid)
+    {:ok, state} = Core.check_out(state, depositor_pid)
     :nosync = Core.get_synced_height(state)
-    {:ok, state, [^depositer_pid, ^exiter_pid]} = Core.check_in(state, depositer_pid, 1, :depositer)
+    {:ok, state, [^depositor_pid, ^exiter_pid]} = Core.check_in(state, depositor_pid, 1, :depositor)
     {:sync, 2} = Core.get_synced_height(state)
   end
 
   test "returns services to sync up only for the last service checking in at a given height" do
-    depositer_pid = :c.pid(0, 1, 0)
+    depositor_pid = :c.pid(0, 1, 0)
     exiter_pid = :c.pid(0, 2, 0)
     block_getter_pid = :c.pid(0, 3, 0)
 
-    state = %Core{allowed_services: MapSet.new([:exiter, :depositer, :block_getter]), root_chain_height: 10}
+    state = %Core{allowed_services: MapSet.new([:exiter, :depositor, :block_getter]), root_chain_height: 10}
 
     {:ok, state, []} = Core.check_in(state, exiter_pid, 1, :exiter)
-    {:ok, state, []} = Core.check_in(state, depositer_pid, 1, :depositer)
+    {:ok, state, []} = Core.check_in(state, depositor_pid, 1, :depositor)
 
-    {:ok, _state, [^block_getter_pid, ^depositer_pid, ^exiter_pid]} =
+    {:ok, _state, [^block_getter_pid, ^depositor_pid, ^exiter_pid]} =
       Core.check_in(state, block_getter_pid, 1, :block_getter)
   end
 
   @tag fixtures: [:initial_state]
   test "updates root chain height", %{initial_state: state} do
-    depositer_pid = :c.pid(0, 1, 0)
+    depositor_pid = :c.pid(0, 1, 0)
     exiter_pid = :c.pid(0, 2, 0)
 
     {:ok, state, []} = Core.check_in(state, exiter_pid, 10, :exiter)
-    {:ok, state, [^depositer_pid, ^exiter_pid]} = Core.check_in(state, depositer_pid, 10, :depositer)
+    {:ok, state, [^depositor_pid, ^exiter_pid]} = Core.check_in(state, depositor_pid, 10, :depositor)
     {:sync, 10} = Core.get_synced_height(state)
 
     {:ok, state} = Core.update_root_chain_height(state, 11)

--- a/apps/omg_api/test/state/prop_test.exs
+++ b/apps/omg_api/test/state/prop_test.exs
@@ -163,7 +163,7 @@ defmodule OMG.API.State.PropTest do
 
   @tag :property
   @tag timeout: 600_000
-  property "OMG.API.State.Core prope check", numtests: 30000 do
+  property "OMG.API.State.Core prope check", numtests: 30_000 do
     state_core_property_test()
   end
 end

--- a/apps/omg_watcher/test/web/controllers/account_test.exs
+++ b/apps/omg_watcher/test/web/controllers/account_test.exs
@@ -36,7 +36,7 @@ defmodule OMG.Watcher.Web.Controller.AccountTest do
                "data" => [%{"currency" => @eth_hex, "amount" => 349}]
              } == TestHelper.rest_call(:get, path_for(bob), nil, 200)
 
-      # adds other token funds for alice to make more interestning
+      # adds other token funds for alice to make more interesting
       DB.Transaction.update_with(%{
         transactions: [API.TestHelper.create_recovered([], @other_token, [{alice, 121}, {alice, 256}])],
         blknum: 11_000,
@@ -45,13 +45,15 @@ defmodule OMG.Watcher.Web.Controller.AccountTest do
         eth_height: 10
       })
 
-      assert %{
-               "result" => "success",
-               "data" => [
-                 %{"currency" => @eth_hex, "amount" => 201},
-                 %{"currency" => @other_token_hex, "amount" => 377}
-               ]
-             } == TestHelper.rest_call(:get, path_for(alice), nil, 200)
+      %{
+        "result" => "success",
+        "data" => data
+      } = TestHelper.rest_call(:get, path_for(alice), nil, 200)
+
+      assert [
+               %{"currency" => @eth_hex, "amount" => 201},
+               %{"currency" => @other_token_hex, "amount" => 377}
+             ] == data |> Enum.sort(&(Map.get(&1, "currency") <= Map.get(&2, "currency")))
     end
 
     @tag fixtures: [:phoenix_ecto_sandbox]


### PR DESCRIPTION
- renamed all occurrence of `depositer` to `depositor`
- removed test non-determinism by ensuring sequence order
