### PR TITLE
fix: fix demos, make default gas/gasprice more affordable in OMG.Eth

### DIFF
--- a/apps/omg_api/test/integration/fixtures.exs
+++ b/apps/omg_api/test/integration/fixtures.exs
@@ -56,18 +56,21 @@ defmodule OMG.API.Integration.Fixtures do
   end
 
   deffixture alice_deposits(alice, token) do
-    deposit(alice, token)
+    prepare_deposits(alice, token)
   end
 
   deffixture stable_alice_deposits(stable_alice, token) do
-    deposit(stable_alice, token)
+    prepare_deposits(stable_alice, token)
   end
 
-  defp deposit(alice, token) do
+  defp prepare_deposits(alice, token_addr) do
+    some_value = 10
+
     {:ok, _} = Eth.DevHelpers.import_unlock_fund(alice)
 
-    deposit_blknum = deposit_to_child_chain(alice.addr, 10)
-    token_deposit_blknum = deposit_to_child_chain(alice.addr, 10, token)
+    deposit_blknum = deposit_to_child_chain(alice.addr, some_value)
+    {:ok, _} = Eth.Token.mint(alice.addr, some_value, token_addr) |> Eth.DevHelpers.transact_sync!()
+    token_deposit_blknum = deposit_to_child_chain(alice.addr, some_value, token_addr)
 
     {deposit_blknum, token_deposit_blknum}
   end

--- a/apps/omg_api/test/support/integration/deposit_helper.ex
+++ b/apps/omg_api/test/support/integration/deposit_helper.ex
@@ -37,8 +37,7 @@ defmodule OMG.API.Integration.DepositHelper do
   def deposit_to_child_chain(to, value, token_addr) when is_binary(token_addr) and byte_size(token_addr) == 20 do
     contract_addr = Eth.Encoding.from_hex(Application.fetch_env!(:omg_eth, :contract_addr))
 
-    to |> Eth.Token.mint(value, token_addr) |> Eth.DevHelpers.transact_sync!()
-    to |> Eth.Token.approve(contract_addr, value, token_addr) |> Eth.DevHelpers.transact_sync!()
+    {:ok, _} = Eth.Token.approve(to, contract_addr, value, token_addr) |> Eth.DevHelpers.transact_sync!()
 
     {:ok, receipt} =
       Transaction.new([], [{to, token_addr, value}])

--- a/apps/omg_eth/lib/eth/defaults.ex
+++ b/apps/omg_eth/lib/eth/defaults.ex
@@ -23,7 +23,7 @@ defmodule OMG.Eth.Defaults do
 
   # safe, reasonable amount, equal to the testnet block gas limit
   @lots_of_gas 5_712_388
-  @gas_price 20_000_000_000
+  @gas_price 1_000_000_000
 
   def tx_defaults do
     [value: 0, gasPrice: @gas_price, gas: @lots_of_gas]

--- a/apps/omg_eth/lib/eth/root_chain.ex
+++ b/apps/omg_eth/lib/eth/root_chain.ex
@@ -32,11 +32,15 @@ defmodule OMG.Eth.RootChain do
 
   @type optional_addr_t() :: <<_::160>> | nil
 
+  @gas_add_token 500_000
   @gas_start_exit 1_000_000
   @gas_challenge_exit 300_000
   @gas_deposit 180_000
   @gas_deposit_from 250_000
   @gas_init 1_000_000
+  @gas_start_in_flight_exit 2_000_000
+  @gas_challenge_in_flight_exit_not_canonical 1_000_000
+  @gas_respond_to_non_canonical_challenge 1_000_000
   @standard_exit_bond 31_415_926_535
   @piggyback_bond 31_415_926_535
 
@@ -113,7 +117,7 @@ defmodule OMG.Eth.RootChain do
   end
 
   def add_token(token, contract \\ nil, opts \\ []) do
-    opts = @tx_defaults |> Keyword.merge(opts)
+    opts = @tx_defaults |> Keyword.put(:gas, @gas_add_token) |> Keyword.merge(opts)
 
     contract = contract || from_hex(Application.fetch_env!(:omg_eth, :contract_addr))
     {:ok, [from | _]} = Ethereumex.HttpClient.eth_accounts()
@@ -150,7 +154,11 @@ defmodule OMG.Eth.RootChain do
         contract \\ nil,
         opts \\ []
       ) do
-    defaults = @tx_defaults |> Keyword.put(:value, @standard_exit_bond)
+    defaults =
+      @tx_defaults
+      |> Keyword.put(:value, @standard_exit_bond)
+      |> Keyword.put(:gas, @gas_start_in_flight_exit)
+
     opts = defaults |> Keyword.merge(opts)
 
     contract = contract || from_hex(Application.fetch_env!(:omg_eth, :contract_addr))
@@ -172,7 +180,7 @@ defmodule OMG.Eth.RootChain do
         contract \\ nil,
         opts \\ []
       ) do
-    defaults = @tx_defaults
+    defaults = @tx_defaults |> Keyword.put(:gas, @gas_challenge_in_flight_exit_not_canonical)
     opts = defaults |> Keyword.merge(opts)
 
     contract = contract || from_hex(Application.fetch_env!(:omg_eth, :contract_addr))
@@ -199,7 +207,7 @@ defmodule OMG.Eth.RootChain do
         contract \\ nil,
         opts \\ []
       ) do
-    defaults = @tx_defaults
+    defaults = @tx_defaults |> Keyword.put(:gas, @gas_respond_to_non_canonical_challenge)
     opts = defaults |> Keyword.merge(opts)
 
     contract = contract || from_hex(Application.fetch_env!(:omg_eth, :contract_addr))

--- a/apps/omg_eth/lib/eth/token.ex
+++ b/apps/omg_eth/lib/eth/token.ex
@@ -23,25 +23,27 @@ defmodule OMG.Eth.Token do
 
   @tx_defaults Eth.Defaults.tx_defaults()
 
+  @gas_token_ops 80_000
+
   ##########
   # writes #
   ##########
 
   def mint(owner, amount, token, opts \\ []) do
-    opts = @tx_defaults |> Keyword.merge(opts)
+    opts = @tx_defaults |> Keyword.put(:gas, @gas_token_ops) |> Keyword.merge(opts)
 
     {:ok, [from | _]} = Ethereumex.HttpClient.eth_accounts()
     Eth.contract_transact(from_hex(from), token, "mint(address,uint256)", [owner, amount], opts)
   end
 
   def transfer(from, owner, amount, token, opts \\ []) do
-    opts = @tx_defaults |> Keyword.merge(opts)
+    opts = @tx_defaults |> Keyword.put(:gas, @gas_token_ops) |> Keyword.merge(opts)
 
     Eth.contract_transact(from, token, "transfer(address,uint256)", [owner, amount], opts)
   end
 
   def approve(from, spender, amount, token, opts \\ []) do
-    opts = @tx_defaults |> Keyword.merge(opts)
+    opts = @tx_defaults |> Keyword.put(:gas, @gas_token_ops) |> Keyword.merge(opts)
 
     Eth.contract_transact(from, token, "approve(address,uint256)", [spender, amount], opts)
   end

--- a/docs/demo_01.md
+++ b/docs/demo_01.md
@@ -20,7 +20,7 @@ alias OMG.API.Integration.DepositHelper
 
 alice = TestHelper.generate_entity()
 bob = TestHelper.generate_entity()
-eth = OMG.Eth.zero_address()
+eth = Eth.RootChain.eth_pseudo_address()
 
 {:ok, _} = Eth.DevHelpers.import_unlock_fund(alice)
 

--- a/docs/demo_02.md
+++ b/docs/demo_02.md
@@ -21,10 +21,11 @@ alias OMG.API.DevCrypto
 alias OMG.API.State.Transaction
 alias OMG.API.TestHelper
 alias OMG.API.Integration.DepositHelper
+alias OMG.Eth.Encoding
 
 alice = TestHelper.generate_entity()
 bob = TestHelper.generate_entity()
-eth = OMG.Eth.zero_address()
+eth = Eth.RootChain.eth_pseudo_address()
 
 alice_enc = Crypto.encode_address!(alice.addr)
 bob_enc = Crypto.encode_address!(bob.addr)
@@ -98,13 +99,11 @@ tx2 =
 :os.cmd() |>
 Poison.decode!()
 
-{:ok, txbytes} = OMG.RPC.Web.Encoding.from_hex(composed_exit["txbytes"])
-{:ok, proof} = OMG.RPC.Web.Encoding.from_hex(composed_exit["proof"])
 {:ok, txhash} =
   Eth.RootChain.start_exit(
     composed_exit["utxo_pos"],
-    txbytes,
-    proof,
+    composed_exit["txbytes"] |> Encoding.from_hex(),
+    composed_exit["proof"] |> Encoding.from_hex(),
     bob.addr
   )
 Eth.WaitFor.eth_receipt(txhash)
@@ -115,14 +114,12 @@ Eth.WaitFor.eth_receipt(txhash)
   :os.cmd() |>
   Poison.decode!()
 
-{:ok, txbytes} = OMG.RPC.Web.Encoding.from_hex(challenge["txbytes"])
-{:ok, sig} = OMG.RPC.Web.Encoding.from_hex(challenge["sig"])
 {:ok, txhash} =
   OMG.Eth.RootChain.challenge_exit(
     challenge["exit_id"],
-    txbytes,
+    challenge["txbytes"] |> Encoding.from_hex(),
     challenge["input_index"],
-    sig,
+    challenge["sig"] |> Encoding.from_hex(),
     alice.addr
   )
 {:ok, %{"status" => "0x1"}} = Eth.WaitFor.eth_receipt(txhash)

--- a/docs/demo_04.md
+++ b/docs/demo_04.md
@@ -21,7 +21,7 @@ alias OMG.Eth.Encoding
 
 alice = TestHelper.generate_entity()
 bob = TestHelper.generate_entity()
-eth = OMG.Eth.zero_address()
+eth = Eth.RootChain.eth_pseudo_address()
 
 {:ok, alice_enc} = Eth.DevHelpers.import_unlock_fund(alice)
 


### PR DESCRIPTION
A small patch fixing some stuff that made using our Eth helpers hard on Rinkeby, where Eth isn't that abundant as in `geth --dev`.

Mainly, all our `Eth.Contract.do_sth` calls have a reasonable gas default, instead of `lots_of_gas`