### PR TITLE
Omg 329 exit proc persistence test

### DIFF
--- a/apps/omg_api/lib/crypto.ex
+++ b/apps/omg_api/lib/crypto.ex
@@ -28,11 +28,6 @@ defmodule OMG.API.Crypto do
   @type hash_t() :: <<_::256>>
 
   @doc """
-  Returns placeholder for non-existent Ethereum address
-  """
-  def zero_address, do: <<0::160>>
-
-  @doc """
   Produces a cryptographic digest of a message.
   """
   def hash(message), do: message |> ExthCrypto.Hash.hash(ExthCrypto.Hash.kec())

--- a/apps/omg_api/lib/fees.ex
+++ b/apps/omg_api/lib/fees.ex
@@ -115,7 +115,7 @@ defmodule OMG.API.Fees do
   end
 
   @empty_input Utxo.position(0, 0, 0)
-  @empty_output %{owner: Crypto.zero_address(), currency: Crypto.zero_address(), amount: 0}
+  @empty_output %{owner: OMG.Eth.zero_address(), currency: OMG.Eth.RootChain.eth_pseudo_address(), amount: 0}
 
   defp has_same_account?(%Transaction.Recovered{
          signed_tx: %Transaction.Signed{raw_tx: raw_tx},

--- a/apps/omg_api/lib/state/transaction.ex
+++ b/apps/omg_api/lib/state/transaction.ex
@@ -22,7 +22,7 @@ defmodule OMG.API.State.Transaction do
 
   require Utxo
 
-  @zero_address Crypto.zero_address()
+  @zero_address OMG.Eth.zero_address()
   @max_inputs 4
   @max_outputs 4
 

--- a/apps/omg_api/test/api/core_test.exs
+++ b/apps/omg_api/test/api/core_test.exs
@@ -17,14 +17,13 @@ defmodule OMG.API.CoreTest do
   use ExUnit.Case, async: true
 
   alias OMG.API.Core
-  alias OMG.API.Crypto
   alias OMG.API.State.Transaction
   alias OMG.API.TestHelper
 
   @empty_signature <<0::size(520)>>
   @no_owner %{priv: <<>>, addr: nil}
 
-  def eth, do: Crypto.zero_address()
+  def eth, do: OMG.Eth.RootChain.eth_pseudo_address()
 
   @tag fixtures: [:alice, :bob]
   test "signed transaction is valid in all input zeroing combinations", %{

--- a/apps/omg_api/test/block_test.exs
+++ b/apps/omg_api/test/block_test.exs
@@ -21,11 +21,10 @@ defmodule OMG.API.BlockTest do
   use ExUnit.Case, async: true
 
   alias OMG.API.Block
-  alias OMG.API.Crypto
   alias OMG.API.State.Transaction
   alias OMG.API.TestHelper, as: Test
 
-  defp eth, do: Crypto.zero_address()
+  defp eth, do: OMG.Eth.RootChain.eth_pseudo_address()
 
   @tag fixtures: [:stable_alice, :stable_bob]
   test "Block merkle proof smoke test", %{

--- a/apps/omg_api/test/fees_test.exs
+++ b/apps/omg_api/test/fees_test.exs
@@ -21,7 +21,7 @@ defmodule OMG.API.FeesTest do
   import OMG.API.Fees
   import OMG.API.TestHelper
 
-  @eth OMG.API.Crypto.zero_address()
+  @eth OMG.Eth.RootChain.eth_pseudo_address()
   @not_eth <<1::size(160)>>
 
   @fees %{

--- a/apps/omg_api/test/fixtures.exs
+++ b/apps/omg_api/test/fixtures.exs
@@ -15,11 +15,12 @@
 defmodule OMG.API.Fixtures do
   use ExUnitFixtures.FixtureModule
 
-  alias OMG.API.Crypto
   alias OMG.API.State.Core
   alias OMG.Eth
 
   import OMG.API.TestHelper
+
+  @eth OMG.Eth.RootChain.eth_pseudo_address()
 
   deffixture(entities, do: entities())
 
@@ -40,11 +41,11 @@ defmodule OMG.API.Fixtures do
 
   deffixture state_alice_deposit(state_empty, alice) do
     state_empty
-    |> do_deposit(alice, %{amount: 10, currency: Crypto.zero_address(), blknum: 1})
+    |> do_deposit(alice, %{amount: 10, currency: @eth, blknum: 1})
   end
 
   deffixture state_stable_alice_deposit(state_empty, stable_alice) do
     state_empty
-    |> do_deposit(stable_alice, %{amount: 10, currency: Crypto.zero_address(), blknum: 1})
+    |> do_deposit(stable_alice, %{amount: 10, currency: @eth, blknum: 1})
   end
 end

--- a/apps/omg_api/test/integration/fixtures.exs
+++ b/apps/omg_api/test/integration/fixtures.exs
@@ -18,7 +18,6 @@ defmodule OMG.API.Integration.Fixtures do
   use OMG.Eth.Fixtures
   use OMG.DB.Fixtures
 
-  alias OMG.API.Crypto
   alias OMG.API.TestHelper
   alias OMG.Eth
 
@@ -27,7 +26,7 @@ defmodule OMG.API.Integration.Fixtures do
   deffixture fee_file(token) do
     # ensuring that the child chain handles the token (esp. fee-wise)
 
-    enc_eth = Eth.Encoding.to_hex(Crypto.zero_address())
+    enc_eth = Eth.Encoding.to_hex(OMG.Eth.RootChain.eth_pseudo_address())
     {:ok, path} = TestHelper.write_fee_file(%{enc_eth => 0, Eth.Encoding.to_hex(token) => 0})
     default_path = Application.fetch_env!(:omg_api, :fee_specs_file_path)
     Application.put_env(:omg_api, :fee_specs_file_path, path, persistent: true)

--- a/apps/omg_api/test/integration/happy_path_test.exs
+++ b/apps/omg_api/test/integration/happy_path_test.exs
@@ -21,6 +21,7 @@ defmodule OMG.API.Integration.HappyPathTest do
   use ExUnit.Case, async: false
   use Plug.Test
 
+  alias OMG.API
   alias OMG.API.Block
   alias OMG.API.Crypto
   alias OMG.API.DevCrypto
@@ -38,6 +39,7 @@ defmodule OMG.API.Integration.HappyPathTest do
   @moduletag timeout: 120_000
 
   @eth Crypto.zero_address()
+  @interval OMG.Eth.RootChain.get_child_block_interval() |> elem(1)
 
   @tag fixtures: [:alice, :bob, :omg_child_chain, :token, :alice_deposits]
   test "deposit, spend, restart, exit etc works fine", %{
@@ -47,21 +49,16 @@ defmodule OMG.API.Integration.HappyPathTest do
     alice_deposits: {deposit_blknum, token_deposit_blknum}
   } do
     raw_tx = Transaction.new([{deposit_blknum, 0, 0}], [{bob.addr, @eth, 7}, {alice.addr, @eth, 3}])
-
     tx = raw_tx |> DevCrypto.sign([alice.priv, <<>>]) |> Transaction.Signed.encode()
-
     # spend the deposit
-    {:ok, %{"blknum" => spend_child_block}} = submit_transaction(tx)
+    assert {:ok, %{"blknum" => spend_child_block}} = submit_transaction(tx)
 
     token_raw_tx = Transaction.new([{token_deposit_blknum, 0, 0}], [{bob.addr, token, 8}, {alice.addr, token, 2}])
-
     token_tx = token_raw_tx |> DevCrypto.sign([alice.priv, <<>>]) |> Transaction.Signed.encode()
-
     # spend the token deposit
     assert {:ok, %{"blknum" => spend_token_child_block}} = submit_transaction(token_tx)
-    {:ok, child_block_interval} = Eth.RootChain.get_child_block_interval()
 
-    post_spend_child_block = spend_token_child_block + child_block_interval
+    post_spend_child_block = spend_token_child_block + @interval
     {:ok, _} = Eth.DevHelpers.wait_for_next_child_block(post_spend_child_block)
 
     # check if operator is propagating block with hash submitted to RootChain
@@ -70,48 +67,37 @@ defmodule OMG.API.Integration.HappyPathTest do
 
     # NOTE: we are checking only the `hd` because token_tx might possibly be in the next block
     {:ok, decoded_tx_bytes} = transactions |> hd() |> Encoding.from_hex()
+    assert {:ok, %{raw_tx: ^raw_tx}} = Transaction.Signed.decode(decoded_tx_bytes)
 
-    assert {:ok, %{raw_tx: ^raw_tx}} =
-             decoded_tx_bytes
-             |> Transaction.Signed.decode()
-
-    # Restart everything to check persistance and revival
+    # Restart everything to check persistance and revival.
+    # NOTE: this is an integration test of the critical data persistence in the child chain
+    #       See various ...PersistenceTest tests for more detailed tests of persistence behaviors
     [:omg_api, :omg_eth, :omg_db] |> Enum.each(&Application.stop/1)
-
     {:ok, started_apps} = Application.ensure_all_started(:omg_api)
     # sanity check, did-we restart really?
     assert Enum.member?(started_apps, :omg_api)
 
     # repeat spending to see if all works
-
     raw_tx2 = Transaction.new([{spend_child_block, 0, 0}, {spend_child_block, 0, 1}], [{alice.addr, @eth, 10}])
     tx2 = raw_tx2 |> DevCrypto.sign([bob.priv, alice.priv]) |> Transaction.Signed.encode()
-
     # spend the output of the first tx
     assert {:ok, %{"blknum" => spend_child_block2}} = submit_transaction(tx2)
 
-    post_spend_child_block2 = spend_child_block2 + child_block_interval
+    post_spend_child_block2 = spend_child_block2 + @interval
     {:ok, _} = Eth.DevHelpers.wait_for_next_child_block(post_spend_child_block2)
 
     # check if operator is propagating block with hash submitted to RootChain
     {:ok, {block_hash2, _}} = Eth.RootChain.get_child_chain(spend_child_block2)
 
     assert {:ok, %{"transactions" => [transaction2]}} = get_block(block_hash2)
-
     {:ok, decoded_tx2_bytes} = transaction2 |> Encoding.from_hex()
-
-    assert {:ok, %{raw_tx: ^raw_tx2}} =
-             decoded_tx2_bytes
-             |> Transaction.Signed.decode()
+    assert {:ok, %{raw_tx: ^raw_tx2}} = Transaction.Signed.decode(decoded_tx2_bytes)
 
     # sanity checks, mainly persistence & failure responses
     assert {:ok, %{}} = get_block(block_hash)
     assert {:error, %{"code" => "get_block:not_found"}} = get_block(<<0::size(256)>>)
-
     assert {:error, %{"code" => "submit:utxo_not_found"}} = submit_transaction(tx)
-
     assert {:error, %{"code" => "submit:utxo_not_found"}} = submit_transaction(tx2)
-
     assert {:error, %{"code" => "submit:utxo_not_found"}} = submit_transaction(token_tx)
 
     # try to exit from transaction2's output
@@ -134,23 +120,17 @@ defmodule OMG.API.Integration.HappyPathTest do
 
     invalid_raw_tx = Transaction.new([{spend_child_block2, 0, 0}], [{alice.addr, @eth, 10}])
     invalid_tx = invalid_raw_tx |> DevCrypto.sign([alice.priv]) |> Transaction.Signed.encode()
-
     assert {:error, %{"code" => "submit:utxo_not_found"}} = submit_transaction(invalid_tx)
   end
 
   @tag fixtures: [:alice, :omg_child_chain, :alice_deposits]
   test "check that unspent funds can be exited exited with in-flight exits",
        %{alice: alice, alice_deposits: {deposit_blknum, _}} do
-    alias OMG.API
-
     # create transaction, submit, wait for block publication
     tx = API.TestHelper.create_signed([{deposit_blknum, 0, 0, alice}], @eth, [{alice, 5}, {alice, 5}])
-
     {:ok, %{"blknum" => blknum, "txindex" => txindex}} = tx |> Transaction.Signed.encode() |> submit_transaction()
 
-    {:ok, child_block_interval} = Eth.RootChain.get_child_block_interval()
-
-    post_spend_child_block = blknum + child_block_interval
+    post_spend_child_block = blknum + @interval
     {:ok, _} = Eth.DevHelpers.wait_for_next_child_block(post_spend_child_block)
 
     # create transaction & data for in-flight exit, start in-flight exit

--- a/apps/omg_api/test/integration/happy_path_test.exs
+++ b/apps/omg_api/test/integration/happy_path_test.exs
@@ -23,7 +23,6 @@ defmodule OMG.API.Integration.HappyPathTest do
 
   alias OMG.API
   alias OMG.API.Block
-  alias OMG.API.Crypto
   alias OMG.API.DevCrypto
   alias OMG.API.Integration.DepositHelper
   alias OMG.API.State.Transaction
@@ -38,7 +37,7 @@ defmodule OMG.API.Integration.HappyPathTest do
   # bumping the timeout to two minutes for the tests here, as they do a lot of transactions to Ethereum to test
   @moduletag timeout: 120_000
 
-  @eth Crypto.zero_address()
+  @eth OMG.Eth.RootChain.eth_pseudo_address()
   @interval OMG.Eth.RootChain.get_child_block_interval() |> elem(1)
 
   @tag fixtures: [:alice, :bob, :omg_child_chain, :token, :alice_deposits]

--- a/apps/omg_api/test/state/core_test.exs
+++ b/apps/omg_api/test/state/core_test.exs
@@ -21,14 +21,14 @@ defmodule OMG.API.State.CoreTest do
   use ExUnit.Case, async: true
 
   alias OMG.API
-  alias OMG.API.{Block, Crypto, Fees, Utxo}
+  alias OMG.API.{Block, Fees, Utxo}
   alias OMG.API.State.{Core, Transaction}
 
   import OMG.API.TestHelper
 
   require Utxo
 
-  @eth Crypto.zero_address()
+  @eth OMG.Eth.RootChain.eth_pseudo_address()
   @not_eth <<1::size(160)>>
   @zero_fees %{@eth => 0, @not_eth => 0}
   @interval OMG.Eth.RootChain.get_child_block_interval() |> elem(1)

--- a/apps/omg_api/test/state/persistence_test.exs
+++ b/apps/omg_api/test/state/persistence_test.exs
@@ -40,49 +40,37 @@ defmodule OMG.API.State.PersistenceTest do
   @tag fixtures: [:state_empty, :alice]
   test "persists_deposits",
        %{alice: alice, db_pid: db_pid, state_empty: state} do
-    state =
-      state
-      |> persist_deposit([%{owner: alice.addr, currency: @eth, amount: 20, blknum: 2}], db_pid)
-
-    assert state == state_from(db_pid)
+    state
+    |> persist_deposit([%{owner: alice.addr, currency: @eth, amount: 20, blknum: 2}], db_pid)
   end
 
   @tag fixtures: [:alice, :state_empty]
   test "spending produces db updates, that will make the state persist",
        %{alice: alice, db_pid: db_pid, state_empty: state} do
-    state =
-      state
-      |> persist_deposit([%{owner: alice.addr, currency: @eth, amount: 20, blknum: 1}], db_pid)
-      |> exec(create_recovered([{1, 0, 0, alice}], @eth, [{alice, 3}]))
-      |> persist_form(db_pid)
-
-    assert state == state_from(db_pid)
+    state
+    |> persist_deposit([%{owner: alice.addr, currency: @eth, amount: 20, blknum: 1}], db_pid)
+    |> exec(create_recovered([{1, 0, 0, alice}], @eth, [{alice, 3}]))
+    |> persist_form(db_pid)
   end
 
   @tag fixtures: [:alice, :bob, :state_empty]
   test "spending produces db updates, that will make the state persist, for all inputs",
        %{alice: alice, db_pid: db_pid, bob: bob, state_empty: state} do
-    state =
-      state
-      |> persist_deposit([%{owner: alice.addr, currency: @eth, amount: 20, blknum: 1}], db_pid)
-      |> exec(create_recovered([{1, 0, 0, alice}], @eth, [{bob, 7}, {alice, 3}]))
-      |> exec(create_recovered([{@blknum1, 0, 0, bob}, {@blknum1, 0, 1, alice}], @eth, [{bob, 10}]))
-      |> persist_form(db_pid)
-
-    assert state == state_from(db_pid)
+    state
+    |> persist_deposit([%{owner: alice.addr, currency: @eth, amount: 20, blknum: 1}], db_pid)
+    |> exec(create_recovered([{1, 0, 0, alice}], @eth, [{bob, 7}, {alice, 3}]))
+    |> exec(create_recovered([{@blknum1, 0, 0, bob}, {@blknum1, 0, 1, alice}], @eth, [{bob, 10}]))
+    |> persist_form(db_pid)
   end
 
   @tag fixtures: [:alice, :bob, :state_empty]
   test "all utxos get initialized by query result from db",
        %{alice: alice, db_pid: db_pid, bob: bob, state_empty: state} do
-    state =
-      state
-      |> persist_deposit([%{owner: alice.addr, currency: @eth, amount: 20, blknum: 1}], db_pid)
-      |> persist_deposit([%{owner: bob.addr, currency: @eth, amount: 20, blknum: 2}], db_pid)
-      |> exec(create_recovered([{1, 0, 0, alice}], @eth, [{bob, 7}, {alice, 3}]))
-      |> persist_form(db_pid)
-
-    assert state == state_from(db_pid)
+    state
+    |> persist_deposit([%{owner: alice.addr, currency: @eth, amount: 20, blknum: 1}], db_pid)
+    |> persist_deposit([%{owner: bob.addr, currency: @eth, amount: 20, blknum: 2}], db_pid)
+    |> exec(create_recovered([{1, 0, 0, alice}], @eth, [{bob, 7}, {alice, 3}]))
+    |> persist_form(db_pid)
   end
 
   @tag fixtures: [:alice, :state_empty]
@@ -92,14 +80,11 @@ defmodule OMG.API.State.PersistenceTest do
     utxo_pos_exit_2 = Utxo.position(@blknum1, 0, 1)
     utxo_positions = [utxo_pos_exit_1, utxo_pos_exit_2]
 
-    state =
-      state
-      |> persist_deposit([%{owner: alice.addr, currency: @eth, amount: 20, blknum: 1}], db_pid)
-      |> exec(create_recovered([{1, 0, 0, alice}], @eth, [{alice, 3}]))
-      |> persist_form(db_pid)
-      |> persist_exit_utxos(utxo_positions, db_pid)
-
-    assert state == state_from(db_pid)
+    state
+    |> persist_deposit([%{owner: alice.addr, currency: @eth, amount: 20, blknum: 1}], db_pid)
+    |> exec(create_recovered([{1, 0, 0, alice}], @eth, [{alice, 3}]))
+    |> persist_form(db_pid)
+    |> persist_exit_utxos(utxo_positions, db_pid)
   end
 
   @tag fixtures: [:alice, :state_empty]
@@ -111,15 +96,12 @@ defmodule OMG.API.State.PersistenceTest do
     utxo_pos_exits_in_flight = [%{call_data: %{in_flight_tx: Transaction.encode(raw_tx)}}]
     utxo_pos_exits_piggyback = [%{tx_hash: tx_hash, output_index: 4}]
 
-    state =
-      state
-      |> persist_deposit([%{owner: alice.addr, currency: @eth, amount: 20, blknum: 1}], db_pid)
-      |> exec(tx)
-      |> persist_form(db_pid)
-      |> persist_exit_utxos(utxo_pos_exits_in_flight, db_pid)
-      |> persist_exit_utxos(utxo_pos_exits_piggyback, db_pid)
-
-    assert state == state_from(db_pid)
+    state
+    |> persist_deposit([%{owner: alice.addr, currency: @eth, amount: 20, blknum: 1}], db_pid)
+    |> exec(tx)
+    |> persist_form(db_pid)
+    |> persist_exit_utxos(utxo_pos_exits_in_flight, db_pid)
+    |> persist_exit_utxos(utxo_pos_exits_piggyback, db_pid)
   end
 
   @tag fixtures: [:alice, :state_empty]
@@ -129,24 +111,18 @@ defmodule OMG.API.State.PersistenceTest do
 
     utxo_pos_exits_in_flight = [%{call_data: %{in_flight_tx: Transaction.encode(raw_tx)}}]
 
-    state =
-      state
-      |> persist_deposit([%{owner: alice.addr, currency: @eth, amount: 20, blknum: 1}], db_pid)
-      |> persist_exit_utxos(utxo_pos_exits_in_flight, db_pid)
-
-    assert state == state_from(db_pid)
+    state
+    |> persist_deposit([%{owner: alice.addr, currency: @eth, amount: 20, blknum: 1}], db_pid)
+    |> persist_exit_utxos(utxo_pos_exits_in_flight, db_pid)
   end
 
   @tag fixtures: [:alice, :state_empty]
   test "tx with zero outputs will not be written to DB, but other stuff will!",
        %{alice: alice, db_pid: db_pid, state_empty: state} do
-    state =
-      state
-      |> persist_deposit([%{owner: alice.addr, currency: @eth, amount: 20, blknum: 1}], db_pid)
-      |> exec(create_recovered([{1, 0, 0, alice}], @eth, [{alice, 0}]))
-      |> persist_form(db_pid)
-
-    assert state == state_from(db_pid)
+    state
+    |> persist_deposit([%{owner: alice.addr, currency: @eth, amount: 20, blknum: 1}], db_pid)
+    |> exec(create_recovered([{1, 0, 0, alice}], @eth, [{alice, 0}]))
+    |> persist_form(db_pid)
   end
 
   @tag fixtures: [:alice, :state_empty]
@@ -177,37 +153,25 @@ defmodule OMG.API.State.PersistenceTest do
     state
   end
 
-  defp deposit(state, deposits) do
-    {:ok, {_, db_updates}, state} = Core.deposit(deposits, state)
-    {state, db_updates}
+  defp persist_common(state, db_updates, db_pid) do
+    assert :ok = OMG.DB.multi_update(db_updates, db_pid)
+    assert state == state_from(db_pid)
+    state
   end
 
   defp persist_deposit(state, deposits, db_pid) do
-    {state, db_updates} = deposit(state, deposits)
-    assert :ok = OMG.DB.multi_update(db_updates, db_pid)
-    state
-  end
-
-  defp form(state) do
-    {:ok, {_, _, db_updates}, state} = Core.form_block(@interval, state)
-    {state, db_updates}
+    {:ok, {_, db_updates}, state} = Core.deposit(deposits, state)
+    persist_common(state, db_updates, db_pid)
   end
 
   defp persist_form(state, db_pid) do
-    {state, db_updates} = form(state)
-    assert :ok = OMG.DB.multi_update(db_updates, db_pid)
-    state
-  end
-
-  defp exit_utxos(state, utxo_positions) do
-    assert {:ok, {_, db_updates, _}, state} = utxo_positions |> Core.exit_utxos(state)
-    {state, db_updates}
+    {:ok, {_, _, db_updates}, state} = Core.form_block(@interval, state)
+    persist_common(state, db_updates, db_pid)
   end
 
   defp persist_exit_utxos(state, utxo_positions, db_pid) do
-    {state, db_updates} = exit_utxos(state, utxo_positions)
-    assert :ok = OMG.DB.multi_update(db_updates, db_pid)
-    state
+    assert {:ok, {_, db_updates, _}, state} = utxo_positions |> Core.exit_utxos(state)
+    persist_common(state, db_updates, db_pid)
   end
 
   defp exec(state, tx) do

--- a/apps/omg_api/test/state/persistence_test.exs
+++ b/apps/omg_api/test/state/persistence_test.exs
@@ -27,7 +27,7 @@ defmodule OMG.API.State.PersistenceTest do
 
   require Utxo
 
-  @eth OMG.API.Crypto.zero_address()
+  @eth OMG.Eth.RootChain.eth_pseudo_address()
   @not_eth <<1::size(160)>>
   @zero_fees %{@eth => 0, @not_eth => 0}
   @interval OMG.Eth.RootChain.get_child_block_interval() |> elem(1)

--- a/apps/omg_api/test/state/transaction_test.exs
+++ b/apps/omg_api/test/state/transaction_test.exs
@@ -17,10 +17,11 @@ defmodule OMG.API.State.TransactionTest do
   use ExUnit.Case, async: true
 
   alias OMG.API
-  alias OMG.API.Crypto
   alias OMG.API.DevCrypto
   alias OMG.API.State.{Core, Transaction}
   alias OMG.API.TestHelper
+
+  @zero_address OMG.Eth.zero_address()
 
   deffixture transaction do
     Transaction.new(
@@ -33,7 +34,7 @@ defmodule OMG.API.State.TransactionTest do
     [{20, 42, 1}, {2, 21, 0}]
   end
 
-  def eth, do: Crypto.zero_address()
+  def eth, do: OMG.Eth.RootChain.eth_pseudo_address()
 
   @tag fixtures: [:transaction]
   test "transaction hash is correct", %{transaction: transaction} do
@@ -50,7 +51,7 @@ defmodule OMG.API.State.TransactionTest do
              inputs: [%{blknum: 20, txindex: 42, oindex: 1} | List.duplicate(%{blknum: 0, oindex: 0, txindex: 0}, 3)],
              outputs: [
                %{owner: "Joe Black", currency: eth(), amount: 99}
-               | List.duplicate(%{owner: Crypto.zero_address(), currency: eth(), amount: 0}, 3)
+               | List.duplicate(%{owner: @zero_address, currency: eth(), amount: 0}, 3)
              ]
            }
 
@@ -62,7 +63,7 @@ defmodule OMG.API.State.TransactionTest do
              outputs: [
                %{owner: "Joe Black", currency: eth(), amount: 22},
                %{owner: "McDuck", currency: eth(), amount: 21}
-               | List.duplicate(%{owner: Crypto.zero_address(), currency: eth(), amount: 0}, 2)
+               | List.duplicate(%{owner: @zero_address, currency: eth(), amount: 0}, 2)
              ]
            }
 
@@ -77,7 +78,7 @@ defmodule OMG.API.State.TransactionTest do
              outputs: [
                %{owner: "Joe Black", currency: eth(), amount: 53},
                %{owner: "McDuck", currency: eth(), amount: 90}
-               | List.duplicate(%{owner: Crypto.zero_address(), currency: eth(), amount: 0}, 2)
+               | List.duplicate(%{owner: @zero_address, currency: eth(), amount: 0}, 2)
              ]
            }
 
@@ -89,7 +90,7 @@ defmodule OMG.API.State.TransactionTest do
                %{blknum: 20, txindex: 42, oindex: 1},
                %{blknum: 2, txindex: 21, oindex: 0} | List.duplicate(%{blknum: 0, txindex: 0, oindex: 0}, 2)
              ],
-             outputs: List.duplicate(%{owner: Crypto.zero_address(), currency: eth(), amount: 0}, 4)
+             outputs: List.duplicate(%{owner: @zero_address, currency: eth(), amount: 0}, 4)
            }
   end
 

--- a/apps/omg_api/test/support/integration/deposit_helper.ex
+++ b/apps/omg_api/test/support/integration/deposit_helper.ex
@@ -17,11 +17,10 @@ defmodule OMG.API.Integration.DepositHelper do
   Common helper functions that are useful when integration-testing the child chain and watcher requiring deposits
   """
 
-  alias OMG.API.Crypto
   alias OMG.API.State.Transaction
   alias OMG.Eth
 
-  @eth Crypto.zero_address()
+  @eth OMG.Eth.RootChain.eth_pseudo_address()
 
   def deposit_to_child_chain(to, value, token \\ @eth)
 

--- a/apps/omg_db/lib/leveldb_core.ex
+++ b/apps/omg_db/lib/leveldb_core.ex
@@ -38,12 +38,12 @@ defmodule OMG.DB.LevelDBCore do
 
   defp parse_multi_update({:put, :block, %{number: number, hash: hash} = item}) do
     [
-      {:put, key(:block, item), encode_value(:block, item)},
+      {:put, key_for_item(:block, item), encode_value(:block, item)},
       {:put, key(:block_hash, number), encode_value(:block_hash, hash)}
     ]
   end
 
-  defp parse_multi_update({:put, type, item}), do: [{:put, key(type, item), encode_value(type, item)}]
+  defp parse_multi_update({:put, type, item}), do: [{:put, key_for_item(type, item), encode_value(type, item)}]
   defp parse_multi_update({:delete, type, item}), do: [{:delete, key(type, item)}]
 
   defp decode_response(_type, db_response) do
@@ -87,17 +87,6 @@ defmodule OMG.DB.LevelDBCore do
   defp do_filter_keys(keys_stream, prefix),
     do: Stream.filter(keys_stream, fn {key, _} -> String.starts_with?(key, prefix) end)
 
-  def key(:block, %{hash: hash} = _block), do: key(:block, hash)
-  def key(:block, hash) when is_binary(hash), do: @keys_prefixes.block <> hash
-  def key(:utxo, {position, _utxo}), do: key(:utxo, position)
-  def key(:spend, {position, _blknum}), do: key(:spend, position)
-  def key(:exit_info, {position, _exit_info}), do: key(:exit_info, position)
-  def key(:in_flight_exit_info, {position, _info}), do: key(:in_flight_exit_info, position)
-  def key(:competitor_info, {position, _info}), do: key(:competitor_info, position)
-
-  def key(type, item) when type in @key_types,
-    do: Map.get(@keys_prefixes, type) <> :erlang.term_to_binary(item)
-
   @single_value_parameter_names [
     :child_top_block_number,
     :last_deposit_child_blknum,
@@ -117,5 +106,21 @@ defmodule OMG.DB.LevelDBCore do
     :last_ife_exit_finalizer_eth_height
   ]
 
+  @doc """
+  Produces a type-specific LevelDB key for a combination of type and type-agnostic/LevelDB-ignorant key
+  """
+  def key(:block, hash) when is_binary(hash), do: @keys_prefixes.block <> hash
   def key(parameter, _) when parameter in @single_value_parameter_names, do: Atom.to_string(parameter)
+
+  def key(type, specific_key) when type in @key_types,
+    do: Map.get(@keys_prefixes, type) <> :erlang.term_to_binary(specific_key)
+
+  # `key_for_item` gets the type-specific key to persist a whole item at, as used by `:put` updates
+  defp key_for_item(:block, %{hash: hash} = _block), do: key(:block, hash)
+  defp key_for_item(:utxo, {position, _utxo}), do: key(:utxo, position)
+  defp key_for_item(:spend, {position, _blknum}), do: key(:spend, position)
+  defp key_for_item(:exit_info, {position, _exit_info}), do: key(:exit_info, position)
+  defp key_for_item(:in_flight_exit_info, {position, _info}), do: key(:in_flight_exit_info, position)
+  defp key_for_item(:competitor_info, {position, _info}), do: key(:competitor_info, position)
+  defp key_for_item(parameter, value) when parameter in @single_value_parameter_names, do: key(parameter, value)
 end

--- a/apps/omg_db/lib/leveldb_core.ex
+++ b/apps/omg_db/lib/leveldb_core.ex
@@ -92,13 +92,11 @@ defmodule OMG.DB.LevelDBCore do
   def key(:utxo, {position, _utxo}), do: key(:utxo, position)
   def key(:spend, {position, _blknum}), do: key(:spend, position)
   def key(:exit_info, {position, _exit_info}), do: key(:exit_info, position)
+  def key(:in_flight_exit_info, {position, _info}), do: key(:in_flight_exit_info, position)
+  def key(:competitor_info, {position, _info}), do: key(:competitor_info, position)
 
   def key(type, item) when type in @key_types,
     do: Map.get(@keys_prefixes, type) <> :erlang.term_to_binary(item)
-
-  def key(:in_flight_exit_info, position) do
-    "ife" <> :erlang.term_to_binary(position)
-  end
 
   @single_value_parameter_names [
     :child_top_block_number,

--- a/apps/omg_db/test/db_test.exs
+++ b/apps/omg_db/test/db_test.exs
@@ -36,7 +36,7 @@ defmodule OMG.DBTest do
 
     assert {:ok, [%{hash: "wvxyz"}, %{hash: "xyz"}]} == DB.blocks(["wvxyz", "xyz"], pid)
 
-    :ok = DB.multi_update([{:delete, :block, %{hash: "xyz"}}], pid)
+    :ok = DB.multi_update([{:delete, :block, "xyz"}], pid)
 
     checks = fn pid ->
       assert {:ok, [%{hash: "wvxyz"}, :not_found, %{hash: "vxyz"}]} == DB.blocks(["wvxyz", "xyz", "vxyz"], pid)

--- a/apps/omg_eth/lib/eth.ex
+++ b/apps/omg_eth/lib/eth.ex
@@ -43,6 +43,12 @@ defmodule OMG.Eth do
     end
   end
 
+  @doc """
+  Returns placeholder for non-existent Ethereum address
+  """
+  @spec zero_address :: address()
+  def zero_address, do: <<0::160>>
+
   def call_contract(contract, signature, args, return_types) do
     data = signature |> ABI.encode(args)
 

--- a/apps/omg_eth/lib/eth/root_chain.ex
+++ b/apps/omg_eth/lib/eth/root_chain.ex
@@ -208,8 +208,18 @@ defmodule OMG.Eth.RootChain do
   # READING THE CONTRACT #
   ########################
 
+  # some constant-like getters to start
+
   @spec get_child_block_interval :: {:ok, pos_integer} | :error
   def get_child_block_interval, do: Application.fetch_env(:omg_eth, :child_block_interval)
+
+  @doc """
+  This is what the contract understands as the address of native Ether token
+  """
+  @spec eth_pseudo_address :: <<_::160>>
+  def eth_pseudo_address, do: Eth.zero_address()
+
+  # actual READING THE CONTRACT
 
   @doc """
   Returns next blknum that is supposed to be mined by operator

--- a/apps/omg_eth/test/eth_test.exs
+++ b/apps/omg_eth/test/eth_test.exs
@@ -27,7 +27,7 @@ defmodule OMG.EthTest do
   use ExUnitFixtures
   use ExUnit.Case, async: false
 
-  @eth <<0::160>>
+  @eth OMG.Eth.RootChain.eth_pseudo_address()
 
   @moduletag :wrappers
 

--- a/apps/omg_performance/lib/performance.ex
+++ b/apps/omg_performance/lib/performance.ex
@@ -48,7 +48,7 @@ defmodule OMG.Performance do
 
   require Utxo
 
-  @eth Crypto.zero_address()
+  @eth OMG.Eth.RootChain.eth_pseudo_address()
 
   @doc """
   start_simple_perf runs test with {ntx_to_send} tx for each {nspenders} senders with given options.

--- a/apps/omg_performance/lib/sender_server.ex
+++ b/apps/omg_performance/lib/sender_server.ex
@@ -23,7 +23,6 @@ defmodule OMG.Performance.SenderServer do
   use GenServer
   use OMG.API.LoggerExt
 
-  alias OMG.API.Crypto
   alias OMG.API.DevCrypto
   alias OMG.API.State.Transaction
   alias OMG.API.TestHelper
@@ -31,7 +30,7 @@ defmodule OMG.Performance.SenderServer do
 
   require Utxo
 
-  @eth Crypto.zero_address()
+  @eth OMG.Eth.RootChain.eth_pseudo_address()
 
   defmodule LastTx do
     @moduledoc """

--- a/apps/omg_watcher/lib/exit_processor/core.ex
+++ b/apps/omg_watcher/lib/exit_processor/core.ex
@@ -325,15 +325,11 @@ defmodule OMG.Watcher.ExitProcessor.Core do
     ifes_to_update =
       finalizations
       |> Enum.reduce(%{}, fn %{in_flight_exit_id: id}, acc ->
-        with :not_found <-
-               Enum.find(ifes, :not_found, fn {_tx_hash, %InFlightExitInfo{contract_id: contract_id}} ->
-                 id == contract_id
-               end) do
-          acc
-        else
+        Enum.find(ifes, fn {_tx_hash, %InFlightExitInfo{contract_id: contract_id}} -> id == contract_id end)
+        |> case do
+          nil -> acc
           # map by id from contract and mark as not updated
-          {tx_hash, ife} ->
-            %{acc | id => {tx_hash, ife, false}}
+          {tx_hash, ife} -> Map.put(acc, id, {tx_hash, ife, false})
         end
       end)
 

--- a/apps/omg_watcher/lib/exit_processor/core.ex
+++ b/apps/omg_watcher/lib/exit_processor/core.ex
@@ -21,7 +21,6 @@ defmodule OMG.Watcher.ExitProcessor.Core do
   """
 
   alias OMG.API.Block
-  alias OMG.API.Crypto
   alias OMG.API.State.Transaction
   alias OMG.API.Utxo
   require Utxo
@@ -34,7 +33,7 @@ defmodule OMG.Watcher.ExitProcessor.Core do
   alias OMG.Watcher.ExitProcessor.TxAppendix
 
   @default_sla_margin 10
-  @zero_address Crypto.zero_address()
+  @zero_address OMG.Eth.zero_address()
 
   @type tx_hash() :: <<_::32>>
   @type output_offset() :: 0..7
@@ -767,7 +766,7 @@ defmodule OMG.Watcher.ExitProcessor.Core do
   end
 
   defp zero_address?(address) do
-    address != Crypto.zero_address()
+    address != @zero_address
   end
 
   defp get_ife(txbytes, %__MODULE__{in_flight_exits: ifes}) do

--- a/apps/omg_watcher/lib/exit_processor/in_flight_exit_info.ex
+++ b/apps/omg_watcher/lib/exit_processor/in_flight_exit_info.ex
@@ -102,7 +102,7 @@ defmodule OMG.Watcher.ExitProcessor.InFlightExitInfo do
   def piggyback(%__MODULE__{exit_map: exit_map} = ife, index) when index in @exit_map_index_range do
     with exit <- Map.get(exit_map, index),
          {:ok, updated_exit} <- piggyback_exit(exit) do
-      {:ok, %{ife | exit_map: Map.merge(exit_map, %{index => updated_exit})}}
+      {:ok, %{ife | exit_map: Map.put(exit_map, index, updated_exit)}}
     end
   end
 

--- a/apps/omg_watcher/test/block_getter/core_test.exs
+++ b/apps/omg_watcher/test/block_getter/core_test.exs
@@ -20,11 +20,10 @@ defmodule OMG.Watcher.BlockGetter.CoreTest do
 
   alias OMG.API
   alias OMG.API.Block
-  alias OMG.API.Crypto
   alias OMG.Watcher.BlockGetter.Core
   alias OMG.Watcher.Event
 
-  @eth Crypto.zero_address()
+  @eth OMG.Eth.RootChain.eth_pseudo_address()
 
   def assert_check(result, status, value) do
     assert {^status, new_state, ^value} = result

--- a/apps/omg_watcher/test/challenger/core_test.exs
+++ b/apps/omg_watcher/test/challenger/core_test.exs
@@ -27,7 +27,7 @@ defmodule OMG.Watcher.Challenger.CoreTest do
 
   require Utxo
 
-  @eth <<1::160>>
+  @eth OMG.Eth.RootChain.eth_pseudo_address()
 
   defp create_block_with(blknum, txs) do
     %Block{

--- a/apps/omg_watcher/test/db/eth_event_test.exs
+++ b/apps/omg_watcher/test/db/eth_event_test.exs
@@ -17,13 +17,12 @@ defmodule OMG.Watcher.DB.EthEventTest do
   use ExUnit.Case, async: false
   use OMG.API.Fixtures
 
-  alias OMG.API.Crypto
   alias OMG.API.Utxo
   alias OMG.Watcher.DB
 
   require Utxo
 
-  @eth Crypto.zero_address()
+  @eth OMG.Eth.RootChain.eth_pseudo_address()
 
   @tag fixtures: [:phoenix_ecto_sandbox]
   test "insert deposits: creates deposit event and utxo" do

--- a/apps/omg_watcher/test/db/txoutput_test.exs
+++ b/apps/omg_watcher/test/db/txoutput_test.exs
@@ -18,13 +18,12 @@ defmodule OMG.Watcher.DB.TxOutputTest do
   use OMG.API.Fixtures
 
   alias OMG.API
-  alias OMG.API.Crypto
   alias OMG.API.Utxo
   alias OMG.Watcher.DB
 
   require Utxo
 
-  @eth Crypto.zero_address()
+  @eth OMG.Eth.RootChain.eth_pseudo_address()
 
   @tag fixtures: [:initial_blocks]
   test "compose_utxo_exit should return proper proof format" do

--- a/apps/omg_watcher/test/eventer/core_test.exs
+++ b/apps/omg_watcher/test/eventer/core_test.exs
@@ -25,10 +25,12 @@ defmodule OMG.Watcher.Eventer.CoreTest do
   alias OMG.Watcher.Eventer
   alias OMG.Watcher.TestHelper
 
+  @zero_address OMG.Eth.zero_address()
+
   @tag fixtures: [:alice, :bob]
   test "notify function generates 2 proper address_received events", %{alice: alice, bob: bob} do
     recovered_tx =
-      API.TestHelper.create_recovered([{1, 0, 0, alice}, {2, 0, 0, bob}], API.Crypto.zero_address(), [
+      API.TestHelper.create_recovered([{1, 0, 0, alice}, {2, 0, 0, bob}], @zero_address, [
         {alice, 100},
         {bob, 5}
       ])
@@ -51,7 +53,7 @@ defmodule OMG.Watcher.Eventer.CoreTest do
 
   @tag fixtures: [:alice, :bob]
   test "prepare_events function generates 1 proper address_received events", %{alice: alice} do
-    recovered_tx = API.TestHelper.create_recovered([{1, 0, 0, alice}], API.Crypto.zero_address(), [{alice, 100}])
+    recovered_tx = API.TestHelper.create_recovered([{1, 0, 0, alice}], @zero_address, [{alice, 100}])
 
     {:ok, encoded_alice_address} = Crypto.encode_address(alice.addr)
     topic = TestHelper.create_topic("transfer", encoded_alice_address)

--- a/apps/omg_watcher/test/exit_processor/core_test.exs
+++ b/apps/omg_watcher/test/exit_processor/core_test.exs
@@ -41,6 +41,9 @@ defmodule OMG.Watcher.ExitProcessor.CoreTest do
   @utxo_pos1 Utxo.position(1, 0, 0)
   @utxo_pos2 Utxo.position(@late_blknum - 1_000, 0, 1)
 
+  @non_zero_exit_id <<1::192>>
+  @zero_sig <<0::520>>
+
   defp not_included_competitor_pos do
     <<long::256>> =
       List.duplicate(<<255::8>>, 32)
@@ -105,7 +108,7 @@ defmodule OMG.Watcher.ExitProcessor.CoreTest do
   end
 
   deffixture contract_ife_statuses(in_flight_exit_events) do
-    List.duplicate({1, <<1::192>>}, length(in_flight_exit_events))
+    List.duplicate({1, @non_zero_exit_id}, length(in_flight_exit_events))
   end
 
   deffixture ife_tx_hashes(transactions) do
@@ -124,7 +127,7 @@ defmodule OMG.Watcher.ExitProcessor.CoreTest do
         call_data: %{
           competing_tx: Transaction.encode(competing_tx1),
           competing_tx_input_index: 1,
-          competing_tx_sig: <<0::520>>
+          competing_tx_sig: @zero_sig
         }
       },
       %{
@@ -134,7 +137,7 @@ defmodule OMG.Watcher.ExitProcessor.CoreTest do
         call_data: %{
           competing_tx: Transaction.encode(competing_tx2),
           competing_tx_input_index: 1,
-          competing_tx_sig: <<0::520>>
+          competing_tx_sig: @zero_sig
         }
       },
       %{
@@ -572,7 +575,7 @@ defmodule OMG.Watcher.ExitProcessor.CoreTest do
       signature = DevCrypto.sign(tx, [alice.priv]) |> Map.get(:sigs) |> Enum.join()
 
       ife_event = %{call_data: %{in_flight_tx: txbytes, in_flight_tx_sigs: signature}, eth_height: 2}
-      ife_status = {1, <<1::192>>}
+      ife_status = {1, @non_zero_exit_id}
 
       {processor, _} = Core.new_in_flight_exits(processor, [ife_event], [ife_status])
 
@@ -620,7 +623,7 @@ defmodule OMG.Watcher.ExitProcessor.CoreTest do
       signature = DevCrypto.sign(tx, [alice.priv, bob.priv]) |> Map.get(:sigs) |> Enum.join()
 
       ife_event = %{call_data: %{in_flight_tx: txbytes, in_flight_tx_sigs: signature}, eth_height: 2}
-      ife_status = {1, <<1::192>>}
+      ife_status = {1, @non_zero_exit_id}
 
       {processor, _} = Core.new_in_flight_exits(processor, [ife_event], [ife_status])
 
@@ -673,7 +676,7 @@ defmodule OMG.Watcher.ExitProcessor.CoreTest do
       other_signature = DevCrypto.sign(comp3, [alice.priv, alice.priv]) |> Map.get(:sigs) |> Enum.join()
 
       other_ife_event = %{call_data: %{in_flight_tx: other_txbytes, in_flight_tx_sigs: other_signature}, eth_height: 2}
-      other_ife_status = {1, <<1::192>>}
+      other_ife_status = {1, @non_zero_exit_id}
 
       {processor, _} = Core.new_in_flight_exits(processor, [other_ife_event], [other_ife_status])
 
@@ -737,7 +740,7 @@ defmodule OMG.Watcher.ExitProcessor.CoreTest do
       %{sigs: [other_signature, _]} = DevCrypto.sign(tx1, [alice.priv, alice.priv])
 
       other_ife_event = %{call_data: %{in_flight_tx: other_txbytes, in_flight_tx_sigs: other_signature}, eth_height: 2}
-      other_ife_status = {1, <<1::192>>}
+      other_ife_status = {1, @non_zero_exit_id}
 
       {processor, _} = Core.new_in_flight_exits(processor, [other_ife_event], [other_ife_status])
 
@@ -759,7 +762,7 @@ defmodule OMG.Watcher.ExitProcessor.CoreTest do
       %{sigs: [other_signature, _]} = DevCrypto.sign(comp1, [alice.priv, <<>>])
 
       other_ife_event = %{call_data: %{in_flight_tx: other_txbytes, in_flight_tx_sigs: other_signature}, eth_height: 2}
-      other_ife_status = {1, <<1::192>>}
+      other_ife_status = {1, @non_zero_exit_id}
 
       {processor, _} = Core.new_in_flight_exits(processor, [other_ife_event], [other_ife_status])
 
@@ -957,7 +960,7 @@ defmodule OMG.Watcher.ExitProcessor.CoreTest do
         eth_height: 2
       }
 
-      other_ife_status = {1, <<1::192>>}
+      other_ife_status = {1, @non_zero_exit_id}
       {processor, _} = Core.new_in_flight_exits(processor, [other_ife_event], [other_ife_status])
 
       exit_processor_request = %ExitProcessor.Request{
@@ -1022,7 +1025,7 @@ defmodule OMG.Watcher.ExitProcessor.CoreTest do
 
       ife_event = %{call_data: %{in_flight_tx: txbytes, in_flight_tx_sigs: signature}, eth_height: 2}
       # inactive
-      ife_status = {0, <<1::192>>}
+      ife_status = {0, @non_zero_exit_id}
 
       {processor, _} = Core.new_in_flight_exits(processor, [ife_event], [ife_status])
 

--- a/apps/omg_watcher/test/exit_processor/core_test.exs
+++ b/apps/omg_watcher/test/exit_processor/core_test.exs
@@ -21,7 +21,6 @@ defmodule OMG.Watcher.ExitProcessor.CoreTest do
   use OMG.API.Fixtures
 
   alias OMG.API.Block
-  alias OMG.API.Crypto
   alias OMG.API.DevCrypto
   alias OMG.API.State
   alias OMG.API.State.Transaction
@@ -32,8 +31,9 @@ defmodule OMG.Watcher.ExitProcessor.CoreTest do
 
   require Utxo
 
-  @eth Crypto.zero_address()
+  @eth OMG.Eth.RootChain.eth_pseudo_address()
   @not_eth <<1::size(160)>>
+  @zero_address OMG.Eth.zero_address()
 
   @early_blknum 1_000
   @late_blknum 10_000
@@ -204,7 +204,7 @@ defmodule OMG.Watcher.ExitProcessor.CoreTest do
   } do
     {processor, _} =
       processor
-      |> Core.new_exits(events, [{alice, @eth, 10}, {Crypto.zero_address(), @not_eth, 9}])
+      |> Core.new_exits(events, [{alice, @eth, 10}, {@zero_address, @not_eth, 9}])
 
     # exits invalidly finalize and continue/start emitting events and complain
     {:ok, {_, _, two_spend}, state_after_spend} =
@@ -334,7 +334,7 @@ defmodule OMG.Watcher.ExitProcessor.CoreTest do
   } do
     {processor, _} =
       processor
-      |> Core.new_exits([one_exit], [{Crypto.zero_address(), @eth, 10}])
+      |> Core.new_exits([one_exit], [{@zero_address, @eth, 10}])
 
     assert {:ok, []} =
              %ExitProcessor.Request{eth_height_now: 13, blknum_now: @late_blknum}

--- a/apps/omg_watcher/test/exit_processor/persistence_test.exs
+++ b/apps/omg_watcher/test/exit_processor/persistence_test.exs
@@ -1,0 +1,289 @@
+# Copyright 2018 OmiseGO Pte Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defmodule OMG.Watcher.ExitProcessor.PersistenceTest do
+  @moduledoc """
+  Test focused on the persistence bits of `OMG.Watcher.ExitProcessor.Core`.
+
+  The aim of this test is to ensure, that whatever state the processor ends up being in will be revived from the DB
+  """
+
+  use ExUnitFixtures
+  use OMG.DB.Case, async: true
+
+  alias OMG.API.DevCrypto
+  alias OMG.API.State.Transaction
+  alias OMG.API.Utxo
+  alias OMG.Watcher.ExitProcessor.Core
+
+  import OMG.API.TestHelper
+
+  require Utxo
+
+  @eth OMG.API.Crypto.zero_address()
+  @not_eth <<1::size(160)>>
+  @zero_address OMG.API.Crypto.zero_address()
+
+  @early_blknum 1_000
+  @late_blknum 10_000
+
+  @utxo_pos1 Utxo.position(1, 0, 0)
+  @utxo_pos2 Utxo.position(@late_blknum - 1_000, 0, 1)
+
+  setup %{db_pid: db_pid} do
+    :ok = OMG.DB.initiation_multiupdate(db_pid)
+  end
+
+  deffixture processor_empty() do
+    {:ok, empty} = Core.init([], [], [])
+    empty
+  end
+
+  @tag fixtures: [:processor_empty, :alice]
+  test "persist started exits and loads persisted on init, not all exits active",
+       %{processor_empty: processor, alice: alice, db_pid: db_pid} do
+    # FIXME: dry against ExitProcessor.CoreTest? but I don't want to use fixtures here :(...
+    exit_events = [
+      %{amount: 10, currency: @eth, owner: alice.addr, utxo_pos: Utxo.Position.encode(@utxo_pos1), eth_height: 2},
+      %{amount: 9, currency: @not_eth, owner: alice.addr, utxo_pos: Utxo.Position.encode(@utxo_pos2), eth_height: 4},
+      %{amount: 9, currency: @not_eth, owner: alice.addr, utxo_pos: Utxo.Position.encode(@utxo_pos2), eth_height: 4}
+    ]
+
+    contract_statuses = [{alice.addr, @eth, 10}, {@zero_address, @eth, 10}, {alice.addr, @not_eth, 9}]
+
+    processor =
+      processor
+      |> persist_new_exits(exit_events, contract_statuses, db_pid)
+
+    assert processor == state_from(db_pid)
+  end
+
+  @tag fixtures: [:processor_empty, :alice]
+  test "persist finalizations with various validities",
+       %{processor_empty: processor, alice: alice, db_pid: db_pid} do
+    # FIXME: dry against ExitProcessor.CoreTest? but I don't want to use fixtures here :(...
+    exit_events = [
+      %{amount: 10, currency: @eth, owner: alice.addr, utxo_pos: Utxo.Position.encode(@utxo_pos1), eth_height: 2},
+      %{amount: 9, currency: @not_eth, owner: alice.addr, utxo_pos: Utxo.Position.encode(@utxo_pos2), eth_height: 4}
+    ]
+
+    contract_statuses = [{alice.addr, @eth, 10}, {@zero_address, @eth, 10}]
+
+    processor =
+      processor
+      |> persist_new_exits(exit_events, contract_statuses, db_pid)
+      |> persist_finalize_exits({[@utxo_pos1], [@utxo_pos2]}, db_pid)
+
+    assert processor == state_from(db_pid)
+  end
+
+  @tag fixtures: [:processor_empty, :alice]
+  test "persist challenges and challenge responses",
+       %{processor_empty: processor, alice: alice, db_pid: db_pid} do
+    # FIXME: dry against ExitProcessor.CoreTest? but I don't want to use fixtures here :(...
+    exit_events = [
+      %{amount: 10, currency: @eth, owner: alice.addr, utxo_pos: Utxo.Position.encode(@utxo_pos1), eth_height: 2},
+      %{amount: 9, currency: @not_eth, owner: alice.addr, utxo_pos: Utxo.Position.encode(@utxo_pos2), eth_height: 4}
+    ]
+
+    contract_statuses = [{alice.addr, @eth, 10}, {@zero_address, @eth, 10}]
+
+    processor
+    |> persist_new_exits(exit_events, contract_statuses, db_pid)
+    |> persist_challenge_exits([@utxo_pos1], db_pid)
+    # NOTE: this might break when respond_to_in_flight_exits_challenges is actually implemented, it works because noop
+    |> persist_respond_to_in_flight_exits_challenges([@utxo_pos1], db_pid)
+
+    processor
+    |> persist_new_exits(exit_events, contract_statuses, db_pid)
+    |> persist_challenge_exits([@utxo_pos2, @utxo_pos1], db_pid)
+    # NOTE: see above comment
+    |> persist_respond_to_in_flight_exits_challenges([@utxo_pos2, @utxo_pos1], db_pid)
+  end
+
+  @tag fixtures: [:processor_empty, :alice, :carol]
+  test "persist started ifes and loads persisted on init",
+       %{processor_empty: processor, alice: alice, carol: carol, db_pid: db_pid} do
+    # FIXME: dry against ExitProcessor.CoreTest? but I don't want to use fixtures here :(...
+    txs = [
+      Transaction.new([{1, 0, 0}, {1, 2, 1}], [{alice.addr, @eth, 1}]),
+      Transaction.new([{2, 1, 0}, {2, 2, 1}], [{alice.addr, @eth, 1}, {carol.addr, @eth, 2}])
+    ]
+
+    processor =
+      processor
+      |> persist_new_ifes(txs, [[alice.priv], [alice.priv, carol.priv]], db_pid)
+
+    assert processor == state_from(db_pid)
+  end
+
+  @tag fixtures: [:processor_empty, :alice, :carol]
+  test "persist started ifes regardless of status",
+       %{processor_empty: processor, alice: alice, carol: carol, db_pid: db_pid} do
+    # FIXME: dry against ExitProcessor.CoreTest? but I don't want to use fixtures here :(...
+    txs = [
+      Transaction.new([{1, 0, 0}, {1, 2, 1}], [{alice.addr, @eth, 1}]),
+      Transaction.new([{2, 1, 0}, {2, 2, 1}], [{alice.addr, @eth, 1}, {carol.addr, @eth, 2}])
+    ]
+
+    contract_statuses = [{1, <<1::192>>}, {0, <<0::192>>}]
+
+    processor =
+      processor
+      |> persist_new_ifes(txs, [[alice.priv], [alice.priv, carol.priv]], contract_statuses, db_pid)
+
+    assert processor == state_from(db_pid)
+  end
+
+  @tag fixtures: [:processor_empty, :alice]
+  test "persist new challenges, responses and piggybacks",
+       %{processor_empty: processor, alice: alice, db_pid: db_pid} do
+    # FIXME: dry against ExitProcessor.CoreTest? but I don't want to use fixtures here :(...
+    tx = Transaction.new([{2, 1, 0}], [{alice.addr, @eth, 1}, {alice.addr, @eth, 2}])
+    hash = Transaction.hash(tx)
+    competing_tx = Transaction.new([{2, 1, 0}, {1, 0, 0}], [{alice.addr, @eth, 2}, {alice.addr, @eth, 1}])
+
+    challenge = %{
+      tx_hash: hash,
+      # in-flight transaction
+      competitor_position: Utxo.Position.encode(@utxo_pos2),
+      call_data: %{
+        competing_tx: Transaction.encode(competing_tx),
+        competing_tx_input_index: 0,
+        competing_tx_sig: <<0::520>>
+      }
+    }
+
+    piggybacks1 = [%{tx_hash: hash, output_index: 0}, %{tx_hash: hash, output_index: 4}]
+    piggybacks2 = [%{tx_hash: hash, output_index: 5}]
+
+    processor =
+      processor
+      |> persist_new_ifes([tx], [[alice.priv]], db_pid)
+      |> persist_new_piggybacks(piggybacks1, db_pid)
+      |> persist_new_piggybacks(piggybacks2, db_pid)
+      |> persist_new_ife_challenges([challenge], db_pid)
+      |> persist_challenge_piggybacks(piggybacks2, db_pid)
+      |> persist_challenge_piggybacks(piggybacks1, db_pid)
+
+    assert processor == state_from(db_pid)
+  end
+
+  @tag fixtures: [:processor_empty, :alice]
+  test "persist finalizations",
+       %{processor_empty: processor, alice: alice, db_pid: db_pid} do
+    # FIXME: dry against ExitProcessor.CoreTest? but I don't want to use fixtures here :(...
+    tx = Transaction.new([{2, 1, 0}], [{alice.addr, @eth, 1}, {alice.addr, @eth, 2}])
+    hash = Transaction.hash(tx)
+
+    piggybacks1 = [%{tx_hash: hash, output_index: 0}, %{tx_hash: hash, output_index: 4}]
+    piggybacks2 = [%{tx_hash: hash, output_index: 5}]
+
+    processor
+    |> persist_new_ifes([tx], [[alice.priv]], db_pid)
+    |> persist_new_piggybacks(piggybacks1, db_pid)
+    |> persist_new_piggybacks(piggybacks2, db_pid)
+    |> persist_finalize_ifes([%{in_flight_exit_id: <<1::192>>, output_index: 0}], db_pid)
+    |> persist_finalize_ifes(
+      [%{in_flight_exit_id: <<1::192>>, output_index: 4}, %{in_flight_exit_id: <<1::192>>, output_index: 5}],
+      db_pid
+    )
+  end
+
+  # mimics `&OMG.Watcher.ExitProcessor.init/1`
+  defp state_from(db_pid) do
+    {:ok, db_exits} = OMG.DB.exit_infos(db_pid)
+    {:ok, db_ifes} = OMG.DB.in_flight_exits_info(db_pid)
+    {:ok, db_competitors} = OMG.DB.competitors_info(db_pid)
+
+    {:ok, state} = Core.init(db_exits, db_ifes, db_competitors)
+    state
+  end
+
+  defp persist_new_exits(processor, exit_events, contract_statuses, db_pid) do
+    {processor, db_updates} = Core.new_exits(processor, exit_events, contract_statuses)
+    assert :ok = OMG.DB.multi_update(db_updates, db_pid)
+    processor
+  end
+
+  defp persist_finalize_exits(processor, validities, db_pid) do
+    {processor, db_updates} = Core.finalize_exits(processor, validities)
+    assert :ok = OMG.DB.multi_update(db_updates, db_pid)
+    processor
+  end
+
+  defp persist_challenge_exits(processor, utxo_positions, db_pid) do
+    {processor, db_updates} =
+      Core.challenge_exits(processor, utxo_positions |> Enum.map(&%{utxo_pos: Utxo.Position.encode(&1)}))
+
+    assert :ok = OMG.DB.multi_update(db_updates, db_pid)
+    processor
+  end
+
+  defp persist_new_ifes(processor, txs, priv_keys, statuses \\ nil, db_pid) do
+    # FIXME: dry against machinery in CorTest
+    encoded_txs =
+      txs
+      |> Enum.map(&Transaction.encode/1)
+
+    sigs =
+      txs
+      |> Enum.zip(priv_keys)
+      |> Enum.map(fn {tx, keys} -> DevCrypto.sign(tx, keys) end)
+      |> Enum.map(&Enum.join(&1.sigs))
+
+    in_flight_exit_events =
+      Enum.zip(encoded_txs, sigs)
+      |> Enum.map(fn {txbytes, sigs} ->
+        %{call_data: %{in_flight_tx: txbytes, in_flight_tx_sigs: sigs}, eth_height: 2}
+      end)
+
+    statuses = statuses || List.duplicate({1, <<1::192>>}, length(in_flight_exit_events))
+    {processor, db_updates} = Core.new_in_flight_exits(processor, in_flight_exit_events, statuses)
+
+    assert :ok = OMG.DB.multi_update(db_updates, db_pid)
+    processor
+  end
+
+  defp persist_new_piggybacks(processor, piggybacks, db_pid) do
+    {processor, db_updates} = Core.new_piggybacks(processor, piggybacks)
+
+    assert :ok = OMG.DB.multi_update(db_updates, db_pid)
+    processor
+  end
+
+  defp persist_new_ife_challenges(processor, challenges, db_pid) do
+    {processor, db_updates} = Core.new_ife_challenges(processor, challenges)
+
+    assert :ok = OMG.DB.multi_update(db_updates, db_pid)
+    processor
+  end
+
+  defp persist_respond_to_in_flight_exits_challenges(processor, challenges, db_pid) do
+    {processor, db_updates} = Core.respond_to_in_flight_exits_challenges(processor, challenges)
+    persist_common(processor, db_updates, db_pid)
+  end
+
+  defp persist_challenge_piggybacks(processor, piggybacks, db_pid) do
+    {processor, db_updates} = Core.challenge_piggybacks(processor, piggybacks)
+
+    assert :ok = OMG.DB.multi_update(db_updates, db_pid)
+    processor
+  end
+
+  defp persist_finalize_ifes(processor, finalizations, db_pid) do
+    {processor, db_updates} = Core.finalize_in_flight_exits(processor, finalizations)
+    persist_common(processor, db_updates, db_pid)
+  end
+end

--- a/apps/omg_watcher/test/exit_processor/persistence_test.exs
+++ b/apps/omg_watcher/test/exit_processor/persistence_test.exs
@@ -29,9 +29,9 @@ defmodule OMG.Watcher.ExitProcessor.PersistenceTest do
 
   require Utxo
 
-  @eth OMG.API.Crypto.zero_address()
+  @eth OMG.Eth.RootChain.eth_pseudo_address()
   @not_eth <<1::size(160)>>
-  @zero_address OMG.API.Crypto.zero_address()
+  @zero_address OMG.Eth.zero_address()
 
   @utxo_pos1 Utxo.position(1, 0, 0)
   @utxo_pos2 Utxo.position(1_000, 0, 1)

--- a/apps/omg_watcher/test/fixtures.exs
+++ b/apps/omg_watcher/test/fixtures.exs
@@ -28,7 +28,7 @@ defmodule OMG.Watcher.Fixtures do
   alias OMG.Watcher.DB
   alias Watcher.TestHelper
 
-  @eth OMG.API.Crypto.zero_address()
+  @eth OMG.Eth.RootChain.eth_pseudo_address()
 
   deffixture child_chain(contract, fee_file) do
     config_file_path = Briefly.create!(extname: ".exs")

--- a/apps/omg_watcher/test/integration/block_getter_test.exs
+++ b/apps/omg_watcher/test/integration/block_getter_test.exs
@@ -37,7 +37,7 @@ defmodule OMG.Watcher.Integration.BlockGetterTest do
   @moduletag :integration
 
   @timeout 40_000
-  @eth Crypto.zero_address()
+  @eth OMG.Eth.RootChain.eth_pseudo_address()
 
   @endpoint OMG.Watcher.Web.Endpoint
 
@@ -184,7 +184,7 @@ defmodule OMG.Watcher.Integration.BlockGetterTest do
     test_server: context
   } do
     # preparing block with invalid transaction
-    recovered = API.TestHelper.create_recovered([{1, 0, 0, alice}], Crypto.zero_address(), [{alice, 10}])
+    recovered = API.TestHelper.create_recovered([{1, 0, 0, alice}], @eth, [{alice, 10}])
     block_with_incorrect_transaction = API.Block.hashed_txs_at([recovered], 1000)
 
     # from now on the child chain server is broken until end of test

--- a/apps/omg_watcher/test/integration/in_flight_exit_test.exs
+++ b/apps/omg_watcher/test/integration/in_flight_exit_test.exs
@@ -20,14 +20,13 @@ defmodule OMG.Watcher.Integration.InFlightExitTest do
   use Plug.Test
 
   alias OMG.API
-  alias OMG.API.Crypto
   alias OMG.API.State.Transaction
   alias OMG.Eth
   alias OMG.Watcher.Integration.TestHelper, as: IntegrationTest
   alias OMG.Watcher.TestHelper
 
   @timeout 40_000
-  @eth Crypto.zero_address()
+  @eth OMG.Eth.RootChain.eth_pseudo_address()
 
   @moduletag :integration
   # bumping the timeout to two minutes for the tests here, as they do a lot of transactions to Ethereum to test

--- a/apps/omg_watcher/test/integration/invalid_exit_test.exs
+++ b/apps/omg_watcher/test/integration/invalid_exit_test.exs
@@ -32,7 +32,7 @@ defmodule OMG.Watcher.Integration.InvalidExitTest do
   @moduletag :integration
 
   @timeout 40_000
-  @eth API.Crypto.zero_address()
+  @eth OMG.Eth.RootChain.eth_pseudo_address()
 
   @tag fixtures: [:watcher_sandbox, :stable_alice, :child_chain, :token, :stable_alice_deposits]
   test "exit which is using already spent utxo from transaction causes to emit invalid_exit event", %{
@@ -81,7 +81,7 @@ defmodule OMG.Watcher.Integration.InvalidExitTest do
       )
       |> Eth.DevHelpers.transact_sync!()
 
-    assert {:ok, {API.Crypto.zero_address(), @eth, 0}} == Eth.RootChain.get_standard_exit(exit_id)
+    assert {:ok, {OMG.Eth.zero_address(), @eth, 0}} == Eth.RootChain.get_standard_exit(exit_id)
 
     IntegrationTest.wait_for_byzantine_events([], @timeout)
   end

--- a/apps/omg_watcher/test/web/controllers/challenge_test.exs
+++ b/apps/omg_watcher/test/web/controllers/challenge_test.exs
@@ -18,14 +18,13 @@ defmodule OMG.Watcher.Web.Controller.ChallengeTest do
   use OMG.API.Fixtures
 
   alias OMG.API
-  alias OMG.API.Crypto
   alias OMG.API.Utxo
   alias OMG.Watcher.DB
   alias OMG.Watcher.TestHelper
 
   require Utxo
 
-  @eth Crypto.zero_address()
+  @eth OMG.Eth.RootChain.eth_pseudo_address()
 
   @tag skip: true
   @tag fixtures: [:phoenix_ecto_sandbox, :alice]

--- a/apps/omg_watcher/test/web/controllers/in_flight_exit_test.exs
+++ b/apps/omg_watcher/test/web/controllers/in_flight_exit_test.exs
@@ -18,12 +18,11 @@ defmodule OMG.Watcher.Web.Controller.InFlightExitTest do
   use OMG.API.Fixtures
 
   alias OMG.API
-  alias OMG.API.Crypto
   alias OMG.API.State.Transaction
   alias OMG.RPC.Web.Encoding
   alias OMG.Watcher.TestHelper
 
-  @eth Crypto.zero_address()
+  @eth OMG.Eth.RootChain.eth_pseudo_address()
 
   describe "getting in-flight exits" do
     @tag fixtures: [:initial_blocks, :bob, :alice]

--- a/apps/omg_watcher/test/web/controllers/transaction_test.exs
+++ b/apps/omg_watcher/test/web/controllers/transaction_test.exs
@@ -17,13 +17,12 @@ defmodule OMG.Watcher.Web.Controller.TransactionTest do
   use ExUnit.Case, async: false
   use OMG.API.Fixtures
 
-  alias OMG.API.Crypto
   alias OMG.RPC.Web.Encoding
   alias OMG.Watcher.DB
   alias OMG.Watcher.TestHelper
 
-  @eth Crypto.zero_address()
-  @zero_address_hex Crypto.zero_address() |> Encoding.to_hex()
+  @eth OMG.Eth.RootChain.eth_pseudo_address()
+  @zero_address_hex OMG.Eth.zero_address() |> Encoding.to_hex()
 
   describe "getting transaction by id" do
     @tag fixtures: [:blocks_inserter, :initial_deposits, :alice, :bob]

--- a/apps/omg_watcher/test/web/controllers/utxo_test.exs
+++ b/apps/omg_watcher/test/web/controllers/utxo_test.exs
@@ -18,7 +18,6 @@ defmodule OMG.Watcher.Web.Controller.UtxoTest do
   use OMG.API.Fixtures
 
   alias OMG.API
-  alias OMG.API.Crypto
   alias OMG.API.TestHelper
   alias OMG.API.Utxo
   alias OMG.RPC.Web.Encoding
@@ -27,8 +26,8 @@ defmodule OMG.Watcher.Web.Controller.UtxoTest do
 
   require Utxo
 
-  @eth Crypto.zero_address()
-  @eth_hex Crypto.zero_address() |> Encoding.to_hex()
+  @eth OMG.Eth.RootChain.eth_pseudo_address()
+  @eth_hex Encoding.to_hex(@eth)
 
   @tag fixtures: [:initial_blocks, :carol]
   test "no utxos are returned for non-existing addresses", %{carol: carol} do


### PR DESCRIPTION
Covers a lot of our code related to persistence of exits' state with tests.

Also improves the `State.Core` part of the persistence tests and fixes one minor bug in persisting IFEs