### PR TITLE
feature: gather VM metrics and forward to AppSignal

### DIFF
--- a/apps/omg_status/.gitignore
+++ b/apps/omg_status/.gitignore
@@ -1,0 +1,17 @@
+# The directory Mix will write compiled artifacts to.
+/_build
+
+# If you run "mix test --cover", coverage assets end up here.
+/cover
+
+# The directory Mix downloads your dependencies sources to.
+/deps
+
+# Where 3rd-party dependencies like ExDoc output generated docs.
+/doc
+
+# If the VM crashes, it generates a dump, let's ignore it too.
+erl_crash.dump
+
+# Also ignore archive artifacts (built via "mix archive.build").
+*.ez

--- a/apps/omg_status/README.md
+++ b/apps/omg_status/README.md
@@ -1,3 +1,2 @@
 # Status
-Status is a Distributed OTP application. It's purpose is to gather
-cache metrics and system wide applications.
+Status is a umbrella application. It's purpose is to gather and send metrics.

--- a/apps/omg_status/README.md
+++ b/apps/omg_status/README.md
@@ -1,0 +1,3 @@
+# Status
+Status is a Distributed OTP application. It's purpose is to gather
+cache metrics and system wide applications.

--- a/apps/omg_status/config/config.exs
+++ b/apps/omg_status/config/config.exs
@@ -1,0 +1,1 @@
+use Mix.Config

--- a/apps/omg_status/config/config.exs
+++ b/apps/omg_status/config/config.exs
@@ -1,1 +1,4 @@
 use Mix.Config
+
+config :omg_status,
+  metrics: true

--- a/apps/omg_status/lib/status.ex
+++ b/apps/omg_status/lib/status.ex
@@ -1,4 +1,4 @@
-# Copyright 2018 OmiseGO Pte Ltd
+# Copyright 2019 OmiseGO Pte Ltd
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/apps/omg_status/lib/status.ex
+++ b/apps/omg_status/lib/status.ex
@@ -39,12 +39,12 @@ defmodule OMG.Status do
 
   defp do_vm_metrics(true) do
     memory =
-      for n <- ~w(total processes ets binary atom atom_used)a,
-          do: {String.to_atom("erlang_memory_#{n}"), fn -> :erlang.memory(n) end}
+      for type <- ~w(total processes ets binary atom atom_used)a,
+          do: {String.to_atom("erlang_memory_#{type}"), fn -> :erlang.memory(type) end}
 
     system_info =
-      for n <- ~w(schedulers atom_count process_count port_count)a,
-          do: {String.to_atom("erlang_system_info_#{n}"), fn -> :erlang.system_info(n) end}
+      for type <- ~w(schedulers atom_count process_count port_count)a,
+          do: {String.to_atom("erlang_system_info_#{type}"), fn -> :erlang.system_info(type) end}
 
     other = [
       {:erlang_uptime, fn -> :erlang.statistics(:wall_clock) |> elem(0) |> Kernel.div(1000) end},

--- a/apps/omg_status/lib/status.ex
+++ b/apps/omg_status/lib/status.ex
@@ -1,40 +1,76 @@
+# Copyright 2018 OmiseGO Pte Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 defmodule OMG.Status do
+  @moduledoc """
+  Top level application module.
+  """
   use Application
-  #  alias OMG.Status.Alert.AlarmHandler
   alias Status.Metric.Recorder
 
   def start(_type, _args) do
     import Supervisor.Spec, warn: false
 
-    children =
-      [
-        {:erlang_schedulers, fn -> :erlang.system_info(:schedulers) end},
-        {:erlang_uptime, fn -> :erlang.statistics(:wall_clock) |> elem(0) |> Kernel.div(1000) end},
-        {:erlang_io_input_kb,
-         fn ->
-           {{:input, input}, {:output, _output}} = :erlang.statistics(:io)
-           input |> Kernel.div(1024)
-         end},
-        {:erlang_io_output_kb,
-         fn ->
-           {{:input, _input}, {:output, output}} = :erlang.statistics(:io)
-           output |> Kernel.div(1024)
-         end},
-        {:erlang_total_run_queue_lengths, fn -> :erlang.statistics(:total_run_queue_lengths) end},
-        {:erlang_atom_count, fn -> :erlang.system_info(:atom_count) end},
-        {:erlang_process_count, fn -> :erlang.system_info(:process_count) end},
-        {:erlang_port_count, fn -> :erlang.system_info(:port_count) end},
-        {:erlang_ets_count, fn -> length(:ets.all()) end}
-      ]
-      |> Enum.map(fn {name, invoke} ->
-        Recorder.prepare_child(%Recorder{
-          name: name,
-          fn: invoke,
-          reporter: &Appsignal.set_gauge/2
-        })
-      end)
+    Enum.map(vm_metrics(), fn {name, invoke} ->
+      Recorder.prepare_child(%Recorder{
+        name: name,
+        fn: invoke,
+        reporter: &Appsignal.set_gauge/3
+      })
+    end)
+    |> Supervisor.start_link(strategy: :one_for_one, name: Status.Supervisor)
+  end
 
-    opts = [strategy: :one_for_one, name: Status.Supervisor]
-    Supervisor.start_link(children, opts)
+  @spec vm_metrics :: maybe_improper_list(atom(), fun()) | []
+  defp vm_metrics, do: do_vm_metrics(is_enabled?())
+
+  defp do_vm_metrics(false), do: []
+
+  defp do_vm_metrics(true) do
+    memory =
+      for n <- ~w(total processes ets binary atom atom_used)a,
+          do: {String.to_atom("erlang_memory_#{n}"), fn -> :erlang.memory(n) end}
+
+    system_info =
+      for n <- ~w(schedulers atom_count process_count port_count)a,
+          do: {String.to_atom("erlang_system_info_#{n}"), fn -> :erlang.system_info(n) end}
+
+    other = [
+      {:erlang_uptime, fn -> :erlang.statistics(:wall_clock) |> elem(0) |> Kernel.div(1000) end},
+      {:erlang_io_input_kb,
+       fn ->
+         {{:input, input}, {:output, _output}} = :erlang.statistics(:io)
+         input |> Kernel.div(1024)
+       end},
+      {:erlang_io_output_kb,
+       fn ->
+         {{:input, _input}, {:output, output}} = :erlang.statistics(:io)
+         output |> Kernel.div(1024)
+       end},
+      {:erlang_total_run_queue_lengths, fn -> :erlang.statistics(:total_run_queue_lengths) end},
+      {:erlang_ets_count, fn -> length(:ets.all()) end}
+    ]
+
+    Enum.concat([memory, system_info, other])
+  end
+
+  @spec is_enabled?() :: boolean()
+  defp is_enabled?() do
+    case {Application.get_env(:omg_status, :metrics), System.get_env("METRICS")} do
+      {nil, nil} -> false
+      {true, _} -> true
+      {_, "TRUE"} -> true
+    end
   end
 end

--- a/apps/omg_status/lib/status.ex
+++ b/apps/omg_status/lib/status.ex
@@ -1,0 +1,40 @@
+defmodule OMG.Status do
+  use Application
+  #  alias OMG.Status.Alert.AlarmHandler
+  alias Status.Metric.Recorder
+
+  def start(_type, _args) do
+    import Supervisor.Spec, warn: false
+
+    children =
+      [
+        {:erlang_schedulers, fn -> :erlang.system_info(:schedulers) end},
+        {:erlang_uptime, fn -> :erlang.statistics(:wall_clock) |> elem(0) |> Kernel.div(1000) end},
+        {:erlang_io_input_kb,
+         fn ->
+           {{:input, input}, {:output, _output}} = :erlang.statistics(:io)
+           input |> Kernel.div(1024)
+         end},
+        {:erlang_io_output_kb,
+         fn ->
+           {{:input, _input}, {:output, output}} = :erlang.statistics(:io)
+           output |> Kernel.div(1024)
+         end},
+        {:erlang_total_run_queue_lengths, fn -> :erlang.statistics(:total_run_queue_lengths) end},
+        {:erlang_atom_count, fn -> :erlang.system_info(:atom_count) end},
+        {:erlang_process_count, fn -> :erlang.system_info(:process_count) end},
+        {:erlang_port_count, fn -> :erlang.system_info(:port_count) end},
+        {:erlang_ets_count, fn -> length(:ets.all()) end}
+      ]
+      |> Enum.map(fn {name, invoke} ->
+        Recorder.prepare_child(%Recorder{
+          name: name,
+          fn: invoke,
+          reporter: &Appsignal.set_gauge/2
+        })
+      end)
+
+    opts = [strategy: :one_for_one, name: Status.Supervisor]
+    Supervisor.start_link(children, opts)
+  end
+end

--- a/apps/omg_status/lib/status/metric/recorder.ex
+++ b/apps/omg_status/lib/status/metric/recorder.ex
@@ -1,4 +1,4 @@
-# Copyright 2018 OmiseGO Pte Ltd
+# Copyright 2019 OmiseGO Pte Ltd
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/apps/omg_status/lib/status/metric/recorder.ex
+++ b/apps/omg_status/lib/status/metric/recorder.ex
@@ -1,3 +1,17 @@
+# Copyright 2018 OmiseGO Pte Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 defmodule Status.Metric.Recorder do
   @moduledoc """
   A GenServer template for metrics recording.
@@ -7,11 +21,11 @@ defmodule Status.Metric.Recorder do
   @type t :: %__MODULE__{
           name: atom(),
           fn: (... -> atom()),
-          key: charlist(),
+          key: charlist() | nil,
           interval: pos_integer(),
           reporter: (... -> atom()),
-          tref: reference(),
-          node: charlist()
+          tref: reference() | nil,
+          node: charlist() | nil
         }
   defstruct name: nil, fn: nil, key: nil, interval: @default_interval, reporter: nil, tref: nil, node: nil
 
@@ -19,11 +33,10 @@ defmodule Status.Metric.Recorder do
   Returns child_specs for the given metric setup, to be included e.g. in Supervisor's children.
   """
   @spec prepare_child(t) :: %{id: atom(), start: tuple()}
-  def prepare_child(opts \\ []) do
+  def prepare_child(opts) do
     %{id: opts.name, start: {__MODULE__, :start_link, [opts]}}
   end
 
-  # Initialization
   def start_link(opts) do
     GenServer.start_link(__MODULE__, opts, name: opts.name)
   end
@@ -43,7 +56,7 @@ defmodule Status.Metric.Recorder do
 
   def handle_info(:gather, state) do
     # invoke the reporter function and pass the key and value (invoke the fn)
-    _ = state.reporter.(state.key, apply(state.fn(), []), %{node: to_charlist(:erlang.node())})
+    _ = state.reporter.(state.key, apply(state.fn(), []), %{node: state.node})
     {:noreply, state}
   end
 

--- a/apps/omg_status/lib/status/metric/recorder.ex
+++ b/apps/omg_status/lib/status/metric/recorder.ex
@@ -25,7 +25,7 @@ defmodule Status.Metric.Recorder do
           interval: pos_integer(),
           reporter: (... -> atom()),
           tref: reference() | nil,
-          node: charlist() | nil
+          node: String.t() | nil
         }
   defstruct name: nil, fn: nil, key: nil, interval: @default_interval, reporter: nil, tref: nil, node: nil
 
@@ -50,7 +50,7 @@ defmodule Status.Metric.Recorder do
        | key: to_charlist(opts.name),
          interval: get_interval(opts.name) || @default_interval,
          tref: tref,
-         node: to_charlist(:erlang.node())
+         node: to_string(:erlang.node())
      }}
   end
 

--- a/apps/omg_status/lib/status/metric/recorder.ex
+++ b/apps/omg_status/lib/status/metric/recorder.ex
@@ -1,0 +1,64 @@
+defmodule Status.Metric.Recorder do
+  @moduledoc """
+  A GenServer template for metrics recording.
+  """
+  use GenServer
+  @default_interval 5_000
+  @type t :: %__MODULE__{
+          name: atom(),
+          fn: (... -> atom()),
+          key: charlist(),
+          interval: pos_integer(),
+          reporter: (... -> atom()),
+          tref: reference(),
+          node: charlist()
+        }
+  defstruct name: nil, fn: nil, key: nil, interval: @default_interval, reporter: nil, tref: nil, node: nil
+
+  @doc """
+  Returns child_specs for the given metric setup, to be included e.g. in Supervisor's children.
+  """
+  @spec prepare_child(t) :: %{id: atom(), start: tuple()}
+  def prepare_child(opts \\ []) do
+    %{id: opts.name, start: {__MODULE__, :start_link, [opts]}}
+  end
+
+  # Initialization
+  def start_link(opts) do
+    GenServer.start_link(__MODULE__, opts, name: opts.name)
+  end
+
+  def init(opts) do
+    {:ok, tref} = :timer.send_interval(opts.interval, self(), :gather)
+
+    {:ok,
+     %{
+       opts
+       | key: to_charlist(opts.name),
+         interval: get_interval(opts.name) || @default_interval,
+         tref: tref,
+         node: to_charlist(:erlang.node())
+     }}
+  end
+
+  def handle_info(:gather, state) do
+    # invoke the reporter function and pass the key and value (invoke the fn)
+    _ = state.reporter.(state.key, apply(state.fn(), []), %{node: to_charlist(:erlang.node())})
+    {:noreply, state}
+  end
+
+  # check configuration and system env variable, otherwise use the default
+  defp get_interval(name) do
+    case Application.get_env(:omg_status, String.to_atom("#{name}_interval")) do
+      nil ->
+        name
+        |> Atom.to_string()
+        |> String.upcase()
+        |> Kernel.<>("_INTERVAL")
+        |> System.get_env()
+
+      num ->
+        num
+    end
+  end
+end

--- a/apps/omg_status/mix.exs
+++ b/apps/omg_status/mix.exs
@@ -1,0 +1,31 @@
+defmodule OMG.Status.Mixfile do
+  use Mix.Project
+
+  def project do
+    [
+      app: :omg_status,
+      version: OMG.Umbrella.MixProject.umbrella_version(),
+      build_path: "../../_build",
+      config_path: "../../config/config.exs",
+      deps_path: "../../deps",
+      lockfile: "../../mix.lock",
+      elixir: "~> 1.8",
+      elixirc_paths: elixirc_paths(Mix.env()),
+      start_permanent: Mix.env() == :prod,
+      deps: deps(),
+      test_coverage: [tool: ExCoveralls]
+    ]
+  end
+
+  defp elixirc_paths(:test), do: ["lib", "test/support"]
+  defp elixirc_paths(_), do: ["lib"]
+
+  def application do
+    [
+      mod: {OMG.Status, []},
+      extra_applications: [:appsignal, :logger, :sasl, :os_mon]
+    ]
+  end
+
+  defp deps, do: []
+end

--- a/apps/omg_status/test/test_helper.exs
+++ b/apps/omg_status/test/test_helper.exs
@@ -1,4 +1,4 @@
-# Copyright 2018 OmiseGO Pte Ltd
+# Copyright 2019 OmiseGO Pte Ltd
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/apps/omg_status/test/test_helper.exs
+++ b/apps/omg_status/test/test_helper.exs
@@ -1,2 +1,15 @@
+# Copyright 2018 OmiseGO Pte Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 Application.ensure_all_started(:omg_status)
 ExUnit.start()

--- a/apps/omg_status/test/test_helper.exs
+++ b/apps/omg_status/test/test_helper.exs
@@ -1,0 +1,2 @@
+Application.ensure_all_started(:omg_status)
+ExUnit.start()


### PR DESCRIPTION
An example dashboard for the current metrics.
```
-
  title: 'VM dashboard'
  graphs:
    -
      title: 'VM atom over time'
      kind: gauge
      format: number
      draw_null_as_zero: true
      fields:
        - erlang_system_info_atom_count
      tags:
        node: '*'
    -
      title: 'ETS count'
      kind: gauge
      draw_null_as_zero: false
      fields:
        - erlang_ets_count
      tags:
        node: '*'
    -
      title: 'IO Input KB'
      kind: gauge
      draw_null_as_zero: false
      fields:
        - erlang_io_input_kb
      tags:
        node: '*'        
    -
      title: 'IO Output KB'
      kind: gauge
      format: number
      draw_null_as_zero: true
      fields:
        - erlang_io_output_kb
      tags:
        node: '*'        
    -
      title: 'Port count'
      kind: gauge
      draw_null_as_zero: false
      fields:
        - erlang_system_info_port_count
      tags:
        node: '*'        
    -
      title: 'Process count'
      kind: gauge
      format: number
      draw_null_as_zero: true
      fields:
        - erlang_system_info_process_count
      tags:
        node: '*'        
    -
      title: 'Number of schedulers'
      kind: gauge
      draw_null_as_zero: false
      fields:
        - erlang_system_info_schedulers
      tags:
        node: '*'        
    -
      title: 'Erlang Total Run Queue Lengths'
      kind: gauge
      format: number
      draw_null_as_zero: true
      fields:
        - erlang_total_run_queue_lengths
      tags:
        node: '*'        
    -
      title: Uptime
      kind: gauge
      draw_null_as_zero: false
      fields:
        - erlang_uptime
      tags:
        node: '*'        
    -
      title: 'Atom memory'
      kind: gauge
      draw_null_as_zero: false
      fields:
        - erlang_memory_atom
      tags:
        node: '*'        
    -
      title: 'Atom memory used'
      kind: gauge
      draw_null_as_zero: false
      fields:
        - erlang_memory_atom_used
      tags:
        node: '*'        
    -
      title: 'Binary memory'
      kind: gauge
      draw_null_as_zero: false
      fields:
        - erlang_memory_binary
      tags:
        node: '*'        
    -
      title: 'ETS memory'
      kind: gauge
      draw_null_as_zero: false
      fields:
        - erlang_memory_ets
      tags:
        node: '*'       
    -
      title: 'Memory processes'
      kind: gauge
      draw_null_as_zero: false
      fields:
        - erlang_memory_processes
      tags:
        node: '*'        
    -
      title: 'Memory total'
      kind: gauge
      draw_null_as_zero: false
      fields:
        - erlang_memory_total
      tags:
        node: '*'        

```