### PR TITLE
fix: prevent child chain allowing spends from exiting deposit

### DIFF
--- a/apps/omg_api/lib/application.ex
+++ b/apps/omg_api/lib/application.ex
@@ -51,8 +51,8 @@ defmodule OMG.API.Application do
           {OMG.API.EthereumEventListener, :start_link,
            [
              %{
-               # 0, because we want the child chain to make UTXOs spent immediately after exit starts
-               block_finality_margin: 0,
+               # we need to be just one block after deposits to never miss exits from deposits
+               block_finality_margin: deposit_finality_margin + 1,
                synced_height_update_key: :last_exiter_eth_height,
                service_name: :exiter,
                get_events_callback: &OMG.Eth.RootChain.get_exits/2,

--- a/apps/omg_watcher/test/integration/block_getter_test.exs
+++ b/apps/omg_watcher/test/integration/block_getter_test.exs
@@ -147,7 +147,8 @@ defmodule OMG.Watcher.Integration.BlockGetterTest do
              Eth.RootChain.get_exits(0, exit_eth_height)
 
     # Here we're waiting for watcher to process the exits
-    Process.sleep(1_00)
+    deposit_finality_margin = Application.fetch_env!(:omg_api, :deposit_finality_margin)
+    Eth.DevHelpers.wait_for_root_chain_block(exit_eth_height + deposit_finality_margin + 1 + 1)
 
     tx2 = API.TestHelper.create_encoded([{block_nr, 0, 0, alice}], @eth, [{alice, 7}])
 

--- a/docs/exit_validation.md
+++ b/docs/exit_validation.md
@@ -17,7 +17,10 @@ For completeness we give a quick run-down of the rules followed by the Child Cha
 1. The Child Chain operator's objective is to pro-actively minimize the risk of chain becoming invalid.
 The Child Chain will become invalid if any invalid exit gets finalized.
 2. To satisfy this objective:
-    - the Child Chain server listens to every `ExitStarted` Root Chain event and immediately "spends" the exited utxo. This blocks the user from spending that utxo, thus preventing exit invalidation.
+    - the Child Chain server listens to every `ExitStarted` Root Chain event and immediately "spends" the exited utxo.
+    This blocks the user from spending that utxo, thus preventing exit invalidation.
+    This immediacy is however limited; the server must wait the same Ethereum blocks' margin as it waits with deposits.
+    Otherwise, an exit from a fresh deposit might be processed before that deposit (and it _must_ wait for deposit's finality).
     - the Child Chain server listens to every `InFlightExitStarted` Root Chain event and immediately "spends" the exiting tx's **inputs**
     - the Child Chain server listens to every `InFlightExitPiggybacked` Root Chain event (on outputs) and immediately "spends" the piggybacked outputs - as long as the IFEing tx has been included in the chain and the output exists
 


### PR DESCRIPTION
Child chain's `:exiter`'s finality margin cannot be zero - it must be greater than its `deposit finality margin`. Otherwise there's an option of child chain letting a UTXO be spent that had been exited immediately after the deposit (because deposit's wait and must wait). Such exit processed by `:exiter` would be a noop.

So `:exiter` must wait at least whatever `:depositor` is waiting, to always come after it.