### PR TITLE
fix: Add Sentry to Watcher's Phoenix endpoint

### DIFF
--- a/apps/omg_watcher/lib/web/sockets/endpoint.ex
+++ b/apps/omg_watcher/lib/web/sockets/endpoint.ex
@@ -15,6 +15,7 @@
 defmodule OMG.Watcher.Web.Endpoint do
   use Phoenix.Endpoint, otp_app: :omg_watcher
   use Appsignal.Phoenix
+  use Sentry.Phoenix.Endpoint
 
   socket("/socket", OMG.Watcher.Web.Socket)
 

--- a/dialyzer.ignore-warnings
+++ b/dialyzer.ignore-warnings
@@ -28,3 +28,5 @@ Function get/2 has no local return
 Function challenge_fastly_invalid_exits/1 has no local return
 # IEx related problems - we need IEx loaded for proper Mix.Tasks running - safe?
 :0: Unknown function 'Elixir.IEx':'started?'/0
+# Sentry problems
+Expression produces a value of type 'error' | 'excluded' | 'ignored' | 'unsampled' | {'ok',binary() | pid() | #{'__struct__':='Elixir.Task', 'owner':=_, 'pid':=_, 'ref':=_}}, but this value is unmatched


### PR DESCRIPTION
Exceptions from the Watcher are not getting caught by Sentry. Phoenix applications require this statement to be added. https://hexdocs.pm/sentry/Sentry.Phoenix.Endpoint.html