### PR TITLE
[elixir-omg] Add support for getting Ethereum RPC address from an ENV

### DIFF
--- a/apps/omg_eth/config/config.exs
+++ b/apps/omg_eth/config/config.exs
@@ -1,7 +1,7 @@
 use Mix.Config
 
 config :ethereumex,
-  url: "http://localhost:8545",
+  url: System.get_env("ETHEREUM_RPC_URL"),
   request_timeout: 5000
 
 config :omg_eth,

--- a/apps/omg_eth/config/config.exs
+++ b/apps/omg_eth/config/config.exs
@@ -1,7 +1,7 @@
 use Mix.Config
 
 config :ethereumex,
-  url: System.get_env("ETHEREUM_RPC_URL"),
+  url: System.get_env("ETHEREUM_RPC_URL") || "http://localhost:8545",
   request_timeout: 5000
 
 config :omg_eth,

--- a/apps/omg_performance/lib/performance.ex
+++ b/apps/omg_performance/lib/performance.ex
@@ -90,7 +90,7 @@ defmodule OMG.Performance do
   ```
   %{
     destdir: ".", # directory where the results will be put
-    geth: "http://localhost:8545",
+    geth: System.get_env("ETHEREUM_RPC_URL"),
     child_chain: "http://localhost:9656"
   }
   ```
@@ -117,7 +117,7 @@ defmodule OMG.Performance do
         "http://localhost:9656"
       )
 
-    defaults = %{destdir: ".", geth: "http://localhost:8545", child_chain: url}
+    defaults = %{destdir: ".", geth: System.get_env("ETHEREUM_RPC_URL"), child_chain: url}
     opts = Map.merge(defaults, opts)
 
     {:ok, started_apps} = setup_extended_perftest(opts, contract_addr)

--- a/apps/omg_performance/lib/performance.ex
+++ b/apps/omg_performance/lib/performance.ex
@@ -117,7 +117,7 @@ defmodule OMG.Performance do
         "http://localhost:9656"
       )
 
-    defaults = %{destdir: ".", geth: System.get_env("ETHEREUM_RPC_URL"), child_chain: url}
+    defaults = %{destdir: ".", geth: System.get_env("ETHEREUM_RPC_URL") || "http://localhost:8545", child_chain: url}
     opts = Map.merge(defaults, opts)
 
     {:ok, started_apps} = setup_extended_perftest(opts, contract_addr)


### PR DESCRIPTION
```
elixir-user@706e6d918044:~/elixir-omg$ mix xomg.child_chain.start --config ~/config.exs
2018-12-07 08:28:58.870 [info] module=OMG.RPC.Application function=start/2 ⋅Started application OMG.RPC.Application⋅
2018-12-07 08:28:58.965 [info] module=Phoenix.Endpoint.CowboyHandler function=start_link/3 ⋅Running OMG.RPC.Web.Endpoint with Cowboy using http://0.0.0.0:9656⋅
2018-12-07 08:28:58.990 [info] module=OMG.API.Application function=start/2 ⋅Started application OMG.API.Application⋅
2018-12-07 08:28:59.024 [info] module=OMG.DB function=utxos/1 ⋅Reading UTXO set, this might take a while. Allowing 600000 ms⋅
2018-12-07 08:28:59.039 [info] module=OMG.API.State function=init/1 ⋅Started State, height: 0, deposit height: 0⋅
2018-12-07 08:28:59.210 [info] module=OMG.API.BlockQueue.Server function=init/1 ⋅Starting BlockQueue at parent_height: 159, parent_start: 13, mined_child_block: 0, stored_child_top_block: 0⋅
2018-12-07 08:28:59.222 [info] module=OMG.API.BlockQueue.Server function=init/1 ⋅Starting BlockQueue, top_mined_hash: "0000000000000000000000000000000000000000000000000000000000000000"⋅
2018-12-07 08:28:59.222 [info] module=OMG.API.BlockQueue.Server function=init/1 ⋅Started BlockQueue⋅
2018-12-07 08:28:59.240 [info] module=OMG.API.FeeChecker function=update_fee_spec/0 ⋅Reloaded 1 fee specs from file, changed at 1544166316⋅
2018-12-07 08:28:59.241 [info] module=OMG.API.FeeChecker function=init/1 ⋅Started FeeChecker⋅
2018-12-07 08:28:59.251 [info] module=OMG.API.EthereumEventListener function=init/1 ⋅Starting EthereumEventListener for depositor⋅
2018-12-07 08:28:59.274 [info] module=OMG.API.EthereumEventListener function=init/1 ⋅Starting EthereumEventListener for exiter⋅
```