### PR TITLE
refactor: move all private-key related Crypto to DevCrypto

### DIFF
--- a/apps/omg_api/lib/state/transaction.ex
+++ b/apps/omg_api/lib/state/transaction.ex
@@ -18,7 +18,6 @@ defmodule OMG.API.State.Transaction do
   """
 
   alias OMG.API.Crypto
-  alias OMG.API.State.Transaction.Signed
   alias OMG.API.Utxo
 
   require Utxo
@@ -224,25 +223,6 @@ defmodule OMG.API.State.Transaction do
     |> encode
     |> Crypto.hash()
   end
-
-  @doc """
-    Signs transaction using private keys
-
-    private keys are in the  binary form, e.g.:
-    ```<<54, 43, 207, 67, 140, 160, 190, 135, 18, 162, 70, 120, 36, 245, 106, 165, 5, 101, 183,
-      55, 11, 117, 126, 135, 49, 50, 12, 228, 173, 219, 183, 175>>```
-  """
-  @spec sign(t(), list(Crypto.priv_key_t())) :: Signed.t()
-  def sign(%__MODULE__{} = tx, private_keys) do
-    encoded_tx = encode(tx)
-    sigs = Enum.map(private_keys, fn pk -> signature(encoded_tx, pk) end)
-
-    transaction = %Signed{raw_tx: tx, sigs: sigs}
-    %{transaction | signed_tx_bytes: Signed.encode(transaction)}
-  end
-
-  defp signature(_encoded_tx, <<>>), do: <<0::size(520)>>
-  defp signature(encoded_tx, priv), do: Crypto.signature(encoded_tx, priv)
 
   @doc """
   Returns all input currencies

--- a/apps/omg_api/test/crypto_test.exs
+++ b/apps/omg_api/test/crypto_test.exs
@@ -20,6 +20,7 @@ defmodule OMG.API.CryptoTest do
   """
 
   alias OMG.API.Crypto
+  alias OMG.API.DevCrypto
 
   test "sha3 library usage, address generation" do
     # test vectors below were generated using pyethereum's sha3 and privtoaddr
@@ -27,7 +28,7 @@ defmodule OMG.API.CryptoTest do
     py_priv = "7880aec93413f117ef14bd4e6d130875ab2c7d7d55a064fac3c2f7bd51516380"
     py_pub = "c4d178249d840f548b09ad8269e8a3165ce2c170"
     assert {:ok, ^priv} = Base.decode16(py_priv, case: :lower)
-    {:ok, pub} = Crypto.generate_public_key(priv)
+    {:ok, pub} = DevCrypto.generate_public_key(priv)
     {:ok, address} = Crypto.generate_address(pub)
     assert {:ok, ^address} = Base.decode16(py_pub, case: :lower)
   end
@@ -35,31 +36,31 @@ defmodule OMG.API.CryptoTest do
   test "signature compatibility" do
     msg = Crypto.hash("1234")
     priv = Crypto.hash("11")
-    {:ok, pub} = Crypto.generate_public_key(priv)
+    {:ok, pub} = DevCrypto.generate_public_key(priv)
     {:ok, _} = Crypto.generate_address(pub)
     # this test vector was generated using plasma.utils.utils.sign/2 from plasma-mvp
     py_signature =
       "b8670d619701733e1b4d10149bc90eb4eb276760d2f77a08a5428d4cbf2eadbd656f374c187b1ac80ce31d8c62076af26150e52ef1f33bfc07c6d244da7ca38c1c"
 
-    sig = Crypto.signature_digest(msg, priv)
+    sig = DevCrypto.signature_digest(msg, priv)
     assert ^sig = Base.decode16!(py_signature, case: :lower)
   end
 
   test "digest sign, recover" do
-    {:ok, priv} = Crypto.generate_private_key()
-    {:ok, pub} = Crypto.generate_public_key(priv)
+    {:ok, priv} = DevCrypto.generate_private_key()
+    {:ok, pub} = DevCrypto.generate_public_key(priv)
     {:ok, address} = Crypto.generate_address(pub)
     msg = :crypto.strong_rand_bytes(32)
-    sig = Crypto.signature_digest(msg, priv)
+    sig = DevCrypto.signature_digest(msg, priv)
     assert {:ok, ^address} = Crypto.recover_address(msg, sig)
   end
 
   test "sign, verify" do
-    {:ok, priv} = Crypto.generate_private_key()
-    {:ok, pub} = Crypto.generate_public_key(priv)
+    {:ok, priv} = DevCrypto.generate_private_key()
+    {:ok, pub} = DevCrypto.generate_public_key(priv)
     {:ok, address} = Crypto.generate_address(pub)
 
-    signature = Crypto.signature("message", priv)
+    signature = DevCrypto.signature("message", priv)
     assert byte_size(signature) == 65
     assert {:ok, true} == Crypto.verify("message", signature, address)
     assert {:ok, false} == Crypto.verify("message2", signature, address)

--- a/apps/omg_api/test/integration/happy_path_test.exs
+++ b/apps/omg_api/test/integration/happy_path_test.exs
@@ -22,6 +22,7 @@ defmodule OMG.API.Integration.HappyPathTest do
   use Plug.Test
 
   alias OMG.API.Crypto
+  alias OMG.API.DevCrypto
   alias OMG.API.State.Transaction
   alias OMG.Eth
   alias OMG.RPC.Web.TestHelper
@@ -39,14 +40,14 @@ defmodule OMG.API.Integration.HappyPathTest do
   } do
     raw_tx = Transaction.new([{deposit_blknum, 0, 0}], [{bob.addr, eth(), 7}, {alice.addr, eth(), 3}])
 
-    tx = raw_tx |> Transaction.sign([alice.priv, <<>>]) |> Transaction.Signed.encode()
+    tx = raw_tx |> DevCrypto.sign([alice.priv, <<>>]) |> Transaction.Signed.encode()
 
     # spend the deposit
     {:ok, %{"blknum" => spend_child_block}} = submit_transaction(tx)
 
     token_raw_tx = Transaction.new([{token_deposit_blknum, 0, 0}], [{bob.addr, token, 8}, {alice.addr, token, 2}])
 
-    token_tx = token_raw_tx |> Transaction.sign([alice.priv, <<>>]) |> Transaction.Signed.encode()
+    token_tx = token_raw_tx |> DevCrypto.sign([alice.priv, <<>>]) |> Transaction.Signed.encode()
 
     # spend the token deposit
     assert {:ok, %{"blknum" => spend_token_child_block}} = submit_transaction(token_tx)
@@ -76,7 +77,7 @@ defmodule OMG.API.Integration.HappyPathTest do
     # repeat spending to see if all works
 
     raw_tx2 = Transaction.new([{spend_child_block, 0, 0}, {spend_child_block, 0, 1}], [{alice.addr, eth(), 10}])
-    tx2 = raw_tx2 |> Transaction.sign([bob.priv, alice.priv]) |> Transaction.Signed.encode()
+    tx2 = raw_tx2 |> DevCrypto.sign([bob.priv, alice.priv]) |> Transaction.Signed.encode()
 
     # spend the output of the first tx
     assert {:ok, %{"blknum" => spend_child_block2}} = submit_transaction(tx2)

--- a/apps/omg_api/test/state/transaction_test.exs
+++ b/apps/omg_api/test/state/transaction_test.exs
@@ -18,6 +18,7 @@ defmodule OMG.API.State.TransactionTest do
 
   alias OMG.API
   alias OMG.API.Crypto
+  alias OMG.API.DevCrypto
   alias OMG.API.State.{Core, Transaction}
   alias OMG.API.TestHelper
 
@@ -168,7 +169,7 @@ defmodule OMG.API.State.TransactionTest do
 
     {:ok, raw} = Transaction.create_from_utxos(utxos, [%{owner: bob.addr, currency: eth(), amount: 12}])
 
-    raw |> Transaction.sign([alice.priv, alice.priv]) |> assert_tx_usable(state)
+    raw |> DevCrypto.sign([alice.priv, alice.priv]) |> assert_tx_usable(state)
   end
 
   @tag fixtures: [:alice, :state_alice_deposit, :bob]
@@ -177,7 +178,7 @@ defmodule OMG.API.State.TransactionTest do
 
     {:ok, raw} = Transaction.create_from_utxos(utxos, [%{owner: bob.addr, currency: eth(), amount: 4}])
 
-    raw |> Transaction.sign([alice.priv, <<>>]) |> assert_tx_usable(state)
+    raw |> DevCrypto.sign([alice.priv, <<>>]) |> assert_tx_usable(state)
   end
 
   defp assert_tx_usable(signed, state_core) do
@@ -209,7 +210,7 @@ defmodule OMG.API.State.TransactionTest do
     tx =
       [{3000, 0, 0}, {3000, 0, 1}]
       |> Transaction.new([{alice.addr, eth(), 10}])
-      |> Transaction.sign([bob.priv, alice.priv])
+      |> DevCrypto.sign([bob.priv, alice.priv])
       |> Transaction.Signed.encode()
 
     {:ok, recovered} = tx |> OMG.API.Core.recover_tx()

--- a/apps/omg_api/test/support/crypto.ex
+++ b/apps/omg_api/test/support/crypto.ex
@@ -1,0 +1,83 @@
+# Copyright 2018 OmiseGO Pte Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defmodule OMG.API.DevCrypto do
+  @moduledoc """
+  Non-production crypto code like:
+    - anything that touches private keys
+  """
+
+  alias OMG.API.Crypto
+  alias OMG.API.State.Transaction
+
+  @doc """
+  Generates private key. Internally uses OpenSSL RAND_bytes. May throw if there is not enough entropy.
+  """
+  @spec generate_private_key() :: {:ok, Crypto.priv_key_t()}
+  def generate_private_key, do: {:ok, :crypto.strong_rand_bytes(32)}
+
+  @doc """
+  Given a private key, returns public key.
+  """
+  @spec generate_public_key(Crypto.priv_key_t()) :: {:ok, Crypto.pub_key_t()}
+  def generate_public_key(<<priv::binary-size(32)>>) do
+    {:ok, der_pub} = Blockchain.Transaction.Signature.get_public_key(priv)
+    {:ok, der_to_raw(der_pub)}
+  end
+
+  @doc """
+    Signs transaction using private keys
+
+    private keys are in the  binary form, e.g.:
+    ```<<54, 43, 207, 67, 140, 160, 190, 135, 18, 162, 70, 120, 36, 245, 106, 165, 5, 101, 183,
+      55, 11, 117, 126, 135, 49, 50, 12, 228, 173, 219, 183, 175>>```
+  """
+  @spec sign(Transaction.t(), list(Crypto.priv_key_t())) :: Transaction.Signed.t()
+  def sign(%Transaction{} = tx, private_keys) do
+    encoded_tx = Transaction.encode(tx)
+    sigs = Enum.map(private_keys, fn pk -> signature(encoded_tx, pk) end)
+
+    transaction = %Transaction.Signed{raw_tx: tx, sigs: sigs}
+    %{transaction | signed_tx_bytes: Transaction.Signed.encode(transaction)}
+  end
+
+  @doc """
+  Produces a stand-alone, 65 bytes long, signature for message hash.
+  """
+  @spec signature_digest(<<_::256>>, <<_::256>>) :: <<_::520>>
+  def signature_digest(digest, priv) when is_binary(digest) and byte_size(digest) == 32 do
+    {v, r, s} = Blockchain.Transaction.Signature.sign_hash(digest, priv)
+    pack_signature(v, r, s)
+  end
+
+  @doc """
+  Produces a stand-alone, 65 bytes long, signature for message of arbitrary length.
+  """
+  @spec signature(binary, Crypto.priv_key_t()) :: Crypto.sig_t()
+  def signature(_msg, <<>>), do: <<0::size(520)>>
+  def signature(msg, priv), do: do_signature(msg, priv)
+
+  defp do_signature(msg, priv) do
+    msg
+    |> Crypto.hash()
+    |> signature_digest(priv)
+  end
+
+  # Pack a {v,r,s} signature as 65-bytes binary.
+  defp pack_signature(v, r, s) do
+    <<r::integer-size(256), s::integer-size(256), v::integer-size(8)>>
+  end
+
+  defp der_to_raw(<<4::integer-size(8), data::binary>>), do: data
+end

--- a/apps/omg_api/test/support/test_helper.ex
+++ b/apps/omg_api/test/support/test_helper.ex
@@ -16,6 +16,7 @@ defmodule OMG.API.TestHelper do
   @moduledoc false
 
   alias OMG.API.Crypto
+  alias OMG.API.DevCrypto
   alias OMG.API.State.Core
   alias OMG.API.State.Transaction
 
@@ -57,8 +58,8 @@ defmodule OMG.API.TestHelper do
 
   @spec generate_entity :: entity()
   def generate_entity do
-    {:ok, priv} = Crypto.generate_private_key()
-    {:ok, pub} = Crypto.generate_public_key(priv)
+    {:ok, priv} = DevCrypto.generate_private_key()
+    {:ok, pub} = DevCrypto.generate_public_key(priv)
     {:ok, addr} = Crypto.generate_address(pub)
     %{priv: priv, addr: addr}
   end
@@ -111,7 +112,7 @@ defmodule OMG.API.TestHelper do
       )
 
     privs = get_private_keys(inputs)
-    Transaction.sign(raw_tx, privs)
+    DevCrypto.sign(raw_tx, privs)
   end
 
   defp get_private_keys(inputs) do
@@ -134,7 +135,7 @@ defmodule OMG.API.TestHelper do
       )
 
     privs = get_private_keys(inputs)
-    Transaction.sign(raw_tx, privs)
+    DevCrypto.sign(raw_tx, privs)
   end
 
   def create_encoded(inputs, currency, outputs) do

--- a/apps/omg_performance/lib/sender_server.ex
+++ b/apps/omg_performance/lib/sender_server.ex
@@ -24,6 +24,7 @@ defmodule OMG.Performance.SenderServer do
   use OMG.API.LoggerExt
 
   alias OMG.API.Crypto
+  alias OMG.API.DevCrypto
   alias OMG.API.State.Transaction
   alias OMG.API.TestHelper
   alias OMG.API.Utxo
@@ -124,7 +125,7 @@ defmodule OMG.Performance.SenderServer do
     # create and return signed transaction
     [{last_tx.blknum, last_tx.txindex, last_tx.oindex}]
     |> Transaction.new([{spender.addr, @eth, newamount}, {recipient.addr, @eth, to_spend}])
-    |> Transaction.sign([spender.priv, <<>>])
+    |> DevCrypto.sign([spender.priv, <<>>])
   end
 
   # Submits new transaction to the blockchain server.

--- a/docs/demo_01.md
+++ b/docs/demo_01.md
@@ -13,6 +13,7 @@ Run a developer's Child chain server and start IEx REPL with code and config loa
 
 alias OMG.{API, Eth}
 alias OMG.API.Crypto
+alias OMG.API.DevCrypto
 alias OMG.API.State.Transaction
 alias OMG.API.TestHelper
 alias OMG.API.Integration.DepositHelper
@@ -32,7 +33,7 @@ deposit_blknum = DepositHelper.deposit_to_child_chain(alice.addr, 10)
 # create and prepare transaction for signing
 tx =
   Transaction.new([{deposit_blknum, 0, 0}], [{bob.addr, eth, 7}, {alice.addr, eth, 3}]) |>
-  Transaction.sign([alice.priv, <<>>]) |>
+  DevCrypto.sign([alice.priv, <<>>]) |>
   Transaction.Signed.encode() |>
   OMG.RPC.Web.Encoding.to_hex()
 

--- a/docs/demo_02.md
+++ b/docs/demo_02.md
@@ -17,6 +17,7 @@ Run a developer's Child chain server, Watcher and start IEx REPL with code and c
 
 alias OMG.{API, Eth}
 alias OMG.API.Crypto
+alias OMG.API.DevCrypto
 alias OMG.API.State.Transaction
 alias OMG.API.TestHelper
 alias OMG.API.Integration.DepositHelper
@@ -47,7 +48,7 @@ alice_deposit_blknum = DepositHelper.deposit_to_child_chain(alice.addr, 10)
 # create and prepare transaction for signing
 tx =
   Transaction.new([{alice_deposit_blknum, 0, 0}], [{bob.addr, eth, 7}, {alice.addr, eth, 3}]) |>
-  Transaction.sign([alice.priv, <<>>]) |>
+  DevCrypto.sign([alice.priv, <<>>]) |>
   Transaction.Signed.encode() |>
   OMG.RPC.Web.Encoding.to_hex()
 
@@ -88,7 +89,7 @@ exiting_utxopos = OMG.API.Utxo.Position.encode({:utxo_position, exiting_utxo_blk
 
 tx2 =
   Transaction.new([{exiting_utxo_blknum, 0, 0}], [{bob.addr, eth, 7}]) |>
-  Transaction.sign([bob.priv, <<>>]) |>
+  DevCrypto.sign([bob.priv, <<>>]) |>
   Transaction.Signed.encode() |>
   OMG.RPC.Web.Encoding.to_hex()
 
@@ -140,7 +141,7 @@ r(OMG.API)
 # submit a transaction that will get mined in a new block
 tx3 =
   Transaction.new([{bob_deposit_blknum, 0, 0}], [{bob.addr, eth, 7}, {alice.addr, eth, 3}]) |>
-  Transaction.sign([bob.priv, <<>>]) |>
+  DevCrypto.sign([bob.priv, <<>>]) |>
   Transaction.Signed.encode() |>
   OMG.RPC.Web.Encoding.to_hex()
 
@@ -175,7 +176,7 @@ r(OMG.API.State.Core)
 
 tx4 =
   Transaction.new([{spend_blknum, 0, 0}], [{bob.addr, eth, 7}]) |>
-  Transaction.sign([bob.priv, <<>>]) |>
+  DevCrypto.sign([bob.priv, <<>>]) |>
   Transaction.Signed.encode() |>
   OMG.RPC.Web.Encoding.to_hex()
 

--- a/docs/demo_03.md
+++ b/docs/demo_03.md
@@ -24,6 +24,7 @@ Run `iex -S mix run --no-start --config ~/config.exs` and inside REPL do:
 
 alias OMG.{API, Eth}
 alias OMG.API.Crypto
+alias OMG.API.DevCrypto
 alias OMG.API.TestHelper
 
 {:ok, contract_addr} = Application.fetch_env!(:omg_eth, :contract_addr) |> Crypto.decode_address()

--- a/docs/demo_04.md
+++ b/docs/demo_04.md
@@ -13,6 +13,7 @@ Run a developer's Child chain server, Watcher, and start IEx REPL with code and 
 
 alias OMG.{API, Eth}
 alias OMG.API.Crypto
+alias OMG.API.DevCrypto
 alias OMG.API.State.Transaction
 alias OMG.API.TestHelper
 alias OMG.RPC.Web.Encoding
@@ -33,7 +34,7 @@ deposit_blknum = DepositHelper.deposit_to_child_chain(alice.addr, 10)
 # create and prepare transaction for signing
 tx =
   Transaction.new([{deposit_blknum, 0, 0}], [{bob.addr, eth, 7}, {alice.addr, eth, 3}]) |>
-  Transaction.sign([alice.priv, <<>>]) |>
+  DevCrypto.sign([alice.priv, <<>>]) |>
   Transaction.Signed.encode() |>
   Encoding.to_hex()
 
@@ -48,7 +49,7 @@ tx =
 # create an in-flight transaction that uses tx's output as an input
 in_flight_tx_bytes =
   Transaction.new([{child_tx_block_number, tx_index, 0}], [{alice.addr, eth, 7}]) |>
-  Transaction.sign([bob.priv, <<>>]) |>
+  DevCrypto.sign([bob.priv, <<>>]) |>
   Transaction.Signed.encode() |>
   Encoding.to_hex()
 


### PR DESCRIPTION
I've stumbled upon a TODO and decided to just fix it for good.

This makes sure that no-one ever is tempted to use private keys in `:prod`.