### PR TITLE
OMG-365 handle exits from future utxos when syncing

### DIFF
--- a/apps/omg_watcher/lib/exit_processor.ex
+++ b/apps/omg_watcher/lib/exit_processor.ex
@@ -125,10 +125,11 @@ defmodule OMG.Watcher.ExitProcessor do
   # combine data from `ExitProcessor` and `API.State` to figure out what to do about exits
   defp determine_invalid_exits(state) do
     {:ok, eth_height_now} = Eth.get_ethereum_height()
+    {blknum_now, _} = State.get_status()
 
     state
     |> Core.get_exiting_utxo_positions()
     |> Enum.map(&State.utxo_exists?/1)
-    |> Core.invalid_exits(state, eth_height_now)
+    |> Core.invalid_exits(state, eth_height_now, blknum_now)
   end
 end

--- a/apps/omg_watcher/lib/exit_processor/core.ex
+++ b/apps/omg_watcher/lib/exit_processor/core.ex
@@ -156,16 +156,22 @@ defmodule OMG.Watcher.ExitProcessor.Core do
   NOTE: If there were any exits unchallenged for some time in chain history, this might detect breach of SLA,
         even if the exits were eventually challenged (e.g. during syncing)
   """
-  @spec invalid_exits(list(boolean), t(), pos_integer) ::
+  @spec invalid_exits(list(boolean), t(), pos_integer, non_neg_integer) ::
           {list(Event.InvalidExit.t() | Event.UnchallengedExit.t()), :chain_ok | {:needs_stopping, :unchallenged_exit}}
-  def invalid_exits(utxo_exists_result, %__MODULE__{exits: exits, sla_margin: sla_margin} = state, eth_height_now) do
+  def invalid_exits(
+        utxo_exists_result,
+        %__MODULE__{exits: exits, sla_margin: sla_margin} = state,
+        eth_height_now,
+        blknum_now
+      ) do
     exiting_utxo_positions = get_exiting_utxo_positions(state)
 
     invalid_exit_positions =
       utxo_exists_result
-      |> Enum.zip(exiting_utxo_positions)
-      |> Enum.filter(fn {utxo_exists, _} -> !utxo_exists end)
-      |> Enum.map(fn {_, position} -> position end)
+      |> Stream.zip(exiting_utxo_positions)
+      |> Stream.filter(fn {utxo_exists, _} -> !utxo_exists end)
+      |> Stream.filter(fn {_, Utxo.position(blknum, _, _)} -> blknum < blknum_now end)
+      |> Stream.map(fn {_, position} -> position end)
 
     # get exits which are still invalid and after the SLA margin
     late_invalid_exits =


### PR DESCRIPTION
They used to excite :invalid (and :unchallenged) exit events, because RootChainCoordinator doesn't stop exit processing since  060123a60f6c3739f9b6b391b3f58e7e9a940b21

