### PR TITLE
fix cleanbuild by making call to OMG.API dynamic

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -67,7 +67,7 @@ podTemplate(
 
         stage('Cleanbuild') {
             withEnv(["MIX_ENV=test", "DATABASE_URL=${DATABASE_URL}"]) {
-                sh("mix do compile --warnings-as-errors --force, test --exclude test")
+                sh("mix do clean, compile --warnings-as-errors --force, test --exclude test")
             }
         }
 

--- a/apps/omg_rpc/lib/web/controllers/block.ex
+++ b/apps/omg_rpc/lib/web/controllers/block.ex
@@ -29,7 +29,7 @@ defmodule OMG.RPC.Web.Controller.Block do
   def get_block(conn, params) do
     with {:ok, hex_str} <- Map.fetch(params, "hash"),
          {:ok, hash} <- Base.decode16(hex_str, case: :mixed),
-         {:ok, block} <- @api_module.get_block(hash) do
+         {:ok, block} <- apply(@api_module, :get_block, [hash]) do
       render(conn, View.Block, :block, block: block)
     end
   end

--- a/apps/omg_rpc/lib/web/controllers/transaction.ex
+++ b/apps/omg_rpc/lib/web/controllers/transaction.ex
@@ -29,7 +29,7 @@ defmodule OMG.RPC.Web.Controller.Transaction do
   def submit(conn, params) do
     with {:ok, hex_str} <- Map.fetch(params, "transaction"),
          {:ok, txbytes} <- Base.decode16(hex_str, case: :mixed),
-         {:ok, details} <- @api_module.submit(txbytes) do
+         {:ok, details} <- apply(@api_module, :submit, [txbytes]) do
       render(conn, View.Transaction, :submit, result: details)
     end
   end


### PR DESCRIPTION
when we did @api_module.call_sth that would cause compiler to complain, in case @api_module wasn't compiled yet (e.g. on CircleCI)