### PR TITLE
fix: \neg → \neq in the definition of competing

### DIFF
--- a/docs/morevp.md
+++ b/docs/morevp.md
@@ -436,7 +436,7 @@ $$
 Two transactions are competing if they have at least one input in common.
 
 $$
-competing(t, t’) = I(t) \cap I(t’) \neg \varnothing
+competing(t, t’) = I(t) \cap I(t’) \neq \varnothing
 $$
 
 The set of competitors to a transaction is therefore every other transaction competing with the transaction in question.


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/22876645/48969575-e0cff400-f043-11e8-9aed-2824e84da8ea.png)

After:
![image](https://user-images.githubusercontent.com/22876645/48969578-e594a800-f043-11e8-879e-4724b3163160.png)
