### PR TITLE
Omg 329 prepare state core test

### DIFF
--- a/apps/omg_api/lib/state.ex
+++ b/apps/omg_api/lib/state.ex
@@ -115,7 +115,7 @@ defmodule OMG.API.State do
   Checks (stateful validity) and executes a spend transaction. Assuming stateless validity!
   """
   def handle_call({:exec, tx, fees}, _from, state) do
-    case Core.exec(tx, fees, state) do
+    case Core.exec(state, tx, fees) do
       {:ok, tx_result, new_state} ->
         {:reply, {:ok, tx_result}, new_state}
 

--- a/apps/omg_api/lib/state/core.ex
+++ b/apps/omg_api/lib/state/core.ex
@@ -140,16 +140,16 @@ defmodule OMG.API.State.Core do
 
   See docs/transaction_validation.md for more information about stateful and stateless validation.
   """
-  @spec exec(tx :: Transaction.Recovered.t(), fees :: map(), state :: t()) ::
+  @spec exec(state :: t(), tx :: Transaction.Recovered.t(), fees :: map()) ::
           {:ok, {Transaction.Recovered.tx_hash_t(), pos_integer, non_neg_integer}, t()}
           | {{:error, exec_error}, t()}
   def exec(
+        %Core{height: height, tx_index: tx_index} = state,
         %Transaction.Recovered{
           signed_tx: %Transaction.Signed{raw_tx: raw_tx},
           tx_hash: tx_hash
         } = recovered_tx,
-        fees,
-        %Core{height: height, tx_index: tx_index} = state
+        fees
       ) do
     outputs = Transaction.get_outputs(raw_tx)
 

--- a/apps/omg_api/test/state/core_test.exs
+++ b/apps/omg_api/test/state/core_test.exs
@@ -27,31 +27,30 @@ defmodule OMG.API.State.CoreTest do
   require Utxo
 
   @eth Crypto.zero_address()
-  @child_block_interval OMG.Eth.RootChain.get_child_block_interval() |> elem(1)
-  @child_block_2 @child_block_interval * 2
-  @child_block_3 @child_block_interval * 3
-  @child_block_4 @child_block_interval * 4
+  @not_eth <<1::size(160)>>
+  @zero_fees_map %{@eth => 0, @not_eth => 0}
+  @interval OMG.Eth.RootChain.get_child_block_interval() |> elem(1)
+  @blknum1 @interval
+  @blknum2 @interval * 2
+  @blknum3 @interval * 3
+  @blknum4 @interval * 4
 
   @empty_block_hash <<119, 106, 49, 219, 52, 161, 160, 167, 202, 175, 134, 44, 255, 223, 255, 23, 137, 41, 127, 250,
                       220, 56, 11, 211, 211, 146, 129, 211, 64, 171, 211, 173>>
 
-  defp eth, do: Crypto.zero_address()
-  defp not_eth, do: <<1::size(160)>>
-  defp zero_fees_map, do: %{eth() => 0, not_eth() => 0}
-
   @tag fixtures: [:alice, :bob, :state_empty]
   test "can spend deposits", %{alice: alice, bob: bob, state_empty: state} do
     state
-    |> Test.do_deposit(alice, %{amount: 10, currency: eth(), blknum: 1})
+    |> Test.do_deposit(alice, %{amount: 10, currency: @eth, blknum: 1})
     |> (&Core.exec(
-          Test.create_recovered([{1, 0, 0, alice}], eth(), [{bob, 7}, {alice, 3}]),
-          zero_fees_map(),
+          Test.create_recovered([{1, 0, 0, alice}], @eth, [{bob, 7}, {alice, 3}]),
+          @zero_fees_map,
           &1
         )).()
     |> success?
     |> (&Core.exec(
-          Test.create_recovered([{@child_block_interval, 0, 1, alice}], eth(), [{bob, 3}]),
-          zero_fees_map(),
+          Test.create_recovered([{@blknum1, 0, 1, alice}], @eth, [{bob, 3}]),
+          @zero_fees_map,
           &1
         )).()
     |> success?
@@ -61,26 +60,26 @@ defmodule OMG.API.State.CoreTest do
   test "output currencies must be included in input currencies", %{alice: alice, state_empty: state} do
     state1 =
       state
-      |> Test.do_deposit(alice, %{amount: 10, currency: not_eth(), blknum: 1})
+      |> Test.do_deposit(alice, %{amount: 10, currency: @not_eth, blknum: 1})
       |> (&Core.exec(
-            Test.create_recovered([{1, 0, 0, alice}], not_eth(), [{alice, 7}, {alice, 3}]),
-            zero_fees_map(),
+            Test.create_recovered([{1, 0, 0, alice}], @not_eth, [{alice, 7}, {alice, 3}]),
+            @zero_fees_map,
             &1
           )).()
       |> success?
 
     state1
-    |> (&Core.exec(Test.create_recovered([{1000, 0, 0, alice}], eth(), [{alice, 9}]), zero_fees_map(), &1)).()
+    |> (&Core.exec(Test.create_recovered([{1000, 0, 0, alice}], @eth, [{alice, 9}]), @zero_fees_map, &1)).()
     |> fail?(:amounts_do_not_add_up)
 
     state1
     |> (&Core.exec(
           Test.create_recovered(
             [{1000, 0, 0, alice}],
-            not_eth(),
+            @not_eth,
             [{alice, 3}, {alice, 0}]
           ),
-          zero_fees_map(),
+          @zero_fees_map,
           &1
         )).()
     |> success?
@@ -89,20 +88,20 @@ defmodule OMG.API.State.CoreTest do
   @tag fixtures: [:alice, :bob, :state_empty]
   test "can spend a batch of deposits", %{alice: alice, bob: bob, state_empty: state} do
     state
-    |> Test.do_deposit(alice, %{amount: 10, currency: eth(), blknum: 1})
-    |> Test.do_deposit(bob, %{amount: 20, currency: eth(), blknum: 2})
-    |> (&Core.exec(Test.create_recovered([{1, 0, 0, alice}], eth(), [{bob, 10}]), zero_fees_map(), &1)).()
+    |> Test.do_deposit(alice, %{amount: 10, currency: @eth, blknum: 1})
+    |> Test.do_deposit(bob, %{amount: 20, currency: @eth, blknum: 2})
+    |> (&Core.exec(Test.create_recovered([{1, 0, 0, alice}], @eth, [{bob, 10}]), @zero_fees_map, &1)).()
     |> success?
-    |> (&Core.exec(Test.create_recovered([{2, 0, 0, bob}], eth(), [{alice, 20}]), zero_fees_map(), &1)).()
+    |> (&Core.exec(Test.create_recovered([{2, 0, 0, bob}], @eth, [{alice, 20}]), @zero_fees_map, &1)).()
     |> success?
   end
 
   @tag fixtures: [:alice, :bob, :state_empty]
   test "can't spend when signature order does not match input order", %{alice: alice, bob: bob, state_empty: state} do
     state
-    |> Test.do_deposit(alice, %{amount: 10, currency: eth(), blknum: 1})
-    |> Test.do_deposit(bob, %{amount: 20, currency: eth(), blknum: 2})
-    |> (&Core.exec(Test.create_recovered([{1, 0, 0, bob}, {2, 0, 0, alice}], eth(), [{bob, 10}]), zero_fees_map(), &1)).()
+    |> Test.do_deposit(alice, %{amount: 10, currency: @eth, blknum: 1})
+    |> Test.do_deposit(bob, %{amount: 20, currency: @eth, blknum: 2})
+    |> (&Core.exec(Test.create_recovered([{1, 0, 0, bob}, {2, 0, 0, alice}], @eth, [{bob, 10}]), @zero_fees_map, &1)).()
     |> fail?(:unauthorized_spent)
   end
 
@@ -112,35 +111,35 @@ defmodule OMG.API.State.CoreTest do
     bob: bob,
     state_empty: state
   } do
-    deposits = [%{owner: alice.addr, currency: eth(), amount: 20, blknum: 2}]
+    deposits = [%{owner: alice.addr, currency: @eth, amount: 20, blknum: 2}]
     assert {:ok, {_, [_, {:put, :last_deposit_child_blknum, 2}]}, state} = Core.deposit(deposits, state)
 
-    assert {:ok, {[], []}, ^state} = Core.deposit([%{owner: bob.addr, currency: eth(), amount: 20, blknum: 1}], state)
+    assert {:ok, {[], []}, ^state} = Core.deposit([%{owner: bob.addr, currency: @eth, amount: 20, blknum: 1}], state)
   end
 
   @tag fixtures: [:bob]
   test "ignores deposits from blocks not higher than the deposit height read from db", %{bob: bob} do
-    {:ok, state} = Core.extract_initial_state([], 0, 1, @child_block_interval)
+    {:ok, state} = Core.extract_initial_state([], 0, 1, @interval)
 
-    assert {:ok, {[], []}, ^state} = Core.deposit([%{owner: bob.addr, currency: eth(), amount: 20, blknum: 1}], state)
+    assert {:ok, {[], []}, ^state} = Core.deposit([%{owner: bob.addr, currency: @eth, amount: 20, blknum: 1}], state)
   end
 
   test "extract_initial_state function returns error when passed last deposit as :not_found" do
-    assert {:error, :last_deposit_not_found} = Core.extract_initial_state([], 0, :not_found, @child_block_interval)
+    assert {:error, :last_deposit_not_found} = Core.extract_initial_state([], 0, :not_found, @interval)
   end
 
   test "extract_initial_state function returns error when passed top block number as :not_found" do
-    assert {:error, :top_block_number_not_found} = Core.extract_initial_state([], :not_found, 0, @child_block_interval)
+    assert {:error, :top_block_number_not_found} = Core.extract_initial_state([], :not_found, 0, @interval)
   end
 
   @tag fixtures: [:alice, :bob, :state_empty]
   test "can't spend nonexistent", %{alice: alice, bob: bob, state_empty: state} do
-    state_deposit = state |> Test.do_deposit(alice, %{amount: 10, currency: eth(), blknum: 1})
+    state_deposit = state |> Test.do_deposit(alice, %{amount: 10, currency: @eth, blknum: 1})
 
     state_deposit
     |> (&Core.exec(
-          Test.create_recovered([{1, 1, 0, alice}, {1, 0, 0, alice}], eth(), [{bob, 7}, {alice, 3}]),
-          zero_fees_map(),
+          Test.create_recovered([{1, 1, 0, alice}, {1, 0, 0, alice}], @eth, [{bob, 7}, {alice, 3}]),
+          @zero_fees_map,
           &1
         )).()
     |> fail?(:utxo_not_found)
@@ -149,21 +148,21 @@ defmodule OMG.API.State.CoreTest do
 
   @tag fixtures: [:alice, :bob, :state_empty]
   test "amounts must add up", %{alice: alice, bob: bob, state_empty: state} do
-    state = Test.do_deposit(state, alice, %{amount: 10, currency: eth(), blknum: 1})
+    state = Test.do_deposit(state, alice, %{amount: 10, currency: @eth, blknum: 1})
 
     state =
       state
       |> (&Core.exec(
-            Test.create_recovered([{1, 0, 0, alice}], eth(), [{alice, 8}, {bob, 3}]),
+            Test.create_recovered([{1, 0, 0, alice}], @eth, [{alice, 8}, {bob, 3}]),
             # outputs exceed inputs, no fee
-            %{eth() => 0},
+            %{@eth => 0},
             &1
           )).()
       |> fail?(:amounts_do_not_add_up)
       |> same?(state)
       |> (&Core.exec(
-            Test.create_recovered([{1, 0, 0, alice}], eth(), [{bob, 2}, {alice, 8}]),
-            zero_fees_map(),
+            Test.create_recovered([{1, 0, 0, alice}], @eth, [{bob, 2}, {alice, 8}]),
+            @zero_fees_map,
             &1
           )).()
       |> success?
@@ -171,12 +170,12 @@ defmodule OMG.API.State.CoreTest do
     state
     |> (&Core.exec(
           Test.create_recovered(
-            [{@child_block_interval, 0, 0, bob}, {@child_block_interval, 0, 1, alice}],
-            eth(),
+            [{@blknum1, 0, 0, bob}, {@blknum1, 0, 1, alice}],
+            @eth,
             [{alice, 7}, {bob, 2}]
           ),
           # outputs exceed inputs, no fee
-          %{eth() => 2},
+          %{@eth => 2},
           &1
         )).()
     |> fail?(:amounts_do_not_add_up)
@@ -186,10 +185,10 @@ defmodule OMG.API.State.CoreTest do
   @tag fixtures: [:alice, :bob, :state_alice_deposit]
   test "can't spend other people's funds", %{alice: alice, bob: bob, state_alice_deposit: state} do
     state
-    |> (&Core.exec(Test.create_recovered([{1, 0, 0, bob}], eth(), [{bob, 8}, {alice, 3}]), zero_fees_map(), &1)).()
+    |> (&Core.exec(Test.create_recovered([{1, 0, 0, bob}], @eth, [{bob, 8}, {alice, 3}]), @zero_fees_map, &1)).()
     |> fail?(:unauthorized_spent)
     |> same?(state)
-    |> (&Core.exec(Test.create_recovered([{1, 0, 0, bob}], eth(), [{alice, 10}]), zero_fees_map(), &1)).()
+    |> (&Core.exec(Test.create_recovered([{1, 0, 0, bob}], @eth, [{alice, 10}]), @zero_fees_map, &1)).()
     |> fail?(:unauthorized_spent)
     |> same?(state)
   end
@@ -197,8 +196,8 @@ defmodule OMG.API.State.CoreTest do
   @tag fixtures: [:alice, :bob, :state_alice_deposit]
   test "can't spend spent", %{alice: alice, bob: bob, state_alice_deposit: state} do
     transactions = [
-      Test.create_recovered([{1, 0, 0, alice}], eth(), [{bob, 7}, {alice, 3}]),
-      Test.create_recovered([{0, 0, 0, %{priv: <<>>, addr: nil}}, {1, 0, 0, alice}], eth(), [
+      Test.create_recovered([{1, 0, 0, alice}], @eth, [{bob, 7}, {alice, 3}]),
+      Test.create_recovered([{0, 0, 0, %{priv: <<>>, addr: nil}}, {1, 0, 0, alice}], @eth, [
         {bob, 7},
         {alice, 3}
       ])
@@ -206,8 +205,8 @@ defmodule OMG.API.State.CoreTest do
 
     for first <- transactions,
         second <- transactions do
-      state2 = state |> (&Core.exec(first, zero_fees_map(), &1)).() |> success?
-      state2 |> (&Core.exec(second, zero_fees_map(), &1)).() |> fail?(:utxo_not_found) |> same?(state2)
+      state2 = state |> (&Core.exec(first, @zero_fees_map, &1)).() |> success?
+      state2 |> (&Core.exec(second, @zero_fees_map, &1)).() |> fail?(:utxo_not_found) |> same?(state2)
     end
   end
 
@@ -220,28 +219,28 @@ defmodule OMG.API.State.CoreTest do
   } do
     state
     |> (&Core.exec(
-          Test.create_recovered([{1, 0, 0, alice}], eth(), [{bob, 7}, {alice, 3}]),
-          zero_fees_map(),
+          Test.create_recovered([{1, 0, 0, alice}], @eth, [{bob, 7}, {alice, 3}]),
+          @zero_fees_map,
           &1
         )).()
     |> success?
     |> (&Core.exec(
-          Test.create_recovered([{@child_block_interval, 0, 0, bob}], eth(), [{carol, 7}]),
-          zero_fees_map(),
+          Test.create_recovered([{@blknum1, 0, 0, bob}], @eth, [{carol, 7}]),
+          @zero_fees_map,
           &1
         )).()
     |> success?
     |> (&Core.exec(
-          Test.create_recovered([{@child_block_interval, 0, 1, alice}], eth(), [{carol, 3}]),
-          zero_fees_map(),
+          Test.create_recovered([{@blknum1, 0, 1, alice}], @eth, [{carol, 3}]),
+          @zero_fees_map,
           &1
         )).()
     |> success?
     |> (&Core.exec(
-          Test.create_recovered([{@child_block_interval, 1, 0, carol}, {@child_block_interval, 2, 0, carol}], eth(), [
+          Test.create_recovered([{@blknum1, 1, 0, carol}, {@blknum1, 2, 0, carol}], @eth, [
             {alice, 10}
           ]),
-          zero_fees_map(),
+          @zero_fees_map,
           &1
         )).()
     |> success?
@@ -249,45 +248,45 @@ defmodule OMG.API.State.CoreTest do
 
   @tag fixtures: [:alice, :bob, :state_alice_deposit]
   test "can spend after block is formed", %{alice: alice, bob: bob, state_alice_deposit: state} do
-    next_block_height = @child_block_2
-    {:ok, {_, _, _}, state} = form_block_check(state, @child_block_interval)
+    next_block_height = @blknum2
+    {:ok, {_, _, _}, state} = form_block_check(state)
 
     state
     |> (&Core.exec(
-          Test.create_recovered([{1, 0, 0, alice}], eth(), [{bob, 7}, {alice, 3}]),
-          zero_fees_map(),
+          Test.create_recovered([{1, 0, 0, alice}], @eth, [{bob, 7}, {alice, 3}]),
+          @zero_fees_map,
           &1
         )).()
     |> success?
-    |> (&Core.exec(Test.create_recovered([{next_block_height, 0, 0, bob}], eth(), [{bob, 7}]), zero_fees_map(), &1)).()
+    |> (&Core.exec(Test.create_recovered([{next_block_height, 0, 0, bob}], @eth, [{bob, 7}]), @zero_fees_map, &1)).()
     |> success?
   end
 
   @tag fixtures: [:alice, :bob, :state_alice_deposit]
   test "forming block doesn't unspend", %{alice: alice, bob: bob, state_alice_deposit: state} do
-    recovered = Test.create_recovered([{1, 0, 0, alice}], eth(), [{bob, 7}, {alice, 3}])
+    recovered = Test.create_recovered([{1, 0, 0, alice}], @eth, [{bob, 7}, {alice, 3}])
 
     {:ok, {_, _, _}, state} =
       state
-      |> (&Core.exec(recovered, zero_fees_map(), &1)).()
+      |> (&Core.exec(recovered, @zero_fees_map, &1)).()
       |> success?
-      |> form_block_check(@child_block_interval)
+      |> form_block_check()
 
-    recovered |> Core.exec(zero_fees_map(), state) |> fail?(:utxo_not_found) |> same?(state)
+    recovered |> Core.exec(@zero_fees_map, state) |> fail?(:utxo_not_found) |> same?(state)
   end
 
   @tag fixtures: [:alice, :bob, :state_alice_deposit]
   test "spending emits event trigger", %{alice: alice, bob: bob, state_alice_deposit: state} do
-    recover1 = Test.create_recovered([{1, 0, 0, alice}], eth(), [{bob, 7}, {alice, 3}])
-    recover2 = Test.create_recovered([{1000, 0, 0, bob}], eth(), [{alice, 3}])
+    recover1 = Test.create_recovered([{1, 0, 0, alice}], @eth, [{bob, 7}, {alice, 3}])
+    recover2 = Test.create_recovered([{1000, 0, 0, bob}], @eth, [{alice, 3}])
 
     assert {:ok, {%Block{hash: block_hash, number: block_number}, triggers, _}, _} =
              state
-             |> (&Core.exec(recover1, zero_fees_map(), &1)).()
+             |> (&Core.exec(recover1, @zero_fees_map, &1)).()
              |> success?
-             |> (&Core.exec(recover2, zero_fees_map(), &1)).()
+             |> (&Core.exec(recover2, @zero_fees_map, &1)).()
              |> success?
-             |> form_block_check(@child_block_interval)
+             |> form_block_check()
 
     assert triggers == [
              %{tx: recover1, child_blknum: block_number, child_txindex: 0, child_block_hash: block_hash},
@@ -304,19 +303,19 @@ defmodule OMG.API.State.CoreTest do
     state =
       state
       |> (&Core.exec(
-            Test.create_recovered([{1, 0, 0, alice}], eth(), [{bob, 7}, {alice, 3}]),
-            zero_fees_map(),
+            Test.create_recovered([{1, 0, 0, alice}], @eth, [{bob, 7}, {alice, 3}]),
+            @zero_fees_map,
             &1
           )).()
       |> success?
       |> (&Core.exec(
-            Test.create_recovered([{@child_block_interval, 0, 0, bob}], eth(), [{alice, 7}]),
-            zero_fees_map(),
+            Test.create_recovered([{@blknum1, 0, 0, bob}], @eth, [{alice, 7}]),
+            @zero_fees_map,
             &1
           )).()
       |> success?
 
-    assert {:ok, {_, [_trigger1, _trigger2], _}, _} = form_block_check(state, @child_block_interval)
+    assert {:ok, {_, [_trigger1, _trigger2], _}, _} = form_block_check(state)
   end
 
   @tag fixtures: [:alice, :bob, :state_alice_deposit]
@@ -327,13 +326,13 @@ defmodule OMG.API.State.CoreTest do
   } do
     state
     |> (&Core.exec(
-          Test.create_recovered([{1, 1, 0, alice}], eth(), [{bob, 7}, {alice, 3}]),
-          zero_fees_map(),
+          Test.create_recovered([{1, 1, 0, alice}], @eth, [{bob, 7}, {alice, 3}]),
+          @zero_fees_map,
           &1
         )).()
     |> same?(state)
 
-    assert {:ok, {_, [], _}, _} = form_block_check(state, @child_block_interval)
+    assert {:ok, {_, [], _}, _} = form_block_check(state)
   end
 
   @tag fixtures: [:alice, :state_empty]
@@ -342,10 +341,10 @@ defmodule OMG.API.State.CoreTest do
     state_empty: state
   } do
     assert {:ok, {[trigger], _}, state} =
-             Core.deposit([%{owner: alice, currency: eth(), amount: 4, blknum: @child_block_interval}], state)
+             Core.deposit([%{owner: alice, currency: @eth, amount: 4, blknum: 1}], state)
 
     assert trigger == %{deposit: %{owner: alice, amount: 4}}
-    assert {:ok, {_, [], _}, _} = form_block_check(state, @child_block_interval)
+    assert {:ok, {_, [], _}, _} = form_block_check(state)
   end
 
   @tag fixtures: [:alice, :bob, :state_alice_deposit]
@@ -357,15 +356,15 @@ defmodule OMG.API.State.CoreTest do
     state =
       state
       |> (&Core.exec(
-            Test.create_recovered([{1, 0, 0, alice}], eth(), [{bob, 7}, {alice, 3}]),
-            zero_fees_map(),
+            Test.create_recovered([{1, 0, 0, alice}], @eth, [{bob, 7}, {alice, 3}]),
+            @zero_fees_map,
             &1
           )).()
       |> success?
 
-    assert {:ok, {_, [_trigger], _}, state} = form_block_check(state, @child_block_interval)
+    assert {:ok, {_, [_trigger], _}, state} = form_block_check(state)
 
-    assert {:ok, {_, [], _}, _} = form_block_check(state, @child_block_interval)
+    assert {:ok, {_, [], _}, _} = form_block_check(state)
   end
 
   @tag fixtures: [:stable_alice, :stable_bob, :state_stable_alice_deposit]
@@ -375,26 +374,26 @@ defmodule OMG.API.State.CoreTest do
     state_stable_alice_deposit: state
   } do
     # odd number of transactions, just in case
-    recovered_tx_1 = Test.create_recovered([{1, 0, 0, alice}], eth(), [{bob, 7}, {alice, 3}])
-    recovered_tx_2 = Test.create_recovered([{@child_block_interval, 0, 0, bob}], eth(), [{alice, 2}, {bob, 5}])
+    recovered_tx_1 = Test.create_recovered([{1, 0, 0, alice}], @eth, [{bob, 7}, {alice, 3}])
+    recovered_tx_2 = Test.create_recovered([{@blknum1, 0, 0, bob}], @eth, [{alice, 2}, {bob, 5}])
 
-    recovered_tx_3 = Test.create_recovered([{@child_block_interval, 0, 1, alice}], eth(), [{alice, 2}, {bob, 1}])
+    recovered_tx_3 = Test.create_recovered([{@blknum1, 0, 1, alice}], @eth, [{alice, 2}, {bob, 1}])
 
     state =
       state
-      |> (&Core.exec(recovered_tx_1, zero_fees_map(), &1)).()
+      |> (&Core.exec(recovered_tx_1, @zero_fees_map, &1)).()
       |> success?
-      |> (&Core.exec(recovered_tx_2, zero_fees_map(), &1)).()
+      |> (&Core.exec(recovered_tx_2, @zero_fees_map, &1)).()
       |> success?
-      |> (&Core.exec(recovered_tx_3, zero_fees_map(), &1)).()
+      |> (&Core.exec(recovered_tx_3, @zero_fees_map, &1)).()
       |> success?
 
     assert {:ok,
             {%Block{
                transactions: [block_tx1, block_tx2, _third_tx],
                hash: block_hash,
-               number: @child_block_interval
-             }, _, _}, _} = form_block_check(state, @child_block_interval)
+               number: @blknum1
+             }, _, _}, _} = form_block_check(state)
 
     # precomputed fixed hash to check compliance with hashing algo
     assert block_hash |> Base.encode16(case: :lower) ==
@@ -414,24 +413,24 @@ defmodule OMG.API.State.CoreTest do
     state =
       state
       |> (&Core.exec(
-            Test.create_recovered([{1, 0, 0, alice}], eth(), [{bob, 7}, {alice, 3}]),
-            zero_fees_map(),
+            Test.create_recovered([{1, 0, 0, alice}], @eth, [{bob, 7}, {alice, 3}]),
+            @zero_fees_map,
             &1
           )).()
       |> success?
 
-    {:ok, {_, _, _}, state} = form_block_check(state, @child_block_interval)
-    expected_block = empty_block(@child_block_2)
+    {:ok, {_, _, _}, state} = form_block_check(state)
+    expected_block = empty_block(@blknum2)
 
-    assert {:ok, {^expected_block, _, _}, _} = form_block_check(state, @child_block_interval)
+    assert {:ok, {^expected_block, _, _}, _} = form_block_check(state)
   end
 
   @tag fixtures: [:state_empty]
   test "no pending transactions at start (no events, empty block, no db updates)", %{state_empty: state} do
     expected_block = empty_block()
 
-    assert {:ok, {^expected_block, [], [{:put, :block, _}, {:put, :child_top_block_number, @child_block_interval}]},
-            _state} = form_block_check(state, @child_block_interval)
+    assert {:ok, {^expected_block, [], [{:put, :block, _}, {:put, :child_top_block_number, @blknum1}]},
+            _state} = form_block_check(state)
   end
 
   @tag fixtures: [:alice, :bob, :state_alice_deposit]
@@ -443,12 +442,12 @@ defmodule OMG.API.State.CoreTest do
     {:ok, {_, _, db_updates}, state} =
       state
       |> (&Core.exec(
-            Test.create_recovered([{1, 0, 0, alice}], eth(), [{bob, 7}, {alice, 3}]),
-            zero_fees_map(),
+            Test.create_recovered([{1, 0, 0, alice}], @eth, [{bob, 7}, {alice, 3}]),
+            @zero_fees_map,
             &1
           )).()
       |> success?
-      |> form_block_check(@child_block_interval)
+      |> form_block_check()
 
     assert [
              {:put, :utxo, new_utxo1},
@@ -456,42 +455,42 @@ defmodule OMG.API.State.CoreTest do
              {:delete, :utxo, {1, 0, 0}},
              {:put, :spend, {{1, 0, 0}, 1000}},
              {:put, :block, _},
-             {:put, :child_top_block_number, @child_block_interval}
+             {:put, :child_top_block_number, @blknum1}
            ] = db_updates
 
-    assert {{@child_block_interval, 0, 0}, %{owner: ^bob_addr, currency: @eth, amount: 7}} = new_utxo1
-    assert {{@child_block_interval, 0, 1}, %{owner: ^alice_addr, currency: @eth, amount: 3}} = new_utxo2
+    assert {{@blknum1, 0, 0}, %{owner: ^bob_addr, currency: @eth, amount: 7}} = new_utxo1
+    assert {{@blknum1, 0, 1}, %{owner: ^alice_addr, currency: @eth, amount: 3}} = new_utxo2
 
-    assert {:ok, {_, _, [{:put, :block, _}, {:put, :child_top_block_number, @child_block_2}]}, state} =
-             form_block_check(state, @child_block_interval)
+    assert {:ok, {_, _, [{:put, :block, _}, {:put, :child_top_block_number, @blknum2}]}, state} =
+             form_block_check(state)
 
     # check double inputey-spends
     {:ok, {_, _, db_updates2}, state} =
       state
       |> (&Core.exec(
-            Test.create_recovered([{@child_block_interval, 0, 0, bob}, {@child_block_interval, 0, 1, alice}], eth(), [
+            Test.create_recovered([{@blknum1, 0, 0, bob}, {@blknum1, 0, 1, alice}], @eth, [
               {bob, 10}
             ]),
-            zero_fees_map(),
+            @zero_fees_map,
             &1
           )).()
       |> success?
-      |> form_block_check(@child_block_interval)
+      |> form_block_check()
 
     assert [
              {:put, :utxo, new_utxo},
-             {:delete, :utxo, {@child_block_interval, 0, 0}},
+             {:delete, :utxo, {@blknum1, 0, 0}},
              {:put, :spend, {{1000, 0, 0}, 3000}},
-             {:delete, :utxo, {@child_block_interval, 0, 1}},
+             {:delete, :utxo, {@blknum1, 0, 1}},
              {:put, :spend, {{1000, 0, 1}, 3000}},
              {:put, :block, _},
-             {:put, :child_top_block_number, @child_block_3}
+             {:put, :child_top_block_number, @blknum3}
            ] = db_updates2
 
-    assert {{@child_block_3, 0, 0}, %{owner: ^bob_addr, currency: @eth, amount: 10}} = new_utxo
+    assert {{@blknum3, 0, 0}, %{owner: ^bob_addr, currency: @eth, amount: 10}} = new_utxo
 
-    assert {:ok, {_, _, [{:put, :block, _}, {:put, :child_top_block_number, @child_block_4}]}, _} =
-             form_block_check(state, @child_block_interval)
+    assert {:ok, {_, _, [{:put, :block, _}, {:put, :child_top_block_number, @blknum4}]}, _} =
+             form_block_check(state)
   end
 
   @tag fixtures: [:alice, :state_empty]
@@ -500,29 +499,29 @@ defmodule OMG.API.State.CoreTest do
     state_empty: state
   } do
     assert {:ok, {_, [utxo_update, height_update]}, state} =
-             Core.deposit([%{owner: alice.addr, currency: eth(), amount: 10, blknum: 1}], state)
+             Core.deposit([%{owner: alice.addr, currency: @eth, amount: 10, blknum: 1}], state)
 
     assert {:put, :utxo, {{1, 0, 0}, %{owner: ^alice_addr, currency: @eth, amount: 10}}} = utxo_update
     assert height_update == {:put, :last_deposit_child_blknum, 1}
 
-    assert {:ok, {_, _, [{:put, :block, _}, {:put, :child_top_block_number, @child_block_interval}]}, _} =
-             form_block_check(state, @child_block_interval)
+    assert {:ok, {_, _, [{:put, :block, _}, {:put, :child_top_block_number, @blknum1}]}, _} =
+             form_block_check(state)
   end
 
   @tag fixtures: [:alice]
   test "utxos get initialized by query result from db and are spendable", %{alice: alice} do
     {:ok, state} =
       Core.extract_initial_state(
-        [{{1, 0, 0}, %{amount: 10, currency: eth(), owner: alice.addr}}],
+        [{{1, 0, 0}, %{amount: 10, currency: @eth, owner: alice.addr}}],
         0,
         1,
-        @child_block_interval
+        @interval
       )
 
     state
     |> (&Core.exec(
-          Test.create_recovered([{1, 0, 0, alice}], eth(), [{alice, 7}, {alice, 3}]),
-          zero_fees_map(),
+          Test.create_recovered([{1, 0, 0, alice}], @eth, [{alice, 7}, {alice, 3}]),
+          @zero_fees_map,
           &1
         )).()
     |> success?
@@ -533,18 +532,18 @@ defmodule OMG.API.State.CoreTest do
     {:ok, state} =
       Core.extract_initial_state(
         [
-          {{1, 0, 0}, %{amount: 10, currency: eth(), owner: alice.addr}},
-          {{1001, 10, 1}, %{amount: 8, currency: eth(), owner: bob.addr}}
+          {{1, 0, 0}, %{amount: 10, currency: @eth, owner: alice.addr}},
+          {{1001, 10, 1}, %{amount: 8, currency: @eth, owner: bob.addr}}
         ],
         1000,
         1,
-        @child_block_interval
+        @interval
       )
 
     state
     |> (&Core.exec(
-          Test.create_recovered([{1, 0, 0, alice}, {1001, 10, 1, bob}], eth(), [{alice, 15}, {alice, 3}]),
-          zero_fees_map(),
+          Test.create_recovered([{1, 0, 0, alice}, {1001, 10, 1, bob}], @eth, [{alice, 15}, {alice, 3}]),
+          @zero_fees_map,
           &1
         )).()
     |> success?
@@ -555,23 +554,23 @@ defmodule OMG.API.State.CoreTest do
     state =
       state
       |> (&Core.exec(
-            Test.create_recovered([{1, 0, 0, alice}], eth(), [{alice, 7}, {alice, 3}]),
-            zero_fees_map(),
+            Test.create_recovered([{1, 0, 0, alice}], @eth, [{alice, 7}, {alice, 3}]),
+            @zero_fees_map,
             &1
           )).()
       |> success?
 
     expected_owner = alice.addr
 
-    utxo_pos_exit_1 = Utxo.position(@child_block_interval, 0, 0)
-    utxo_pos_exit_2 = Utxo.position(@child_block_interval, 0, 1)
+    utxo_pos_exit_1 = Utxo.position(@blknum1, 0, 0)
+    utxo_pos_exit_2 = Utxo.position(@blknum1, 0, 1)
     utxo_pos_exits = [utxo_pos_exit_1, utxo_pos_exit_2]
 
     assert {:ok,
             {[
                %{exit: %{owner: ^expected_owner, utxo_pos: ^utxo_pos_exit_1}},
                %{exit: %{owner: ^expected_owner, utxo_pos: ^utxo_pos_exit_2}}
-             ], [{:delete, :utxo, {@child_block_interval, 0, 0}}, {:delete, :utxo, {@child_block_interval, 0, 1}}],
+             ], [{:delete, :utxo, {@blknum1, 0, 0}}, {:delete, :utxo, {@blknum1, 0, 1}}],
              {[^utxo_pos_exit_1, ^utxo_pos_exit_2], []}},
             state_after_exit} =
              exit_utxos_response =
@@ -586,15 +585,15 @@ defmodule OMG.API.State.CoreTest do
 
     state_after_exit
     |> (&Core.exec(
-          Test.create_recovered([{@child_block_interval, 0, 0, alice}], eth(), [{alice, 7}]),
-          zero_fees_map(),
+          Test.create_recovered([{@blknum1, 0, 0, alice}], @eth, [{alice, 7}]),
+          @zero_fees_map,
           &1
         )).()
     |> fail?(:utxo_not_found)
     |> same?(state_after_exit)
     |> (&Core.exec(
-          Test.create_recovered([{@child_block_interval, 0, 1, alice}], eth(), [{alice, 3}]),
-          zero_fees_map(),
+          Test.create_recovered([{@blknum1, 0, 1, alice}], @eth, [{alice, 3}]),
+          @zero_fees_map,
           &1
         )).()
     |> fail?(:utxo_not_found)
@@ -603,36 +602,36 @@ defmodule OMG.API.State.CoreTest do
   @tag fixtures: [:alice, :state_alice_deposit]
   test "removed utxo after piggyback from available utxo", %{alice: alice, state_alice_deposit: state} do
     %Transaction.Recovered{tx_hash: tx_hash, signed_tx: %Transaction.Signed{raw_tx: raw_tx}} =
-      tx = Test.create_recovered([{1, 0, 0, alice}], eth(), [{alice, 7}, {alice, 3}])
+      tx = Test.create_recovered([{1, 0, 0, alice}], @eth, [{alice, 7}, {alice, 3}])
 
     state =
       state
-      |> (&Core.exec(tx, zero_fees_map(), &1)).()
+      |> (&Core.exec(tx, @zero_fees_map, &1)).()
       |> success?
 
     expected_owner = alice.addr
     utxo_pos_exits_in_flight = [%{call_data: %{in_flight_tx: Transaction.encode(raw_tx)}}]
     utxo_pos_exits_piggyback = [%{tx_hash: tx_hash, output_index: 4}]
-    expected_position = Utxo.position(@child_block_interval, 0, 0)
+    expected_position = Utxo.position(@blknum1, 0, 0)
 
     assert {:ok, {[], [], {[], _}}, ^state} = Core.exit_utxos(utxo_pos_exits_in_flight, state)
 
     assert {:ok,
             {[%{exit: %{owner: ^expected_owner, utxo_pos: ^expected_position}}],
-             [{:delete, :utxo, {@child_block_interval, 0, 0}}], {[^expected_position], []}},
+             [{:delete, :utxo, {@blknum1, 0, 0}}], {[^expected_position], []}},
             state_after_exit} = Core.exit_utxos(utxo_pos_exits_piggyback, state)
 
     state_after_exit
     |> (&Core.exec(
-          Test.create_recovered([{@child_block_interval, 0, 0, alice}], eth(), [{alice, 7}]),
-          zero_fees_map(),
+          Test.create_recovered([{@blknum1, 0, 0, alice}], @eth, [{alice, 7}]),
+          @zero_fees_map,
           &1
         )).()
     |> fail?(:utxo_not_found)
     |> same?(state_after_exit)
     |> (&Core.exec(
-          Test.create_recovered([{@child_block_interval, 0, 1, alice}], eth(), [{alice, 3}]),
-          zero_fees_map(),
+          Test.create_recovered([{@blknum1, 0, 1, alice}], @eth, [{alice, 3}]),
+          @zero_fees_map,
           &1
         )).()
     |> success?
@@ -642,32 +641,32 @@ defmodule OMG.API.State.CoreTest do
   test "removed inflight intputs from available utxo", %{alice: alice, state_alice_deposit: state} do
     state =
       state
-      |> (&Core.exec(Test.create_recovered([{1, 0, 0, alice}], eth(), [{alice, 7}, {alice, 3}]), zero_fees_map(), &1)).()
+      |> (&Core.exec(Test.create_recovered([{1, 0, 0, alice}], @eth, [{alice, 7}, {alice, 3}]), @zero_fees_map, &1)).()
       |> success?
 
     %Transaction.Recovered{signed_tx: %Transaction.Signed{raw_tx: raw_tx}} =
-      Test.create_recovered([{@child_block_interval, 0, 0, alice}], eth(), [{alice, 3}, {alice, 3}])
+      Test.create_recovered([{@blknum1, 0, 0, alice}], @eth, [{alice, 3}, {alice, 3}])
 
     expected_owner = alice.addr
     utxo_pos_exits_in_flight = [%{call_data: %{in_flight_tx: Transaction.encode(raw_tx)}}]
-    expected_position = Utxo.position(@child_block_interval, 0, 0)
+    expected_position = Utxo.position(@blknum1, 0, 0)
 
     assert {:ok,
             {[%{exit: %{owner: ^expected_owner, utxo_pos: ^expected_position}}],
-             [{:delete, :utxo, {@child_block_interval, 0, 0}}], {[^expected_position], _}},
+             [{:delete, :utxo, {@blknum1, 0, 0}}], {[^expected_position], _}},
             state_after_exit} = Core.exit_utxos(utxo_pos_exits_in_flight, state)
 
     state_after_exit
     |> (&Core.exec(
-          Test.create_recovered([{@child_block_interval, 0, 0, alice}], eth(), [{alice, 7}]),
-          zero_fees_map(),
+          Test.create_recovered([{@blknum1, 0, 0, alice}], @eth, [{alice, 7}]),
+          @zero_fees_map,
           &1
         )).()
     |> fail?(:utxo_not_found)
     |> same?(state_after_exit)
     |> (&Core.exec(
-          Test.create_recovered([{@child_block_interval, 0, 1, alice}], eth(), [{alice, 3}]),
-          zero_fees_map(),
+          Test.create_recovered([{@blknum1, 0, 1, alice}], @eth, [{alice, 3}]),
+          @zero_fees_map,
           &1
         )).()
     |> success?
@@ -675,7 +674,7 @@ defmodule OMG.API.State.CoreTest do
 
   @tag fixtures: [:state_empty]
   test "notifies about invalid utxo exiting", %{state_empty: state} do
-    utxo_pos_exit_1 = Utxo.position(@child_block_interval, 0, 0)
+    utxo_pos_exit_1 = Utxo.position(@blknum1, 0, 0)
 
     assert {:ok, {[], [], {[], [^utxo_pos_exit_1]}}, ^state} = Core.exit_utxos([utxo_pos_exit_1], state)
   end
@@ -684,12 +683,12 @@ defmodule OMG.API.State.CoreTest do
   test "tells if utxo exists", %{alice: alice, state_empty: state} do
     assert not Core.utxo_exists?(Utxo.position(1, 0, 0), state)
 
-    state = state |> Test.do_deposit(alice, %{amount: 10, currency: eth(), blknum: 1})
+    state = state |> Test.do_deposit(alice, %{amount: 10, currency: @eth, blknum: 1})
     assert Core.utxo_exists?(Utxo.position(1, 0, 0), state)
 
     state =
       state
-      |> (&Core.exec(Test.create_recovered([{1, 0, 0, alice}], eth(), [{alice, 10}]), zero_fees_map(), &1)).()
+      |> (&Core.exec(Test.create_recovered([{1, 0, 0, alice}], @eth, [{alice, 10}]), @zero_fees_map, &1)).()
       |> success?
 
     assert not Core.utxo_exists?(Utxo.position(1, 0, 0), state)
@@ -697,23 +696,19 @@ defmodule OMG.API.State.CoreTest do
 
   @tag fixtures: [:state_empty]
   test "Getting current block height on empty state", %{state_empty: state} do
-    {blknum, _} = Core.get_status(state)
-
-    assert blknum == @child_block_interval
+    assert {@blknum1, _} = Core.get_status(state)
   end
 
   @tag fixtures: [:state_empty]
   test "Getting current block height with one formed block", %{state_empty: state} do
-    {:ok, {_, _, _}, new_state} = state |> form_block_check(@child_block_interval)
-    {blknum, true} = Core.get_status(new_state)
-
-    assert blknum == @child_block_interval + @child_block_interval
+    {:ok, {_, _, _}, new_state} = state |> form_block_check()
+    assert {@blknum2, true} = Core.get_status(new_state)
   end
 
   @tag fixtures: [:alice, :state_empty]
   test "is beginning of block changes when transactions executed and block formed",
        %{alice: alice, state_empty: state} do
-    fee = %{eth() => 0}
+    fee = %{@eth => 0}
 
     # at empty state it is at the beginning of the next block
     {_, true} = Core.get_status(state)
@@ -721,13 +716,13 @@ defmodule OMG.API.State.CoreTest do
     # when we execute a tx it isn't at the beginning
     {:ok, _, state} =
       state
-      |> Test.do_deposit(alice, %{amount: 10, currency: eth(), blknum: 1})
-      |> (&Core.exec(Test.create_recovered([{1, 0, 0, alice}], eth(), [{alice, 10}]), fee, &1)).()
+      |> Test.do_deposit(alice, %{amount: 10, currency: @eth, blknum: 1})
+      |> (&Core.exec(Test.create_recovered([{1, 0, 0, alice}], @eth, [{alice, 10}]), fee, &1)).()
 
     {_, false} = Core.get_status(state)
 
     # when a block has been newly formed it is at the beginning
-    {:ok, _, state} = state |> form_block_check(@child_block_interval)
+    {:ok, _, state} = state |> form_block_check()
 
     {_, true} = Core.get_status(state)
   end
@@ -736,69 +731,69 @@ defmodule OMG.API.State.CoreTest do
     @tag fixtures: [:alice, :bob, :state_empty]
     test "Inputs sums up exactly to outputs plus fee", %{alice: alice, bob: bob, state_empty: state} do
       # outputs: 5 + 3 + 2 == 10 <- inputs
-      fee = %{eth() => 2}
+      fee = %{@eth => 2}
 
       state
-      |> Test.do_deposit(alice, %{amount: 10, currency: eth(), blknum: 1})
-      |> (&Core.exec(Test.create_recovered([{1, 0, 0, alice}], eth(), [{bob, 5}, {alice, 3}]), fee, &1)).()
+      |> Test.do_deposit(alice, %{amount: 10, currency: @eth, blknum: 1})
+      |> (&Core.exec(Test.create_recovered([{1, 0, 0, alice}], @eth, [{bob, 5}, {alice, 3}]), fee, &1)).()
       |> success?
     end
 
     @tag fixtures: [:alice, :bob, :state_empty]
     test "Inputs exceeds outputs plus fee", %{alice: alice, bob: bob, state_empty: state} do
       # outputs: 4 + 3 + 2 < 10 <- inputs
-      fee = %{eth() => 2}
+      fee = %{@eth => 2}
 
       state
-      |> Test.do_deposit(alice, %{amount: 10, currency: eth(), blknum: 1})
-      |> (&Core.exec(Test.create_recovered([{1, 0, 0, alice}], eth(), [{bob, 4}, {alice, 3}]), fee, &1)).()
+      |> Test.do_deposit(alice, %{amount: 10, currency: @eth, blknum: 1})
+      |> (&Core.exec(Test.create_recovered([{1, 0, 0, alice}], @eth, [{bob, 4}, {alice, 3}]), fee, &1)).()
       |> success?
     end
 
     @tag fixtures: [:alice, :bob, :state_empty]
     test "Inputs are not sufficient for outputs plus fee", %{alice: alice, bob: bob, state_empty: state} do
       # outputs: 6 + 3 + 2 > 10 <- inputs
-      fee = %{eth() => 2}
+      fee = %{@eth => 2}
 
       state
-      |> Test.do_deposit(alice, %{amount: 10, currency: eth(), blknum: 1})
-      |> (&Core.exec(Test.create_recovered([{1, 0, 0, alice}], eth(), [{bob, 6}, {alice, 3}]), fee, &1)).()
+      |> Test.do_deposit(alice, %{amount: 10, currency: @eth, blknum: 1})
+      |> (&Core.exec(Test.create_recovered([{1, 0, 0, alice}], @eth, [{bob, 6}, {alice, 3}]), fee, &1)).()
       |> fail?(:amounts_do_not_add_up)
     end
   end
 
   @tag fixtures: [:alice, :state_empty]
   test "Output can have a zero value; can't be used as input though", %{alice: alice, state_empty: state} do
-    fee = %{eth() => 0}
+    fee = %{@eth => 0}
 
     state
-    |> Test.do_deposit(alice, %{amount: 10, currency: eth(), blknum: 1})
-    |> (&Core.exec(Test.create_recovered([{1, 0, 0, alice}], eth(), [{alice, 8}, {alice, 0}]), fee, &1)).()
+    |> Test.do_deposit(alice, %{amount: 10, currency: @eth, blknum: 1})
+    |> (&Core.exec(Test.create_recovered([{1, 0, 0, alice}], @eth, [{alice, 8}, {alice, 0}]), fee, &1)).()
     |> success?
-    |> (&Core.exec(Test.create_recovered([{1000, 0, 1, alice}], eth(), [{alice, 0}]), fee, &1)).()
+    |> (&Core.exec(Test.create_recovered([{1000, 0, 1, alice}], @eth, [{alice, 0}]), fee, &1)).()
     |> fail?(:utxo_not_found)
   end
 
   @tag fixtures: [:alice, :state_empty]
   test "Output with zero value does not change oindex of other outputs", %{alice: alice, state_empty: state} do
-    fee = %{eth() => 0}
+    fee = %{@eth => 0}
 
     state
-    |> Test.do_deposit(alice, %{amount: 10, currency: eth(), blknum: 1})
-    |> (&Core.exec(Test.create_recovered([{1, 0, 0, alice}], eth(), [{alice, 0}, {alice, 8}]), fee, &1)).()
+    |> Test.do_deposit(alice, %{amount: 10, currency: @eth, blknum: 1})
+    |> (&Core.exec(Test.create_recovered([{1, 0, 0, alice}], @eth, [{alice, 0}, {alice, 8}]), fee, &1)).()
     |> success?
-    |> (&Core.exec(Test.create_recovered([{1000, 0, 1, alice}], eth(), [{alice, 1}]), fee, &1)).()
+    |> (&Core.exec(Test.create_recovered([{1000, 0, 1, alice}], @eth, [{alice, 1}]), fee, &1)).()
     |> success?
   end
 
   @tag fixtures: [:alice, :state_empty]
   test "Output with zero value will not be written to DB", %{alice: alice, state_empty: state} do
-    fee = %{eth() => 2}
+    fee = %{@eth => 2}
 
     state =
       state
-      |> Test.do_deposit(alice, %{amount: 10, currency: eth(), blknum: 1})
-      |> (&Core.exec(Test.create_recovered([{1, 0, 0, alice}], eth(), [{alice, 0}]), fee, &1)).()
+      |> Test.do_deposit(alice, %{amount: 10, currency: @eth, blknum: 1})
+      |> (&Core.exec(Test.create_recovered([{1, 0, 0, alice}], @eth, [{alice, 0}]), fee, &1)).()
       |> success?
 
     {_, {_, _, db_updates}, _} = Core.form_block(1000, state)
@@ -807,11 +802,11 @@ defmodule OMG.API.State.CoreTest do
 
   @tag fixtures: [:alice, :state_empty]
   test "Transaction can have no outputs", %{alice: alice, state_empty: state} do
-    fee = %{eth() => 2}
+    fee = %{@eth => 2}
 
     state
-    |> Test.do_deposit(alice, %{amount: 10, currency: eth(), blknum: 1})
-    |> (&Core.exec(Test.create_recovered([{1, 0, 0, alice}], eth(), []), fee, &1)).()
+    |> Test.do_deposit(alice, %{amount: 10, currency: @eth, blknum: 1})
+    |> (&Core.exec(Test.create_recovered([{1, 0, 0, alice}], @eth, []), fee, &1)).()
     |> success?
   end
 
@@ -821,15 +816,15 @@ defmodule OMG.API.State.CoreTest do
     bob: bob,
     state_alice_deposit: state
   } do
-    fee = %{eth() => 0}
+    fee = %{@eth => 0}
 
-    future_deposit_blknum = @child_block_interval + 1
-    state = Test.do_deposit(state, alice, %{amount: 10, currency: eth(), blknum: future_deposit_blknum})
+    future_deposit_blknum = @blknum1 + 1
+    state = Test.do_deposit(state, alice, %{amount: 10, currency: @eth, blknum: future_deposit_blknum})
 
     # input utxo blknum is greater than state's blknum
     state
     |> (&Core.exec(
-          Test.create_recovered([{future_deposit_blknum, 0, 0, alice}], eth(), [
+          Test.create_recovered([{future_deposit_blknum, 0, 0, alice}], @eth, [
             {bob, 6},
             {alice, 4}
           ]),
@@ -842,7 +837,7 @@ defmodule OMG.API.State.CoreTest do
     |> (&Core.exec(
           Test.create_recovered(
             [{1, 0, 0, alice}, {future_deposit_blknum, 0, 0, alice}],
-            eth(),
+            @eth,
             [{bob, 6}, {alice, 4}]
           ),
           fee,
@@ -853,7 +848,7 @@ defmodule OMG.API.State.CoreTest do
     # when non-existent input comes with a blknum of the current block fail with :utxo_not_found
     state
     |> (&Core.exec(
-          Test.create_recovered([{@child_block_interval, 1, 0, alice}], eth(), [
+          Test.create_recovered([{@blknum1, 1, 0, alice}], @eth, [
             {bob, 6},
             {alice, 4}
           ]),
@@ -870,11 +865,11 @@ defmodule OMG.API.State.CoreTest do
     state_empty: state
   } do
     state
-    |> Test.do_deposit(alice, %{amount: 1, currency: eth(), blknum: 1})
-    |> Test.do_deposit(alice, %{amount: 2, currency: not_eth(), blknum: 2})
+    |> Test.do_deposit(alice, %{amount: 1, currency: @eth, blknum: 1})
+    |> Test.do_deposit(alice, %{amount: 2, currency: @not_eth, blknum: 2})
     |> (&Core.exec(
-          Test.create_recovered([{1, 0, 0, alice}, {2, 0, 0, alice}], [{bob, eth(), 1}, {bob, not_eth(), 2}]),
-          zero_fees_map(),
+          Test.create_recovered([{1, 0, 0, alice}, {2, 0, 0, alice}], [{bob, @eth, 1}, {bob, @not_eth, 2}]),
+          @zero_fees_map,
           &1
         )).()
     |> success?
@@ -886,17 +881,17 @@ defmodule OMG.API.State.CoreTest do
     bob: bob,
     state_empty: state
   } do
-    fees = %{eth() => 1, not_eth() => 1}
+    fees = %{@eth => 1, @not_eth => 1}
 
     state =
       state
-      |> Test.do_deposit(alice, %{amount: 10, currency: eth(), blknum: 1})
-      |> Test.do_deposit(alice, %{amount: 10, currency: not_eth(), blknum: 2})
+      |> Test.do_deposit(alice, %{amount: 10, currency: @eth, blknum: 1})
+      |> Test.do_deposit(alice, %{amount: 10, currency: @not_eth, blknum: 2})
 
     # fee is paid in the same currency as an output
     state
     |> (&Core.exec(
-          Test.create_recovered([{1, 0, 0, alice}, {2, 0, 0, alice}], [{bob, eth(), 10}, {bob, not_eth(), 1}]),
+          Test.create_recovered([{1, 0, 0, alice}, {2, 0, 0, alice}], [{bob, @eth, 10}, {bob, @not_eth, 1}]),
           fees,
           &1
         )).()
@@ -905,7 +900,7 @@ defmodule OMG.API.State.CoreTest do
     # fee is paid in different currency then outputs
     state
     |> (&Core.exec(
-          Test.create_recovered([{1, 0, 0, alice}, {2, 0, 0, alice}], [{bob, eth(), 9}, {bob, eth(), 1}]),
+          Test.create_recovered([{1, 0, 0, alice}, {2, 0, 0, alice}], [{bob, @eth, 9}, {bob, @eth, 1}]),
           fees,
           &1
         )).()
@@ -914,7 +909,7 @@ defmodule OMG.API.State.CoreTest do
     # fee is respected but amounts don't add up
     state
     |> (&Core.exec(
-          Test.create_recovered([{1, 0, 0, alice}, {2, 0, 0, alice}], [{bob, eth(), 10}, {bob, eth(), 1}]),
+          Test.create_recovered([{1, 0, 0, alice}, {2, 0, 0, alice}], [{bob, @eth, 10}, {bob, @eth, 1}]),
           fees,
           &1
         )).()
@@ -923,7 +918,7 @@ defmodule OMG.API.State.CoreTest do
     # fee is not respected
     state
     |> (&Core.exec(
-          Test.create_recovered([{1, 0, 0, alice}, {2, 0, 0, alice}], [{bob, eth(), 10}, {bob, not_eth(), 10}]),
+          Test.create_recovered([{1, 0, 0, alice}, {2, 0, 0, alice}], [{bob, @eth, 10}, {bob, @not_eth, 10}]),
           fees,
           &1
         )).()
@@ -950,14 +945,14 @@ defmodule OMG.API.State.CoreTest do
     state
   end
 
-  defp empty_block(number \\ @child_block_interval) do
+  defp empty_block(number \\ @blknum1) do
     %Block{transactions: [], hash: @empty_block_hash, number: number}
   end
 
   # used to check the invariants in form_block
   # use this throughout this test module instead of Core.form_block
-  defp form_block_check(state, child_block_interval) do
-    {_, {block, _, db_updates}, _} = result = Core.form_block(child_block_interval, state)
+  defp form_block_check(state) do
+    {_, {block, _, db_updates}, _} = result = Core.form_block(@interval, state)
 
     # check if block returned and sent to db_updates is the same
     assert Enum.member?(db_updates, {:put, :block, block})

--- a/apps/omg_api/test/state/transaction_test.exs
+++ b/apps/omg_api/test/state/transaction_test.exs
@@ -183,7 +183,7 @@ defmodule OMG.API.State.TransactionTest do
   defp assert_tx_usable(signed, state_core) do
     {:ok, transaction} = signed |> Transaction.Signed.encode() |> API.Core.recover_tx()
 
-    assert {:ok, {_, _, _}, _state} = Core.exec(transaction, %{eth() => 0}, state_core)
+    assert {:ok, {_, _, _}, _state} = Core.exec(state_core, transaction, %{eth() => 0})
   end
 
   @tag fixtures: [:alice, :state_empty, :bob]

--- a/apps/omg_watcher/test/block_getter/core_test.exs
+++ b/apps/omg_watcher/test/block_getter/core_test.exs
@@ -112,7 +112,7 @@ defmodule OMG.Watcher.BlockGetter.CoreTest do
              Core.get_blocks_to_apply(state, [%{blknum: block.number, eth_height: synced_height}], synced_height)
 
     # check feasibility of transactions from block to consume at the API.State
-    assert {:ok, tx_result, _} = API.State.Core.exec(tx, fees, state_alice_deposit)
+    assert {:ok, tx_result, _} = API.State.Core.exec(state_alice_deposit, tx, fees)
 
     assert {:ok, ^state} = Core.validate_executions([{:ok, tx_result}], {:ok, []}, block, state)
 


### PR DESCRIPTION
1/ mechanical tidies and readability of `State.CoreTest`
2/ some regrouping of tests

**NOTE** reviewing on a per-commit basis is encouraged, as the mechanical changes (
37d5cba and 
d9e2c72) are separated from the the last more concrete one (1623885)