### PR TITLE
OMG-405 fix: workaround by removing optional & broken stop on unchallenged_exit

### DIFF
--- a/apps/omg_watcher/lib/block_getter/core.ex
+++ b/apps/omg_watcher/lib/block_getter/core.ex
@@ -578,8 +578,16 @@ defmodule OMG.Watcher.BlockGetter.Core do
   def consider_exits(%__MODULE__{} = state, {:ok, _}), do: state
 
   def consider_exits(%__MODULE__{} = state, {{:error, :unchallenged_exit} = error, _}) do
-    _ = Logger.warn("Chain invalid when taking exits into account, because of #{inspect(error)}")
-    set_chain_status(state, :error)
+    # NOTE: this is the correct implementation of this function `:unchallenged_exit` should set chain to invalid
+    # _ = Logger.warn("Chain invalid when taking exits into account, because of #{inspect(error)}")
+    # set_chain_status(state, :error)
+    #
+    # this is a temporary implementation, which turns this check off, but still prints a more explanatory warning
+    # revert after OMG-405 is properly fixed. Also:
+    #   - revert (2) test skips to bring back testing that this check is functional
+    #   - remove 1 sanity check that checks that this workaround is applied
+    _ = Logger.warn("#{inspect(error)} spotted, but if syncing, it's probably OK. Check status.get after synced")
+    state
   end
 
   defp add_zero_fee(%Transaction.Recovered{signed_tx: %Transaction.Signed{raw_tx: raw_tx}}, fee_map) do

--- a/apps/omg_watcher/test/block_getter/core_test.exs
+++ b/apps/omg_watcher/test/block_getter/core_test.exs
@@ -299,15 +299,25 @@ defmodule OMG.Watcher.BlockGetter.CoreTest do
     assert {:ok, []} = init_state() |> Core.consider_exits({:ok, [%Event.InvalidExit{}]}) |> Core.chain_ok()
   end
 
+  # temporarily skipped, see comment in Core.consider_exits
+  @tag :skip
   @tag :capture_log
   test "prevents progressing when unchallenged_exit is detected" do
     assert {:error, []} = init_state() |> Core.consider_exits({{:error, :unchallenged_exit}, []}) |> Core.chain_ok()
   end
 
+  # temporarily skipped, see comment in Core.consider_exits
+  @tag :skip
   @tag :capture_log
   test "prevents applying when started with an unchallenged_exit" do
-    state = init_state(exit_processor_results: {{:error, :unchallenged_exit}, []})
-    assert {:error, []} = Core.chain_ok(state)
+    assert {:error, []} = init_state(exit_processor_results: {{:error, :unchallenged_exit}, []}) |> Core.chain_ok()
+  end
+
+  # temporarily _added_ see above
+  @tag :capture_log
+  test "temporarily allows an unchallenged_exit" do
+    assert {:ok, []} = init_state(exit_processor_results: {{:error, :unchallenged_exit}, []}) |> Core.chain_ok()
+    assert {:ok, []} = init_state() |> Core.consider_exits({{:error, :unchallenged_exit}, []}) |> Core.chain_ok()
   end
 
   test "validate_executions function prevent getter from progressing when invalid block is detected" do


### PR DESCRIPTION
workaround for #430 

instead of stopping of the syncing, when an unchallenged_exit is spotted we give a softer warnings

w/ some tests to unskip and remove after OMG_405 (#430) is truly done