### PR TITLE
Add mix deps.clean to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -65,6 +65,7 @@ WORKDIR /home/elixir-user/elixir-omg/
 
 RUN mix do local.hex --force, local.rebar --force
 
+RUN mix deps.clean --all
 RUN mix deps.get 
 
 RUN mix compile


### PR DESCRIPTION
Fixes issue when building the docker image in a repo that had already build locally - local build cache was getting copied to the docker image and interfering with `mix compile` 