### PR TITLE
Make appsignal report metrics

### DIFF
--- a/apps/omg_rpc/config/config.exs
+++ b/apps/omg_rpc/config/config.exs
@@ -15,7 +15,8 @@ config :omg_rpc, OMG.RPC.Client, child_chain_url: {:system, "CHILD_CHAIN_URL", "
 # Configures the endpoint
 config :omg_rpc, OMG.RPC.Web.Endpoint,
   secret_key_base: "TKO1TD87rXknWy9NhAGiEdv0cXm6W88/8G1E0uV0LISh998yZYNNPRZ5vfEexceb",
-  render_errors: [view: OMG.RPC.Web.ErrorView, accepts: ~w(json)]
+  render_errors: [view: OMG.RPC.Web.ErrorView, accepts: ~w(json)],
+  instrumenters: [Appsignal.Phoenix.Instrumenter]
 
 # Use Poison for JSON parsing in Phoenix
 config :phoenix,

--- a/apps/omg_watcher/config/config.exs
+++ b/apps/omg_watcher/config/config.exs
@@ -23,7 +23,8 @@ config :omg_watcher,
 config :omg_watcher, OMG.Watcher.Web.Endpoint,
   secret_key_base: "grt5Ef/y/jpx7AfLmrlUS/nfYJUOq+2e+1xmU4nphTm2x8WB7nLFCJ91atbSBrv5",
   render_errors: [view: OMG.Watcher.Web.View.ErrorView, accepts: ~w(json)],
-  pubsub: [name: OMG.Watcher.PubSub, adapter: Phoenix.PubSub.PG2]
+  pubsub: [name: OMG.Watcher.PubSub, adapter: Phoenix.PubSub.PG2],
+  instrumenters: [Appsignal.Phoenix.Instrumenter]
 
 config :omg_watcher, OMG.Watcher.DB.Repo,
   adapter: Ecto.Adapters.Postgres,

--- a/config/config.exs
+++ b/config/config.exs
@@ -22,6 +22,6 @@ config :logger, :console,
 config :appsignal, :config,
   name: "OmiseGO Plasma MoreVP Implementation",
   env: Mix.env(),
-  instrumenters: [Appsignal.Phoenix.Instrumenter]
+  active: true
 
 import_config "#{Mix.env()}.exs"


### PR DESCRIPTION
Instrumenters configuration needs to be on the Phoenix level, hope that solves it.
 https://hexdocs.pm/appsignal/Appsignal.Phoenix.Instrumenter.html
The default value for active seems to be `false`.

Hope this makes metrics appear in Appsignal.
