### PR TITLE
[elixir-omg] Add fix for Sentry

### DIFF
--- a/apps/omg_api/lib/application.ex
+++ b/apps/omg_api/lib/application.ex
@@ -68,6 +68,7 @@ defmodule OMG.API.Application do
 
     _ = Logger.info(fn -> "Started application OMG.API.Application" end)
     opts = [strategy: :one_for_one]
+    :error_logger.start()
     :ok = :error_logger.add_report_handler(Sentry.Logger)
     Supervisor.start_link(children, opts)
   end


### PR DESCRIPTION
Relevant line: 

```
Sentry.Client.do_send_event/3>, []]}], :temporary, nil}, :infinity)
    ** (EXIT) no process: the process is not alive or there's no process currently associated with the given name, possibly because its application isn't started
```

According to https://github.com/getsentry/sentry-elixir/issues/276`:error_logger.start()` may be required for Elixir 1.6.

Full output:

```
2018-12-15 12:31:17,731 INFO    :Starting Launcher
2018-12-15 12:31:17,736 INFO    :Service type to launch is Elixir Childchain
2018-12-15 12:31:17,736 INFO    :Starting launch process for build 1bf933f6f07978d23984972f4feb8733d5384cf6
2018-12-15 12:31:17,736 INFO    :Childchain data found
2018-12-15 12:31:17,746 INFO    :Connected to the Ethereum client
2018-12-15 12:31:17,746 INFO    :Ethereum client is b'{"jsonrpc":"2.0","id":67,"result":"Geth/v1.8.20-stable/linux-amd64/go1.11.2"}\n'
2018-12-15 12:31:17,761 INFO    :Response received from the contract exchanger service
2018-12-15 12:31:17,762 INFO    :Written config.exs
2018-12-15 12:31:17,762 INFO    :Launcher process complete
2018-12-15 12:31:21.004 [info] module=OMG.RPC.Application function=start/2 ⋅Started application OMG.RPC.Application⋅
2018-12-15 12:31:21.088 [info] module=Phoenix.Endpoint.CowboyHandler function=start_link/3 ⋅Running OMG.RPC.Web.Endpoint with Cowboy using http://0.0.0.0:9656⋅
2018-12-15 12:31:21.114 [info] module=OMG.API.Application function=start/2 ⋅Started application OMG.API.Application⋅
2018-12-15 12:31:21.151 [info] module=OMG.DB function=utxos/1 ⋅Reading UTXO set, this might take a while. Allowing 600000 ms⋅
2018-12-15 12:31:21.159 [info] module=OMG.API.State function=init/1 ⋅Started State, height: 0, deposit height: 0⋅
2018-12-15 12:31:21.277 [info] module=OMG.API.BlockQueue.Server function=init/1 ⋅Starting BlockQueue at parent_height: 81, parent_start: 13, mined_child_block: 0, stored_child_top_block: 0⋅
2018-12-15 12:31:21.285 [info] module=OMG.API.BlockQueue.Server function=init/1 ⋅Starting BlockQueue, top_mined_hash: "0000000000000000000000000000000000000000000000000000000000000000"⋅
2018-12-15 12:31:21.285 [info] module=OMG.API.BlockQueue.Server function=init/1 ⋅Started BlockQueue⋅
2018-12-15 12:31:21.297 [info] module=OMG.API.FeeChecker function=update_fee_spec/0 ⋅Reloaded 1 fee specs from file, changed at 1544166316⋅
2018-12-15 12:31:21.297 [info] module=OMG.API.FeeChecker function=init/1 ⋅Started FeeChecker⋅
2018-12-15 12:31:21.352 [error] ⋅GenServer OMG.API.RootChainCoordinator terminating
** (MatchError) no match of right hand side value: :invalid_synced_height_update
    (omg_api) lib/root_chain_coordinator/core.ex:64: OMG.API.RootChainCoordinator.Core.check_in/4
    (omg_api) lib/root_chain_coordinator.ex:60: OMG.API.RootChainCoordinator.handle_call/3
    (stdlib) gen_server.erl:636: :gen_server.try_handle_call/4
    (stdlib) gen_server.erl:665: :gen_server.handle_msg/6
    (stdlib) proc_lib.erl:247: :proc_lib.init_p_do_apply/3
Last message (from :depositor): {:check_in, 316, :depositor}⋅
** (MatchError) no match of right hand side value: {:error, {:omg_api, {{:shutdown, {:failed_to_start_child, :depositor, {{{:badmatch, :invalid_synced_height_update}, [{OMG.API.RootChainCoordinator.Core, :check_in, 4, [file: 'lib/root_chain_coordinator/core.ex', line: 64]}, {OMG.API.RootChainCoordinator, :handle_call, 3, [file: 'lib/root_chain_coordinator.ex', line: 60]}, {:gen_server, :try_handle_call, 4, [file: 'gen_server.erl', line: 636]}, {:gen_server, :handle_msg, 6, [file: 'gen_server.erl', line: 665]}, {:proc_lib, :init_p_do_apply, 3, [file: 'proc_lib.erl', line: 247]}]}, {GenServer, :call, [OMG.API.RootChainCoordinator, {:check_in, 316, :depositor}, 5000]}}}}, {OMG.API.Application, :start, [:normal, []]}}}}
    (omg_api) lib/mix/tasks/child_chain.ex:30: Mix.Tasks.Xomg.ChildChain.Start.run/1
    (mix) lib/mix/task.ex:314: Mix.Task.run_task/3
    (mix) lib/mix/cli.ex:80: Mix.CLI.run_task/2
    (elixir) lib/code.ex:677: Code.require_file/2
2018-12-15 12:31:21.413 [info] ⋅Application omg_api exited: OMG.API.Application.start(:normal, []) returned an error: shutdown: failed to start child: :depositor
    ** (EXIT) exited in: GenServer.call(OMG.API.RootChainCoordinator, {:check_in, 316, :depositor}, 5000)
        ** (EXIT) an exception was raised:
            ** (MatchError) no match of right hand side value: :invalid_synced_height_update
                (omg_api) lib/root_chain_coordinator/core.ex:64: OMG.API.RootChainCoordinator.Core.check_in/4
                (omg_api) lib/root_chain_coordinator.ex:60: OMG.API.RootChainCoordinator.handle_call/3
                (stdlib) gen_server.erl:636: :gen_server.try_handle_call/4
                (stdlib) gen_server.erl:665: :gen_server.handle_msg/6
                (stdlib) proc_lib.erl:247: :proc_lib.init_p_do_apply/3⋅
2018-12-15 12:31:21.413 [info] ⋅Application omg_rpc exited: :stopped⋅
2018-12-15 12:31:21.413 [info] ⋅Application phoenix_swagger exited: :stopped⋅
2018-12-15 12:31:21.413 [info] ⋅Application cowboy exited: :stopped⋅
2018-12-15 12:31:21.413 [info] ⋅Application cowlib exited: :stopped⋅
2018-12-15 12:31:21.413 [info] ⋅Application ranch exited: :stopped⋅
2018-12-15 12:31:21.413 [info] ⋅Application runtime_tools exited: :stopped⋅
2018-12-15 12:31:21.413 [info] ⋅Application blockchain exited: :stopped⋅
2018-12-15 12:31:21.413 [info] ⋅Application evm exited: :stopped⋅
2018-12-15 12:31:21.413 [info] ⋅Application merkle_patricia_tree exited: :stopped⋅
2018-12-15 12:31:21.413 [info] ⋅Application hex_prefix exited: :stopped⋅
2018-12-15 12:31:21.413 [info] ⋅Application omg_eth exited: :stopped⋅
2018-12-15 12:31:21.413 [info] ⋅Application exexec exited: :stopped⋅
2018-12-15 12:31:21.413 [info] ⋅Application ethereumex exited: :stopped⋅
2018-12-15 12:31:21.413 [info] ⋅Application httpoison exited: :stopped⋅
2018-12-15 12:31:21.413 [info] ⋅Application abi exited: :stopped⋅
2018-12-15 12:31:21.413 [info] ⋅Application exth_crypto exited: :stopped⋅
2018-12-15 12:31:21.413 [info] ⋅Application keccakf1600 exited: :stopped⋅
2018-12-15 12:31:21.413 [info] ⋅Application binary exited: :stopped⋅
2018-12-15 12:31:21.413 [info] ⋅Application ex_rlp exited: :stopped⋅
2018-12-15 12:31:21.413 [info] ⋅Application omg_db exited: :stopped⋅
2018-12-15 12:31:21.413 [info] ⋅Application exleveldb exited: :stopped⋅
2018-12-15 12:31:21.413 [info] ⋅Application eleveldb exited: :stopped⋅
2018-12-15 12:31:21.413 [info] ⋅Application briefly exited: :stopped⋅
2018-12-15 12:31:21.413 [info] ⋅Application merkle_tree exited: :stopped⋅
2018-12-15 12:31:21.413 [info] ⋅Application libsecp256k1 exited: :stopped⋅
2018-12-15 12:31:21.413 [info] ⋅Application propcheck exited: :stopped⋅
2018-12-15 12:31:21.413 [info] ⋅Application proper exited: :stopped⋅
2018-12-15 12:31:21.413 [info] ⋅Application sentry exited: :stopped⋅
2018-12-15 12:31:21.413 [info] ⋅Application uuid exited: :stopped⋅
2018-12-15 12:31:21.413 [info] ⋅Application hackney exited: :stopped⋅
2018-12-15 12:31:21.413 [info] ⋅Application metrics exited: :stopped⋅
2018-12-15 12:31:21.413 [info] ⋅Application ssl_verify_fun exited: :stopped⋅
2018-12-15 12:31:21.413 [info] ⋅Application certifi exited: :stopped⋅
2018-12-15 12:31:21.413 [info] ⋅Application mimerl exited: :stopped⋅
2018-12-15 12:31:21.413 [info] ⋅Application idna exited: :stopped⋅
2018-12-15 12:31:21.413 [info] ⋅Application unicode_util_compat exited: :stopped⋅
2018-12-15 12:31:21.419 [error] ⋅GenEvent handler Sentry.Logger installed in :error_logger terminating
** (stop) exited in: GenServer.call(Sentry.TaskSupervisor, {:start_task, [#PID<0.32.0>, :monitor, {:nonode@nohost, :error_logger}, {:erlang, :apply, [#Function<3.81924908/0 in Sentry.Client.do_send_event/3>, []]}], :temporary, nil}, :infinity)
    ** (EXIT) no process: the process is not alive or there's no process currently associated with the given name, possibly because its application isn't started
Last message: {:error_report, #PID<0.765.0>, {#PID<0.777.0>, :crash_report, [[initial_call: {OMG.API.RootChainCoordinator, :init, [:Argument__1]}, pid: #PID<0.777.0>, registered_name: OMG.API.RootChainCoordinator, error_info: {:error, {:badmatch, :invalid_synced_height_update}, [{OMG.API.RootChainCoordinator.Core, :check_in, 4, [file: 'lib/root_chain_coordinator/core.ex', line: 64]}, {OMG.API.RootChainCoordinator, :handle_call, 3, [file: 'lib/root_chain_coordinator.ex', line: 60]}, {:gen_server, :try_handle_call, 4, [file: 'gen_server.erl', line: 636]}, {:gen_server, :handle_msg, 6, [file: 'gen_server.erl', line: 665]}, {:proc_lib, :init_p_do_apply, 3, [file: 'proc_lib.erl', line: 247]}]}, ancestors: [#PID<0.767.0>, #PID<0.766.0>], message_queue_len: 0, messages: [], links: [#PID<0.767.0>, #PID<0.774.0>], dictionary: [], trap_exit: false, status: :running, heap_size: 987, stack_size: 27, reductions: 471], []]}}⋅
```