### PR TITLE
fix: update excoveralls dep to fix html output

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -50,16 +50,17 @@ podTemplate(
         }
 
         stage('Integration test') {
-           withCredentials([string(credentialsId: 'elixir-omg_coveralls', variable: 'ELIXIR_OMG_COVERALLS')]){
+           withCredentials([string(credentialsId: 'elixir-omg_coveralls', variable: 'COVERALLS_REPO_TOKEN')]){
                 withEnv(["MIX_ENV=test", "SHELL=/bin/bash", "DATABASE_URL=${DATABASE_URL}"]) {
                     sh ("""
-                        set +x
+                        BRANCH=`git describe --contains --exact-match --all HEAD | sed -r 's/^remotes\\/origin\\///'`
                         mix coveralls.post \
                             --umbrella \
                             --include integration \
                             --include wrappers \
-                            --token '${ELIXIR_OMG_COVERALLS}' \
                             --sha '${scmVars.GIT_COMMIT}' \
+                            --branch \$BRANCH \
+                            --message "`git log -1 --pretty=%B | head -n 1`" \
                     """)
                 }
            }

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 The `elixir-omg` repository contains OmiseGO's Elixir implementation of Plasma and forms the basis for the OMG Network.
 
-[![Build Status](https://jenkins.omisego.io/buildStatus/icon?job=omisego/elixir-omg/develop)](https://jenkins.omisego.io/blue/organizations/jenkins/omisego%2Felixir-omg/activity?branch=develop) [![Coverage Status](https://coveralls.io/repos/github/omisego/elixir-omg/badge.svg?branch=develop)](https://coveralls.io/github/omisego/elixir-omg?branch=develop) [![Gitter chat](https://badges.gitter.im/omisego/elixir-omg.png)](https://gitter.im/omisego/elixir-omg)
+[![Build Status](https://jenkins.omisego.io/buildStatus/icon?job=omisego/elixir-omg/master)](https://jenkins.omisego.io/blue/organizations/jenkins/omisego%2Felixir-omg/activity?branch=master) [![Coverage Status](https://coveralls.io/repos/github/omisego/elixir-omg/badge.svg?branch=master)](https://coveralls.io/github/omisego/elixir-omg?branch=master) [![Gitter chat](https://badges.gitter.im/omisego/elixir-omg.png)](https://gitter.im/omisego/elixir-omg)
 
 **IMPORTANT NOTICE: Heavily WIP, expect anything**
 

--- a/apps/omg_api/coveralls.json
+++ b/apps/omg_api/coveralls.json
@@ -1,5 +1,5 @@
 {
   "skip_files": [
-    "test/support"
+    "test/support", "mix/tasks"
   ]
 }

--- a/apps/omg_rpc/mix.exs
+++ b/apps/omg_rpc/mix.exs
@@ -13,7 +13,8 @@ defmodule OMG.RPC.MixProject do
       elixirc_paths: elixirc_paths(Mix.env()),
       compilers: [:phoenix, :phoenix_swagger] ++ Mix.compilers(),
       start_permanent: Mix.env() == :prod,
-      deps: deps()
+      deps: deps(),
+      test_coverage: [tool: ExCoveralls]
     ]
   end
 

--- a/apps/omg_watcher/coveralls.json
+++ b/apps/omg_watcher/coveralls.json
@@ -1,6 +1,6 @@
 {
   "skip_files": [
-    "test/support"
+    "test/support", "mix/tasks"
   ],
   "custom_stop_words": [
     "swagger_schema",

--- a/coveralls.json
+++ b/coveralls.json
@@ -1,5 +1,0 @@
-{
-  "coverage_options": {
-    "treat_no_relevant_lines_as_covered": true
-  }
-}

--- a/mix.exs
+++ b/mix.exs
@@ -27,10 +27,7 @@ defmodule OMG.Umbrella.MixProject do
     [
       {:dialyxir, "~> 0.5", only: [:prod], runtime: false},
       {:credo, "~> 0.10.0", only: [:dev, :test], runtime: false},
-      {
-        :excoveralls,
-        git: "https://github.com/vorce/excoveralls.git", branch: "fix_post_args", only: [:test], runtime: false
-      },
+      {:excoveralls, "~> 0.10.3", only: [:test], runtime: false},
       {:licensir, "~> 0.2.0", only: :dev, runtime: false},
       {
         :ex_unit_fixtures,

--- a/mix.lock
+++ b/mix.lock
@@ -22,7 +22,7 @@
   "ex_doc": {:hex, :ex_doc, "0.19.1", "519bb9c19526ca51d326c060cb1778d4a9056b190086a8c6c115828eaccea6cf", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.7", [hex: :makeup_elixir, repo: "hexpm", optional: false]}], "hexpm"},
   "ex_rlp": {:hex, :ex_rlp, "0.2.1", "bd320900d6316cdfe01d365d4bda22eb2f39b359798daeeffd3bd1ca7ba958ec", [:mix], [], "hexpm"},
   "ex_unit_fixtures": {:git, "https://github.com/omisego/ex_unit_fixtures.git", "4a099c621dc70e0d65cb9619b38192e31ec5f504", [branch: "feature/require_files_not_load"]},
-  "excoveralls": {:git, "https://github.com/vorce/excoveralls.git", "319dd6f40ec9d51b5d734c7c897b297f2ec86d4b", [branch: "fix_post_args"]},
+  "excoveralls": {:hex, :excoveralls, "0.10.3", "b090a3fbcb3cfa136f0427d038c92a9051f840953ec11b40ee74d9d4eac04d1e", [:mix], [{:hackney, "~> 1.13", [hex: :hackney, repo: "hexpm", optional: false]}, {:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: false]}], "hexpm"},
   "exexec": {:git, "https://github.com/pthomalla/exexec.git", "213658a4ccb96d7a84ffddc642b2596c86acc5d0", [branch: "add_streams"]},
   "exjsx": {:hex, :exjsx, "4.0.0", "60548841e0212df401e38e63c0078ec57b33e7ea49b032c796ccad8cde794b5c", [:mix], [{:jsx, "~> 2.8.0", [hex: :jsx, repo: "hexpm", optional: false]}], "hexpm"},
   "exleveldb": {:hex, :exleveldb, "0.11.1", "37c0414208a50d2419d8246305e6c4a33ed339c25c0bdfa27774795e1e089f7b", [:mix], [{:eleveldb, "~> 2.2.19", [hex: :eleveldb, repo: "hexpm", optional: false]}], "hexpm"},


### PR DESCRIPTION
use 0.10.3 - it already has the fixed that was done in the previous source (github branch) + it additionally fixes the `.html` command, which we use a lot