### PR TITLE
refactor: eth_height is delivered in BlockApplication now...

### DIFF
--- a/apps/omg_watcher/lib/block_getter.ex
+++ b/apps/omg_watcher/lib/block_getter.ex
@@ -73,7 +73,7 @@ defmodule OMG.Watcher.BlockGetter do
          {:ok, state} <- Core.validate_executions(tx_exec_results, to_apply, state) do
       _ =
         to_apply
-        |> Core.ensure_block_imported_once(eth_height, state.last_block_persisted_from_prev_run)
+        |> Core.ensure_block_imported_once(state)
         |> Enum.each(&DB.Transaction.update_with/1)
 
       state = run_block_download_task(state)

--- a/apps/omg_watcher/lib/block_getter/core.ex
+++ b/apps/omg_watcher/lib/block_getter/core.ex
@@ -583,8 +583,6 @@ defmodule OMG.Watcher.BlockGetter.Core do
   key constraints on WatcherDB.
   """
   @spec ensure_block_imported_once(BlockApplication.t(), t()) :: [OMG.Watcher.DB.Transaction.mined_block()]
-  def ensure_block_imported_once(block, state)
-
   def ensure_block_imported_once(block, %__MODULE__{last_block_persisted_from_prev_run: last_persisted_block}),
     do: do_ensure_block_imported_once(block, last_persisted_block)
 


### PR DESCRIPTION
so one doesn't need to handle it explicitly in BlockGetter.Core.ensure_block_imported_once