### PR TITLE
Optimization in WatcherDB

### DIFF
--- a/apps/omg_watcher/lib/block_getter/core.ex
+++ b/apps/omg_watcher/lib/block_getter/core.ex
@@ -73,6 +73,7 @@ defmodule OMG.Watcher.BlockGetter.Core do
     :last_applied_block,
     :num_of_highest_block_being_downloaded,
     :number_of_blocks_being_downloaded,
+    :last_block_persisted_from_prev_run,
     :unapplied_blocks,
     :potential_block_withholdings,
     :config
@@ -84,6 +85,7 @@ defmodule OMG.Watcher.BlockGetter.Core do
           last_applied_block: non_neg_integer,
           num_of_highest_block_being_downloaded: non_neg_integer,
           number_of_blocks_being_downloaded: non_neg_integer,
+          last_block_persisted_from_prev_run: non_neg_integer,
           unapplied_blocks: %{
             non_neg_integer => OMG.API.Block.t()
           },
@@ -111,13 +113,14 @@ defmodule OMG.Watcher.BlockGetter.Core do
     - `:maximum_number_of_pending_blocks` - how many block should be pulled from the child chain at once (10)
     - `:maximum_block_withholding_time_ms` - how much time should we wait after the first failed pull until we call it a block withholding byzantine condition of the child chain (0 ms)
   """
-  @spec init(non_neg_integer, pos_integer, non_neg_integer, non_neg_integer, boolean, Keyword.t()) ::
+  @spec init(non_neg_integer, pos_integer, non_neg_integer, non_neg_integer, non_neg_integer, boolean, Keyword.t()) ::
           {:ok, %__MODULE__{}} | {:error, init_error()}
   def init(
         block_number,
         child_block_interval,
         synced_height,
         finality_margin,
+        last_persisted_block,
         state_at_block_beginning,
         opts \\ []
       ) do
@@ -128,6 +131,7 @@ defmodule OMG.Watcher.BlockGetter.Core do
         last_applied_block: block_number,
         num_of_highest_block_being_downloaded: block_number,
         number_of_blocks_being_downloaded: 0,
+        last_block_persisted_from_prev_run: last_persisted_block,
         unapplied_blocks: %{},
         potential_block_withholdings: %{},
         config:

--- a/apps/omg_watcher/lib/db/txoutput.ex
+++ b/apps/omg_watcher/lib/db/txoutput.ex
@@ -26,8 +26,7 @@ defmodule OMG.Watcher.DB.TxOutput do
 
   require Utxo
 
-  import Ecto.Changeset
-  import Ecto.Query, only: [from: 2]
+  import Ecto.Query, only: [from: 2, where: 2]
 
   @primary_key false
   schema "txoutputs" do
@@ -118,12 +117,11 @@ defmodule OMG.Watcher.DB.TxOutput do
   @spec spend_utxos([map()]) :: :ok
   def spend_utxos(db_inputs) do
     db_inputs
-    |> Enum.each(fn {utxo_pos, spending_oindex, spending_txhash} ->
-      if utxo = DB.TxOutput.get_by_position(utxo_pos) do
-        utxo
-        |> change(spending_tx_oindex: spending_oindex, spending_txhash: spending_txhash)
-        |> Repo.update!()
-      end
+    |> Enum.each(fn {Utxo.position(blknum, txindex, oindex), spending_oindex, spending_txhash} ->
+      _ =
+        DB.TxOutput
+        |> where(blknum: ^blknum, txindex: ^txindex, oindex: ^oindex)
+        |> Repo.update_all(set: [spending_tx_oindex: spending_oindex, spending_txhash: spending_txhash])
     end)
   end
 

--- a/apps/omg_watcher/test/block_getter/core_test.exs
+++ b/apps/omg_watcher/test/block_getter/core_test.exs
@@ -638,9 +638,16 @@ defmodule OMG.Watcher.BlockGetter.CoreTest do
     synced_height = 1
     finality_margin = 5
     state_at_beginning = false
+    last_persisted_block = nil
 
-    assert Core.init(start_block_number, interval, synced_height, finality_margin, state_at_beginning) ==
-             {:error, :not_at_block_beginning}
+    assert Core.init(
+             start_block_number,
+             interval,
+             synced_height,
+             finality_margin,
+             last_persisted_block,
+             state_at_beginning
+           ) == {:error, :not_at_block_beginning}
   end
 
   test "BlockGetter omits submissions of already applied blocks" do
@@ -815,7 +822,9 @@ defmodule OMG.Watcher.BlockGetter.CoreTest do
       opts: opts
     } = defaults |> Keyword.merge(opts) |> Map.new()
 
-    {:ok, state} = Core.init(start_block_number, interval, synced_height, finality_margin, state_at_beginning, opts)
+    {:ok, state} =
+      Core.init(start_block_number, interval, synced_height, finality_margin, nil, state_at_beginning, opts)
+
     state
   end
 


### PR DESCRIPTION
 * speed ups updates (avoid fetch_then_update)
 * fetching last_persisted_block_number from DB only on init