### PR TITLE
OMG-239 fix: adjust multiple configuration parameters to match Ari/staging needs

### DIFF
--- a/apps/omg_api/config/config.exs
+++ b/apps/omg_api/config/config.exs
@@ -4,7 +4,9 @@ config :omg_api,
   deposit_finality_margin: 10,
   exiters_finality_margin: 11,
   submission_finality_margin: 20,
-  ethereum_status_check_interval_ms: 6_000,
+  ethereum_events_check_interval_ms: 500,
+  block_queue_eth_height_check_interval_ms: 6_000,
+  coordinator_eth_height_check_interval_ms: 6_000,
   child_block_minimal_enqueue_gap: 1,
   fee_specs_file_path: "./fee_specs.json"
 

--- a/apps/omg_api/config/dev.exs
+++ b/apps/omg_api/config/dev.exs
@@ -2,5 +2,7 @@
 use Mix.Config
 
 config :omg_api,
-  ethereum_status_check_interval_ms: 500,
+  ethereum_events_check_interval_ms: 500,
+  block_queue_eth_height_check_interval_ms: 1_000,
+  coordinator_eth_height_check_interval_ms: 1_000,
   loggers: [Appsignal.Ecto, Ecto.LogEntry]

--- a/apps/omg_api/config/test.exs
+++ b/apps/omg_api/config/test.exs
@@ -3,5 +3,7 @@ use Mix.Config
 config :omg_api,
   deposit_finality_margin: 1,
   exiters_finality_margin: 2,
-  ethereum_status_check_interval_ms: 50,
+  ethereum_events_check_interval_ms: 50,
+  block_queue_eth_height_check_interval_ms: 100,
+  coordinator_eth_height_check_interval_ms: 100,
   fee_specs_file_path: "./../../fee_specs.json"

--- a/apps/omg_api/lib/block_queue.ex
+++ b/apps/omg_api/lib/block_queue.ex
@@ -112,7 +112,7 @@ defmodule OMG.API.BlockQueue do
             other
         end
 
-      interval = Application.fetch_env!(:omg_api, :ethereum_status_check_interval_ms)
+      interval = Application.fetch_env!(:omg_api, :block_queue_eth_height_check_interval_ms)
       {:ok, _} = :timer.send_interval(interval, self(), :check_ethereum_status)
 
       _ = Logger.info("Started BlockQueue")

--- a/apps/omg_api/lib/ethereum_event_listener.ex
+++ b/apps/omg_api/lib/ethereum_event_listener.ex
@@ -113,7 +113,7 @@ defmodule OMG.API.EthereumEventListener do
   end
 
   defp schedule_get_events do
-    Application.fetch_env!(:omg_api, :ethereum_status_check_interval_ms)
+    Application.fetch_env!(:omg_api, :ethereum_events_check_interval_ms)
     |> :timer.send_after(self(), :sync)
   end
 end

--- a/apps/omg_api/lib/root_chain_coordinator.ex
+++ b/apps/omg_api/lib/root_chain_coordinator.ex
@@ -63,8 +63,8 @@ defmodule OMG.API.RootChainCoordinator do
 
   def init(configs_services) do
     {:ok, rootchain_height} = Eth.get_ethereum_height()
-    height_sync_interval = Application.fetch_env!(:omg_api, :ethereum_status_check_interval_ms)
-    {:ok, _} = schedule_get_ethereum_height(height_sync_interval)
+    height_check_interval = Application.fetch_env!(:omg_api, :coordinator_eth_height_check_interval_ms)
+    {:ok, _} = schedule_get_ethereum_height(height_check_interval)
     state = Core.init(configs_services, rootchain_height)
 
     configs_services

--- a/apps/omg_api/mix.exs
+++ b/apps/omg_api/mix.exs
@@ -24,7 +24,9 @@ defmodule OMG.API.MixProject do
         # we need to be just one block after deposits to never miss exits from deposits
         exiters_finality_margin: 11,
         submission_finality_margin: 20,
-        ethereum_status_check_interval_ms: 6_000,
+        ethereum_events_check_interval_ms: 500,
+        block_queue_eth_height_check_interval_ms: 6_000,
+        coordinator_eth_height_check_interval_ms: 6_000,
         child_block_minimal_enqueue_gap: 1
       ],
       # Add Sentry and Appsignal

--- a/apps/omg_api/test/support/integration/deposit_helper.ex
+++ b/apps/omg_api/test/support/integration/deposit_helper.ex
@@ -57,26 +57,10 @@ defmodule OMG.API.Integration.DepositHelper do
   end
 
   defp wait_deposit_recognized(deposit_eth_height) do
-    wait_deposit_finality_margin(deposit_eth_height)
-
-    # sleeping some more, until the deposit is spendable
-    geth_mining_period_ms = 1000
-
-    Process.sleep(geth_mining_period_ms + Application.fetch_env!(:omg_api, :ethereum_status_check_interval_ms) * 3)
-
-    :ok
-  end
-
-  defp wait_deposit_finality_margin(eth_height) do
-    post_event_block_finality = eth_height + Application.fetch_env!(:omg_api, :deposit_finality_margin)
-
-    {:ok, _} = Eth.DevHelpers.wait_for_root_chain_block(post_event_block_finality)
-
+    post_event_block_finality = deposit_eth_height + Application.fetch_env!(:omg_api, :deposit_finality_margin)
+    {:ok, _} = Eth.DevHelpers.wait_for_root_chain_block(post_event_block_finality + 1)
     # sleeping until the deposit is spendable
-    geth_mining_period_ms = 1000
-
-    Process.sleep(geth_mining_period_ms + Application.fetch_env!(:omg_api, :ethereum_status_check_interval_ms) * 3)
-
+    Process.sleep(Application.fetch_env!(:omg_api, :ethereum_events_check_interval_ms) * 2)
     :ok
   end
 end

--- a/apps/omg_watcher/config/config.exs
+++ b/apps/omg_watcher/config/config.exs
@@ -9,8 +9,8 @@ use Mix.Config
 config :omg_watcher,
   namespace: OMG.Watcher,
   ecto_repos: [OMG.Watcher.DB.Repo],
-  # an hour worth of blocks - this is how long the child chain server has to block spends from exiting utxos
-  exit_processor_sla_margin: 4 * 60,
+  # 4 hours worth of blocks - this is how long the child chain server has to block spends from exiting utxos
+  exit_processor_sla_margin: 4 * 4 * 60,
   maximum_block_withholding_time_ms: 1_200_000,
   block_getter_loops_interval_ms: 500,
   maximum_number_of_unapplied_blocks: 50,
@@ -24,6 +24,12 @@ config :omg_watcher, OMG.Watcher.Web.Endpoint,
   secret_key_base: "grt5Ef/y/jpx7AfLmrlUS/nfYJUOq+2e+1xmU4nphTm2x8WB7nLFCJ91atbSBrv5",
   render_errors: [view: OMG.Watcher.Web.View.ErrorView, accepts: ~w(json)],
   pubsub: [name: OMG.Watcher.PubSub, adapter: Phoenix.PubSub.PG2]
+
+config :omg_watcher, OMG.Watcher.DB.Repo,
+  adapter: Ecto.Adapters.Postgres,
+  # NOTE: not sure if appropriate, but this allows reasonable blocks to be written to unoptimized Postgres setup
+  timeout: 60_000,
+  connect_timeout: 60_000
 
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.

--- a/apps/omg_watcher/config/dev.exs
+++ b/apps/omg_watcher/config/dev.exs
@@ -43,13 +43,6 @@ config :phoenix, :stacktrace_depth, 20
 config :omg_watcher, OMG.Watcher.DB.Repo,
   adapter: Ecto.Adapters.Postgres,
   pool_size: 10,
-  timeout: 60_000,
-  connect_timeout: 60_000,
   # DATABASE_URL format is following `postgres://{user_name}:{password}@{host:port}/{database_name}`
   url: {:system, "DATABASE_URL", "postgres://omisego_dev:omisego_dev@localhost/omisego_dev"},
   loggers: [Appsignal.Ecto, Ecto.LogEntry]
-
-config :omg_watcher,
-  exit_processor_sla_margin: 10,
-  maximum_block_withholding_time_ms: 10_000,
-  exit_finality_margin: 4

--- a/apps/omg_watcher/config/prod.exs
+++ b/apps/omg_watcher/config/prod.exs
@@ -23,10 +23,6 @@ config :omg_watcher, OMG.Watcher.Web.Endpoint,
 # Configure your database
 config :omg_watcher, OMG.Watcher.DB.Repo,
   adapter: Ecto.Adapters.Postgres,
-  # NOTE: taken from :dev env, not sure if appropriate, but this allows reasonable blocks to be written to unoptimized
-  #       Postgres setup
-  timeout: 60_000,
-  connect_timeout: 60_000,
   # DATABASE_URL format is following `postgres://{user_name}:{password}@{host:port}/{database_name}`
   url: {:system, "DATABASE_URL"},
   loggers: [Appsignal.Ecto, Ecto.LogEntry]

--- a/apps/omg_watcher/config/test.exs
+++ b/apps/omg_watcher/config/test.exs
@@ -15,6 +15,7 @@ config :omg_watcher, OMG.Watcher.DB.Repo,
 config :omg_watcher,
   # NOTE: can't be made shorter. At 3 it sometimes causes :unchallenged_exit because `geth --dev` is too fast
   exit_processor_sla_margin: 5,
-  maximum_block_withholding_time_ms: 6_000,
   block_getter_loops_interval_ms: 50,
+  # NOTE: must be here - one of our integration tests actually fakes block withholding to test something
+  maximum_block_withholding_time_ms: 1_000,
   exit_finality_margin: 1

--- a/apps/omg_watcher/lib/block_getter/core.ex
+++ b/apps/omg_watcher/lib/block_getter/core.ex
@@ -191,11 +191,7 @@ defmodule OMG.Watcher.BlockGetter.Core do
         eth_height: eth_height,
         eth_height_done: eth_height_done
       }) do
-    _ =
-      Logger.info(
-        "Applied block: ##{inspect(blknum)}, from eth height: #{inspect(eth_height)}, " <>
-          "eth height done?: #{inspect(eth_height_done)}"
-      )
+    _ = Logger.debug("\##{inspect(blknum)}, from: #{inspect(eth_height)}, eth height done: #{inspect(eth_height_done)}")
 
     if eth_height_done do
       # final - we need to mark this eth height as processed
@@ -509,9 +505,11 @@ defmodule OMG.Watcher.BlockGetter.Core do
         _time
       ) do
     _ =
-      Logger.info(fn ->
-        short_hash = returned_hash |> Base.encode16() |> Binary.drop(-48)
-        "Validating block \##{inspect(requested_number)} #{short_hash}... with #{inspect(length(transactions))} txs"
+      Logger.debug(fn ->
+        short_hash = returned_hash |> OMG.Eth.Encoding.to_hex() |> Binary.drop(-48)
+
+        "Validating block \##{inspect(requested_number)} #{inspect(short_hash)}... " <>
+          "with #{inspect(length(transactions))} txs"
       end)
 
     with true <- returned_hash == requested_hash || {:error, :bad_returned_hash},
@@ -527,13 +525,7 @@ defmodule OMG.Watcher.BlockGetter.Core do
   end
 
   def validate_download_response({:error, _} = error, requested_hash, requested_number, _block_timestamp, time) do
-    _ =
-      Logger.info(
-        "Detected potential block withholding  #{inspect(error)}, hash: #{inspect(requested_hash |> Base.encode16())}, number: #{
-          inspect(requested_number)
-        }"
-      )
-
+    _ = Logger.info("Potential block withholding #{inspect(error)}, number: \##{inspect(requested_number)}")
     {:ok, %PotentialWithholdingReport{blknum: requested_number, hash: requested_hash, time: time}}
   end
 

--- a/apps/omg_watcher/lib/db/transaction.ex
+++ b/apps/omg_watcher/lib/db/transaction.ex
@@ -142,7 +142,7 @@ defmodule OMG.Watcher.DB.Transaction do
         ]
       )
 
-    _ = Logger.info("Block ##{block_number} persisted in DB done in #{insert_duration / 1000}ms")
+    _ = Logger.debug("Block \##{block_number} persisted in WatcherDB, done in #{insert_duration / 1000}ms")
 
     result
   end

--- a/apps/omg_watcher/mix.exs
+++ b/apps/omg_watcher/mix.exs
@@ -22,7 +22,7 @@ defmodule OMG.Watcher.Mixfile do
   def application do
     [
       env: [
-        exit_processor_sla_margin: 4 * 60,
+        exit_processor_sla_margin: 4 * 4 * 60,
         maximum_block_withholding_time_ms: 1_200_000,
         block_getter_loops_interval_ms: 500,
         maximum_number_of_unapplied_blocks: 50,

--- a/apps/omg_watcher/test/support/integration/test_helper.ex
+++ b/apps/omg_watcher/test/support/integration/test_helper.ex
@@ -69,7 +69,7 @@ defmodule OMG.Watcher.Integration.TestHelper do
   def wait_for_exit_processing(exit_eth_height, timeout \\ 5_000) do
     exit_finality = Application.fetch_env!(:omg_watcher, :exit_finality_margin) + 1
     Eth.DevHelpers.wait_for_root_chain_block(exit_eth_height + exit_finality, timeout)
-
-    Process.sleep(100)
+    # wait some more to ensure exit is processed
+    Process.sleep(Application.fetch_env!(:omg_api, :ethereum_events_check_interval_ms) * 2)
   end
 end


### PR DESCRIPTION
This mainly consists in fixing `:dev` environment, which our deployments use in a way, that allows them to be more robust, under e.g. invalid exits.

Also significant cleanups to config vars and prettify info level logs a bit