### PR TITLE
alter restart strategy

### DIFF
--- a/apps/omg_api/lib/application.ex
+++ b/apps/omg_api/lib/application.ex
@@ -68,7 +68,7 @@ defmodule OMG.API.Application do
       {OMG.RPC.Web.Endpoint, []}
     ]
 
-    opts = [strategy: :one_for_one]
+    opts = [strategy: :one_for_one, name: __MODULE__, max_restarts: 10000, max_seconds: 60_000]
 
     _ = Logger.info("Starting #{inspect(__MODULE__)}")
     :ok = :error_logger.add_report_handler(Sentry.Logger)


### PR DESCRIPTION
This PR solves the problem when the Ethereum client becomes unreachable. I didn't find any logs of restarts in Kibana though.
The restart intensity gives us roughly 1 minute for the connection to recover.

This is a temporary solution to a different problem. Processes in omg_api are all supervised on the same level and coupled to a connection that's not monitored separately.

So I would suggest a refactor and decoupling to separate hierarchies and in cases when the connection goes offline - I would suspend the API.

