### PR TITLE
[elixir-omg] Fix Watcher database init

### DIFF
--- a/launcher.py
+++ b/launcher.py
@@ -249,17 +249,16 @@ class WatcherLauncher:
         if self.deploy_contract() is False:
             logging.critical('Contract not deployed. Exiting.')
             sys.exit(1)
-        if self.chain_data_present is False:
-            if self.initialise_watcher_postgres_database() is False:
-                logging.critical(
-                    'Could not connect to the Postgres database Exiting.'
-                )
-                sys.exit(1)
-            if self.initialise_watcher_chain_database() is False:
-                logging.critical(
-                    'Could not initialise the chain database. Exiting.'
-                )
-                sys.exit(1)
+        if self.initialise_watcher_postgres_database() is False:
+            logging.critical(
+                'Could not connect to the Postgres database Exiting.'
+            )
+            sys.exit(1)
+        if self.initialise_watcher_chain_database() is False:
+            logging.critical(
+                'Could not initialise the chain database. Exiting.'
+            )
+            sys.exit(1)
 
         logging.info('Launcher process complete')
 
@@ -348,9 +347,9 @@ class WatcherLauncher:
     def initialise_watcher_postgres_database(self) -> bool:
         ''' Initialise the watcher database (Postgres)
         '''
-        os.chdir(os.getcwd() + '/apps/omg_watcher')
+        os.chdir(os.path.expanduser('~') + '/elixir-omg')
         result = subprocess.run(
-            'printf "y\r" | mix ecto.create --no-start',
+            'mix ecto.create --no-start',
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             shell=True


### PR DESCRIPTION
```
2018-12-11 09:10:12,914 INFO    :Starting Launcher
2018-12-11 09:10:12,919 INFO    :Service type to launch is Elixir
Watcher
2018-12-11 09:10:12,919 INFO    :Starting launch process for build
 a74e2b304855882b1d418c2de21fb03f6da35cb9
2018-12-11 09:10:12,919 INFO    :Childchain data found
2018-12-11 09:10:12,925 INFO    :Connected to the Ethereum client
2018-12-11 09:10:12,925 INFO    :Ethereum client is b'{"jsonrpc":"
2.0","id":67,"result":"Geth/v1.8.20-unstable-f850123e/linux-amd64/
go1.11.2"}\n'
2018-12-11 09:10:12,929 INFO    :Response received from the contra
ct exchanger service
2018-12-11 09:10:12,929 INFO    :Written config_watcher.exs
2018-12-11 09:10:12,929 INFO    :Launcher process complete
omg_rpc: generated priv/static/swagger.json
omg_watcher: generated priv/static/swagger.json
2018-12-11 09:10:15.639 [info] module=OMG.Watcher.Application func
tion=start_watcher_supervisor/0 Started application OMG.Watcher.Ap
plication
2018-12-11 09:10:15.877 [info] module=OMG.API.EthereumEventListene
r function=init/1 Starting EthereumEventListener for depositor
2018-12-11 09:10:15.878 [info] module=OMG.DB function=exit_infos/1
 Reading exit infos, this might take a while. Allowing 60000 ms
2018-12-11 09:10:15.892 [info] module=OMG.API.EthereumEventListene
r function=init/1 Starting EthereumEventListener for exit_processo
r
2018-12-11 09:10:15.893 [info] module=OMG.API.EthereumEventListene
r function=init/1 Starting EthereumEventListener for exit_finalize
r
2018-12-11 09:10:15.895 [info] module=OMG.API.EthereumEventListene
r function=init/1 Starting EthereumEventListener for exit_challeng
er
2018-12-11 09:10:15.983 [info] module=Phoenix.Endpoint.CowboyHandl
er function=start_link/3 Running OMG.Watcher.Web.Endpoint with Cow
boy using http://0.0.0.0:4000
2018-12-11 09:10:15.996 [info] module=OMG.DB function=utxos/1 Read
ing UTXO set, this might take a while. Allowing 600000 ms
2018-12-11 09:10:16.000 [info] module=OMG.API.State function=init/
1 Started State, height: 0, deposit height: 0
```