### PR TITLE
Fix: Do not deploy the Watcher until the Childchain is in a "Running" status

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,7 +93,7 @@ jobs:
             docker tag elixir-omg $DOCKER_IMAGE
             docker push jakebunce/elixir-omg:$CIRCLE_SHA1
             kubectl set image statefulset childchain childchain=$DOCKER_IMAGE
-            sleep 120
+            while true; do if [ "$(kubectl get pods childchain-0 -o jsonpath=\"{.status.phase}\" | grep Running)" ]; then break; fi; done
             kubectl set image statefulset watcher watcher=$DOCKER_IMAGE
 
   build_and_deploy_staging:
@@ -132,7 +132,7 @@ jobs:
             docker tag elixir-omg $DOCKER_IMAGE
             docker push jakebunce/elixir-omg:$CIRCLE_SHA1
             kubectl set image statefulset childchain childchain=$DOCKER_IMAGE
-            sleep 120
+            while true; do if [ "$(kubectl get pods childchain-0 -o jsonpath=\"{.status.phase}\" | grep Running)" ]; then break; fi; done
             kubectl set image statefulset watcher watcher=$DOCKER_IMAGE
 
 workflows:


### PR DESCRIPTION
Replaces sleep statements by checking the childchain pod returns the "Running" status from Kubernetes.