### PR TITLE
fix warning about "coveralls" atom

### DIFF
--- a/mix.lock
+++ b/mix.lock
@@ -23,7 +23,7 @@
   "ex_rlp": {:hex, :ex_rlp, "0.2.1", "bd320900d6316cdfe01d365d4bda22eb2f39b359798daeeffd3bd1ca7ba958ec", [:mix], [], "hexpm"},
   "ex_unit_fixtures": {:git, "https://github.com/omisego/ex_unit_fixtures.git", "4a099c621dc70e0d65cb9619b38192e31ec5f504", [branch: "feature/require_files_not_load"]},
   "excoveralls": {:git, "https://github.com/vorce/excoveralls.git", "319dd6f40ec9d51b5d734c7c897b297f2ec86d4b", [branch: "fix_post_args"]},
-  "exexec": {:git, "https://github.com/pthomalla/exexec.git", "0b8e0a781f72d340355b61979f0d23505356fbe6", [branch: "add_streams"]},
+  "exexec": {:git, "https://github.com/pthomalla/exexec.git", "213658a4ccb96d7a84ffddc642b2596c86acc5d0", [branch: "add_streams"]},
   "exjsx": {:hex, :exjsx, "4.0.0", "60548841e0212df401e38e63c0078ec57b33e7ea49b032c796ccad8cde794b5c", [:mix], [{:jsx, "~> 2.8.0", [hex: :jsx, repo: "hexpm", optional: false]}], "hexpm"},
   "exleveldb": {:hex, :exleveldb, "0.11.1", "37c0414208a50d2419d8246305e6c4a33ed339c25c0bdfa27774795e1e089f7b", [:mix], [{:eleveldb, "~> 2.2.19", [hex: :eleveldb, repo: "hexpm", optional: false]}], "hexpm"},
   "exth_crypto": {:hex, :exth_crypto, "0.1.4", "11f9084dfd70d4f9e96f2710a472f4e6b23044b97530c719550c2b0450ffeb61", [:mix], [{:binary, "~> 0.0.4", [hex: :binary, repo: "hexpm", optional: false]}, {:keccakf1600, "~> 2.0.0", [hex: :keccakf1600_orig, repo: "hexpm", optional: false]}, {:libsecp256k1, "~> 0.1.3", [hex: :libsecp256k1, repo: "hexpm", optional: false]}], "hexpm"},


### PR DESCRIPTION
No more of this:
```Elixir
warning: found quoted keyword "coveralls" but the quotes are not required. Note that keywords are always atoms, even when quoted, and quotes should only be used to introduce keywords with foreign characters in them
  /home/pawel/omise/chain/deps/exexec/mix.exs:27
```