### PR TITLE
fix: omg watcher and api should have status as a umbrella dependency

### DIFF
--- a/apps/omg_api/mix.exs
+++ b/apps/omg_api/mix.exs
@@ -49,6 +49,7 @@ defmodule OMG.API.MixProject do
       {:merkle_tree, "~> 1.5.0"},
       {:deferred_config, "~> 0.1.1"},
       #
+      {:omg_status, in_umbrella: true},
       {:omg_db, in_umbrella: true},
       {:omg_eth, in_umbrella: true},
       {:omg_rpc, in_umbrella: true},

--- a/apps/omg_status/config/config.exs
+++ b/apps/omg_status/config/config.exs
@@ -2,3 +2,5 @@ use Mix.Config
 
 config :omg_status,
   metrics: true
+
+import_config "#{Mix.env()}.exs"

--- a/apps/omg_status/config/dev.exs
+++ b/apps/omg_status/config/dev.exs
@@ -1,0 +1,1 @@
+use Mix.Config

--- a/apps/omg_status/config/prod.exs
+++ b/apps/omg_status/config/prod.exs
@@ -1,0 +1,1 @@
+use Mix.Config

--- a/apps/omg_status/config/test.exs
+++ b/apps/omg_status/config/test.exs
@@ -1,0 +1,4 @@
+use Mix.Config
+
+config :omg_status,
+  metrics: false

--- a/apps/omg_status/lib/status.ex
+++ b/apps/omg_status/lib/status.ex
@@ -68,9 +68,9 @@ defmodule OMG.Status do
   @spec is_enabled?() :: boolean()
   defp is_enabled?() do
     case {Application.get_env(:omg_status, :metrics), System.get_env("METRICS")} do
-      {nil, nil} -> false
       {true, _} -> true
       {_, "TRUE"} -> true
+      _ -> false
     end
   end
 end

--- a/apps/omg_status/lib/status.ex
+++ b/apps/omg_status/lib/status.ex
@@ -33,7 +33,7 @@ defmodule OMG.Status do
   end
 
   @spec vm_metrics :: maybe_improper_list(atom(), fun()) | []
-  defp vm_metrics, do: do_vm_metrics(is_enabled?())
+  defp vm_metrics, do: do_vm_metrics(is_enabled?() || false)
 
   defp do_vm_metrics(false), do: []
 
@@ -65,12 +65,14 @@ defmodule OMG.Status do
     Enum.concat([memory, system_info, other])
   end
 
-  @spec is_enabled?() :: boolean()
+  @spec is_enabled?() :: boolean() | nil
   defp is_enabled?() do
     case {Application.get_env(:omg_status, :metrics), System.get_env("METRICS")} do
       {true, _} -> true
-      {_, "TRUE"} -> true
-      _ -> false
+      {_, "true"} -> true
+      {false, _} -> false
+      {_, "false"} -> false
+      _ -> nil
     end
   end
 end

--- a/apps/omg_watcher/mix.exs
+++ b/apps/omg_watcher/mix.exs
@@ -55,6 +55,7 @@ defmodule OMG.Watcher.Mixfile do
       {:briefly, "~> 0.3"},
       {:fake_server, "~> 1.5", only: [:test, :dev]},
       #
+      {:omg_status, in_umbrella: true},
       {:omg_api, in_umbrella: true, runtime: false},
       {:omg_db, in_umbrella: true},
       {:omg_eth, in_umbrella: true},


### PR DESCRIPTION
Without this, they're not started in deployment.