### PR TITLE
Idempotent writes of deposits and exits to WatcherDB (postgres)

### DIFF
--- a/apps/omg_watcher/test/db/eth_event_test.exs
+++ b/apps/omg_watcher/test/db/eth_event_test.exs
@@ -92,4 +92,16 @@ defmodule OMG.Watcher.DB.EthEventTest do
     assert %DB.TxOutput{amount: 50, spending_tx_oindex: nil, spending_exit: ^alices_utxo_exit_hash} =
              DB.TxOutput.get_by_position(alices_utxo_pos)
   end
+
+  @tag fixtures: [:alice, :initial_blocks]
+  test "Writes of deposits and exits are idempotent", %{alice: alice} do
+    # try to insert again existing deposit (from initial_blocks)
+    assert [{:ok, _}] = DB.EthEvent.insert_deposits([%{owner: alice.addr, currency: @eth, amount: 333, blknum: 1}])
+
+    assert [{:ok, _}, {:ok, _}] =
+             DB.EthEvent.insert_exits([
+               Utxo.position(1, 0, 0),
+               Utxo.position(1, 0, 0)
+             ])
+  end
 end


### PR DESCRIPTION
First attempt was to create a [Rule On Insert](https://www.postgresql.org/docs/9.1/rules-update.html) but I gave up the idea since EthEvent has association to TxOutput, so there are in fact 2 DB operations.

Idempotent writes is done by simply checking whether record exists in db before write.
There won't be raise condition since deposits/exits are processed sequentially by single process.

I also rejected `Repo.insert_or_update` as it requires fetch the record from DB first, so there will be no gain. 

Closes: #454 