### PR TITLE
OMG-355 use solc to do contract compilation (and reduce deployment gas)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,8 +22,6 @@ erl_crash.dump
 # Also ignore archive artifacts (built via "mix archive.build").
 *.ez
 
-contracts/build/
-
 # Dev sqllite db
 *ecto_simple.sqlite3*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -59,7 +59,6 @@ RUN wget https://github.com/ethereum/solidity/releases/download/v0.4.25/solc-sta
 
 RUN sudo -H pip3 install --upgrade pip \
   && sudo -H -n ln -s /usr/bin/python3 python \
-  && sudo -H -n pip3 install -r contracts/requirements.txt \
   && sudo -H -n pip3 install requests gitpython
 
 WORKDIR /home/elixir-user/elixir-omg/

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -33,7 +33,6 @@ podTemplate(
 
         stage('Build') {
             sh("mix do local.hex --force, local.rebar --force")
-            sh("pip install -r contracts/requirements.txt")
             withEnv(["PATH+FIXPIPPATH=/home/jenkins/.local/bin/","MIX_ENV=test"]) {
                 sh("mix do deps.get, deps.compile, compile")
             }

--- a/Jenkinsfile.cron
+++ b/Jenkinsfile.cron
@@ -23,7 +23,6 @@ podTemplate(
 
         stage('Build') {
             sh("mix do local.hex --force, local.rebar --force")
-            sh("pip install -r contracts/requirements.txt")
             withEnv(["PATH+FIXPIPPATH=/home/jenkins/.local/bin/","MIX_ENV=test"]) {
                 sh("mix do deps.get, deps.compile, compile")
             }

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ To deploy `child chain` on in an environment with limited `Eth` provide `:faucet
 
 **NOTE**: the faucet account must first be unlocked and funded
 **NOTE**: the newly created `authority` address needs refunding from time to time (preferably done by `geth attach`)
-    
+
 #### Initialize the child chain database
 Initialize the database with the following command.
 **CAUTION** This wipes the old data clean!:
@@ -187,7 +187,7 @@ You need to re-initialize the database, in case you want to start a new child ch
 * Start Up the child chain server:
 
 ```bash
-iex -S mix xomg.child_chain.start --config ~/config.exs 
+iex -S mix xomg.child_chain.start --config ~/config.exs
 ```
 
 ### Setting up a Watcher (a developer environment)
@@ -233,15 +233,15 @@ mix run --no-start -e 'OMG.DB.init()' --config ~/config_watcher.exs
 It is possible to run the watcher in two different modes:
 - The first is `security critical` mode.
 ```bash
-iex -S mix xomg.watcher.start --config ~/config_watcher.exs 
+iex -S mix xomg.watcher.start --config ~/config_watcher.exs
 ```
 - The second is `security critical` + `convenience` mode.
 ```bash
-iex -S mix xomg.watcher.start --convenience --config ~/config_watcher.exs 
+iex -S mix xomg.watcher.start --convenience --config ~/config_watcher.exs
 ```
 
 See docs/TODO for more details about watcher modes.
- 
+
 ### Follow the demos
 After starting the child chain server and/or Watcher as above, you may follow the steps in the demo scripts.
 Note that some steps should be performed in the Elixir shell (iex) and some in the shell directly.
@@ -285,8 +285,8 @@ For the responsibilities and design of the child chain server see [Tesuji Plasma
 #### Http-RPC
 
 Http-RPC requests are served up on the port specified in `omg_rpc`'s `config` (`9656` by default).
-The available RPC calls are defined by `omg_api` in `api.ex` - paths follow RPC convention e.g. `block.get`, `transaction.submit`. All requests shall be POST with parameters provided in the request 
-body in JSON object. Object's properties names correspond to the names of parameters. Binary values 
+The available RPC calls are defined by `omg_api` in `api.ex` - paths follow RPC convention e.g. `block.get`, `transaction.submit`. All requests shall be POST with parameters provided in the request
+body in JSON object. Object's properties names correspond to the names of parameters. Binary values
 shall be hex-encoded strings.
 
 ##### `transaction.submit`
@@ -518,12 +518,9 @@ You can find the downloaded version of that code under `deps/plasma_contracts`.
 
 ### Installing dependencies and compiling contracts
 
-**Python3 is required**, [`virtualenv`](https://virtualenv.pypa.io/en/stable/) is recommended.
-
 To install dependencies:
 ```bash
 sudo apt-get install libssl-dev solc
-pip install -r contracts/requirements.txt
 ```
 
 Contracts will compile automatically as a regular mix dependency.
@@ -531,14 +528,6 @@ To compile contracts manually:
 ```bash
 mix deps.compile plasma_contracts
 ```
-
-**DEV NOTE** `requirements.txt` is the frozen set of versioned dependencies, effect of running
-```bash
-pip install -r requirements-to-freeze.txt && pip freeze | grep -v ^pkg-resources > requirements.txt
-```
-see [a better pip workflow^TM here](https://www.kennethreitz.org/essays/a-better-pip-workflow) for rationale.
-
-**DEV NOTE** removing `pkg-resources` comes from [here](https://stackoverflow.com/a/48365609)
 
 # Testing & development
 

--- a/apps/omg_eth/lib/eth.ex
+++ b/apps/omg_eth/lib/eth.ex
@@ -80,12 +80,7 @@ defmodule OMG.Eth do
   end
 
   def get_bytecode!(path_project_root, contract_name) do
-    %{"evm" => %{"bytecode" => %{"object" => bytecode}}} =
-      path_project_root
-      |> read_contracts_json!(contract_name)
-      |> Poison.decode!()
-
-    "0x" <> bytecode
+    "0x" <> read_contracts_bin!(path_project_root, contract_name)
   end
 
   defp encode_tx_data(signature, args) do
@@ -113,8 +108,8 @@ defmodule OMG.Eth do
          do: {:ok, from_hex(txhash)}
   end
 
-  defp read_contracts_json!(path_project_root, contract_name) do
-    path = "contracts/build/#{contract_name}.json"
+  defp read_contracts_bin!(path_project_root, contract_name) do
+    path = "_build/contracts/#{contract_name}.bin"
 
     case File.read(Path.join(path_project_root, path)) do
       {:ok, contract_json} ->

--- a/apps/omg_eth/mix.exs
+++ b/apps/omg_eth/mix.exs
@@ -55,6 +55,14 @@ defmodule OMG.Eth.MixProject do
 
   defp contracts_compile do
     mixfile_path = __DIR__
-    "cd #{mixfile_path}/../../ && py-solc-simple -i deps/plasma_contracts/contracts/ -o contracts/build/"
+    contracts_dir = Path.join(mixfile_path, "../../deps/plasma_contracts/contracts")
+
+    contract_paths =
+      ["RootChain.sol", "MintableToken.sol"]
+      |> Enum.map(&Path.join(contracts_dir, &1))
+      |> Enum.join(" ")
+
+    output_path = Path.join(mixfile_path, "../../_build/contracts")
+    "solc #{contract_paths} --overwrite --abi --bin --optimize --optimize-runs 1 -o #{output_path}"
   end
 end

--- a/apps/omg_eth/test/support/dev_helpers.ex
+++ b/apps/omg_eth/test/support/dev_helpers.ex
@@ -37,7 +37,7 @@ defmodule OMG.Eth.DevHelpers do
   Prepares the developer's environment with respect to the root chain contract and its configuration within
   the application.
 
-   - `root_path` should point to `elixir-omg` root or wherever where `./contracts/build` holds the compiled contracts
+   - `root_path` should point to `elixir-omg` root or wherever where `./_build/contracts` holds the compiled contracts
   """
   def prepare_env!(opts \\ []) do
     opts = Keyword.merge([root_path: "./"], opts)

--- a/contracts/.flake8
+++ b/contracts/.flake8
@@ -1,4 +1,0 @@
-[flake8]
-max_line_length = 120
-ignore = E302
-exclude = omg_contract_codes.py

--- a/contracts/requirements-to-freeze.txt
+++ b/contracts/requirements-to-freeze.txt
@@ -1,1 +1,0 @@
-py-solc-simple==0.0.10

--- a/contracts/requirements.txt
+++ b/contracts/requirements.txt
@@ -1,3 +1,0 @@
-py-solc==3.1.0
-py-solc-simple==0.0.10
-semantic-version==2.6.0

--- a/docs/install.md
+++ b/docs/install.md
@@ -10,7 +10,6 @@ Only **Linux** platforms are supported now. These instructions have been tested 
 ## Prerequisites
 * **Erlang OTP** `>=20` (check with `elixir --version`)
 * **Elixir** `>=1.6` (check with `elixir --version`)
-* **Python** `>=3.5, <4` (check with `python --version`)
 * **solc** `>=0.4.24` (check with `solc --version`)
 
 ### Optional prerequisites
@@ -46,19 +45,6 @@ sudo apt-get update
 sudo apt-get -y install geth
 ```
 
-## Install pip3
-```
-sudo apt-get -y install python3-pip
-```
-
-## (optional) Install virtualenv
-This step is optional but recommended to isolate the python environment. [Ref](https://gist.github.com/IamAdiSri/a379c36b70044725a85a1216e7ee9a46)
-```
-sudo pip3 install virtualenv
-virtualenv DEV
-source DEV/bin/activate
-```
-
 ## Install solc
 ```
 sudo apt-get install libssl-dev solc
@@ -72,15 +58,6 @@ mix do local.hex --force, local.rebar --force
 ## Clone repo
 ```
 git clone https://github.com/omisego/elixir-omg
-```
-
-## Install contract building machinery
-[Ref](../README.md#contracts)
-```
-# contract building requires character encoding to be set
-export LC_ALL=C.UTF-8
-export LANG=C.UTF-8
-pip3 install -r contracts/requirements.txt
 ```
 
 ## Build

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -15,20 +15,9 @@
 Answer:
 Ensure `solc` is at at least the required version (see [installation instructions](./install.md)).
 
-## Error compiling contracts
-
-```
-** (Mix) Could not compile dependency :plasma_contracts, "cd elixir-omg/apps/omg_eth/../../ && py-solc-simple -i deps/plasma_con
-tracts/contracts/ -o contracts/build/" command failed. You can recompile this dependency with "mix deps.compile plasma_contracts", update it with "mix deps.up
-date plasma_contracts" or clean it with "mix deps.clean plasma_contracts"
-```
-
-Answer: [install the contract building machinery](./install.md#install-contract-building-machinery)
-
-
 ## To compile or recompile the contracts
 ```
-mix deps.compile plasma_contract
+mix deps.compile plasma_contracts
 ```
 
 ## To re-activate the virtualenv


### PR DESCRIPTION
Reason to do this is that contract build customization (e.g. libraries) would be awkward otherwise.

This also smuggles a modification (wrt to paramteres in `py-solc-simple`), to have `--optimizer-runs=1` instead of `10000` which tends to give much more expensive deployments (too expensive). About 10% gas is saved (tried on `v0.0` contract code).

Doing `--optimizer-runs=something_flexible` would be hard with `py-solc/-simple`. Drawback is that build systems of `elixir-omg` and `plasma-contracts` diverge, but no biggie, the differences were present elsewhere anyway.

This manages to remove `python` dependency on greater scale (`builder.py` has its own flow)