### PR TITLE
Add support for Parity

### DIFF
--- a/apps/omg_api/lib/sup.ex
+++ b/apps/omg_api/lib/sup.ex
@@ -25,6 +25,7 @@ defmodule OMG.API.Sup do
 
   def init(:ok) do
     DeferredConfig.populate(:omg_api)
+    DeferredConfig.populate(:omg_eth)
 
     monitor_children = [
       {OMG.API.BlockQueue.Server, []},

--- a/apps/omg_eth/config/config.exs
+++ b/apps/omg_eth/config/config.exs
@@ -10,7 +10,9 @@ config :omg_eth,
   contract_addr: nil,
   authority_addr: nil,
   txhash_contract: nil,
-  geth_logging_in_debug: true,
+  # "geth" | "parity"
+  eth_node: {:system, "ETH_NODE", "geth"},
+  node_logging_in_debug: true,
   child_block_interval: 1000,
   exit_period_seconds: {:system, "EXIT_PERIOD_SECONDS", 7 * 24 * 60 * 60, {String, :to_integer}},
   ethereum_client_warning_time_ms: ethereum_client_timeout_ms / 4

--- a/apps/omg_eth/test/eth_test.exs
+++ b/apps/omg_eth/test/eth_test.exs
@@ -31,7 +31,7 @@ defmodule OMG.EthTest do
 
   @moduletag :wrappers
 
-  @tag fixtures: [:geth]
+  @tag fixtures: [:eth_node]
   test "get_ethereum_height returns integer" do
     assert {:ok, number} = Eth.get_ethereum_height()
     assert is_integer(number)

--- a/apps/omg_eth/test/fixtures.exs
+++ b/apps/omg_eth/test/fixtures.exs
@@ -22,15 +22,15 @@ defmodule OMG.Eth.Fixtures do
 
   import Eth.Encoding
 
-  deffixture geth do
+  deffixture eth_node do
     DeferredConfig.populate(:omg_eth)
     {:ok, exit_fn} = Eth.DevNode.start()
     on_exit(exit_fn)
     :ok
   end
 
-  deffixture contract(geth) do
-    :ok = geth
+  deffixture contract(eth_node) do
+    :ok = eth_node
 
     %{} = Eth.DevHelpers.prepare_env!(root_path: "../../")
   end
@@ -41,6 +41,7 @@ defmodule OMG.Eth.Fixtures do
     root_path = "../../"
     {:ok, [addr | _]} = Ethereumex.HttpClient.eth_accounts()
 
+    DeferredConfig.populate(:omg_eth)
     {:ok, _, token_addr} = Eth.Deployer.create_new(OMG.Eth.Token, root_path, from_hex(addr))
 
     # ensuring that the root chain contract handles token_addr
@@ -52,6 +53,7 @@ defmodule OMG.Eth.Fixtures do
   end
 
   deffixture root_chain_contract_config(contract) do
+    DeferredConfig.populate(:omg_eth)
     Application.put_env(:omg_eth, :contract_addr, to_hex(contract.contract_addr), persistent: true)
     Application.put_env(:omg_eth, :authority_addr, to_hex(contract.authority_addr), persistent: true)
     Application.put_env(:omg_eth, :txhash_contract, to_hex(contract.txhash_contract), persistent: true)

--- a/apps/omg_eth/test/fixtures.exs
+++ b/apps/omg_eth/test/fixtures.exs
@@ -23,7 +23,8 @@ defmodule OMG.Eth.Fixtures do
   import Eth.Encoding
 
   deffixture geth do
-    {:ok, exit_fn} = Eth.DevGeth.start()
+    DeferredConfig.populate(:omg_eth)
+    {:ok, exit_fn} = Eth.DevNode.start()
     on_exit(exit_fn)
     :ok
   end

--- a/apps/omg_eth/test/support/dev_helpers.ex
+++ b/apps/omg_eth/test/support/dev_helpers.ex
@@ -124,15 +124,6 @@ defmodule OMG.Eth.DevHelpers do
     fn -> WaitFor.repeat_until_ok(f) end |> Task.async() |> Task.await(timeout)
   end
 
-  # private
-
-  defp create_and_fund_authority_addr(opts) do
-    with {:ok, authority} <- Ethereumex.HttpClient.request("personal_newAccount", [@passphrase], []),
-         {:ok, _} <- fund_address_from_faucet(authority, opts) do
-      {:ok, from_hex(authority)}
-    end
-  end
-
   def create_account_from_secret(:geth, secret, passphrase) do
     {:ok, _} = Ethereumex.HttpClient.request("personal_importRawKey", [secret, passphrase], [])
   end
@@ -141,6 +132,15 @@ defmodule OMG.Eth.DevHelpers do
     secret = secret |> Base.decode16!(case: :upper) |> Base.encode16(case: :lower)
     secret = "0x" <> secret
     {:ok, _} = Ethereumex.HttpClient.request("parity_newAccountFromSecret", [secret, passphrase], [])
+  end
+
+  # private
+
+  defp create_and_fund_authority_addr(opts) do
+    with {:ok, authority} <- Ethereumex.HttpClient.request("personal_newAccount", [@passphrase], []),
+         {:ok, _} <- fund_address_from_faucet(authority, opts) do
+      {:ok, from_hex(authority)}
+    end
   end
 
   defp get_exit_period(nil) do

--- a/apps/omg_eth/test/support/dev_mining_helper.ex
+++ b/apps/omg_eth/test/support/dev_mining_helper.ex
@@ -1,0 +1,78 @@
+# Copyright 2019 OmiseGO Pte Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defmodule OMG.Eth.DevMiningHelper do
+  @moduledoc """
+  Sends small tx every second, causing Ethereum node in `--dev` mode to create new blocks.
+  Basically helps to simulate behavior of `geth --dev --dev.period 1`. Useful with parity.
+  """
+  @devperiod_ms 1000
+
+  use GenServer
+
+  def start do
+    GenServer.start(__MODULE__, [:ok], name: __MODULE__)
+  end
+
+  def init(_) do
+    {:ok, acc, passphrase} = create_tick_account()
+    {:ok, %{forced_height: 0, account: acc, passphrase: passphrase}, {:continue, :continue}}
+  end
+
+  def handle_continue(:continue, state) do
+    :timer.send_interval(@devperiod_ms, :timer)
+    {:noreply, state}
+  end
+
+  def handle_info(:timer, %{forced_height: counter, account: acc, passphrase: passphrase} = state) do
+    {:ok, _} = mine(acc, passphrase)
+    {:noreply, %{state | forced_height: counter + 1}}
+  end
+
+  defp mine(addr, passphrase) do
+    %{from: addr, to: addr, value: OMG.Eth.Encoding.to_hex(1)}
+    |> OMG.Eth.send_transaction(passphrase: passphrase)
+    |> OMG.Eth.DevHelpers.transact_sync!()
+  end
+
+  defp create_tick_account do
+    tick_acc = generate_entity()
+    account_priv_enc = Base.encode16(tick_acc.priv)
+    passphrase = "dev.period"
+
+    {:ok, addr} = OMG.Eth.DevHelpers.create_account_from_secret(OMG.Eth.backend(), account_priv_enc, passphrase)
+
+    {:ok, [faucet | _]} = Ethereumex.HttpClient.eth_accounts()
+
+    %{from: faucet, to: addr, value: OMG.Eth.Encoding.to_hex(1_000_000 * trunc(:math.pow(10, 9 + 5)))}
+    |> OMG.Eth.send_transaction(passphrase: "")
+    |> OMG.Eth.DevHelpers.transact_sync!()
+
+    {:ok, addr, passphrase}
+  end
+
+  defp generate_entity do
+    priv = :crypto.strong_rand_bytes(32)
+    {:ok, <<4::integer-size(8), pub::binary>>} = Blockchain.Transaction.Signature.get_public_key(priv)
+    {:ok, addr} = generate_address(pub)
+    %{priv: priv, addr: addr}
+  end
+
+  defp generate_address(<<pub::binary-size(64)>>) do
+    <<_::binary-size(12), address::binary-size(20)>> = hash(pub)
+    {:ok, address}
+  end
+
+  defp hash(message), do: message |> ExthCrypto.Hash.hash(ExthCrypto.Hash.kec())
+end

--- a/apps/omg_eth/test/support/dev_node.ex
+++ b/apps/omg_eth/test/support/dev_node.ex
@@ -1,0 +1,54 @@
+# Copyright 2019 OmiseGO Pte Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defmodule OMG.Eth.DevNode do
+  @moduledoc """
+  Common library for running geth and parity in dev mode.
+  """
+  require Logger
+
+  def start do
+    OMG.Eth.backend()
+    |> start()
+  end
+
+  defp start(:geth) do
+    OMG.Eth.DevGeth.start()
+  end
+
+  defp start(:parity) do
+    OMG.Eth.DevParity.start()
+  end
+
+  def wait_for_start(outstream, look_for, timeout, logger_fn \\ &default_logger/1) do
+    # Monitors the stdout coming out of a process for signal of successful startup
+    waiting_task_function = fn ->
+      outstream
+      |> Stream.map(logger_fn)
+      |> Stream.take_while(fn line -> not String.contains?(line, look_for) end)
+      |> Enum.to_list()
+    end
+
+    waiting_task_function
+    |> Task.async()
+    |> Task.await(timeout)
+
+    :ok
+  end
+
+  def default_logger(line) do
+    _ = Logger.debug("eth node: " <> line)
+    line
+  end
+end

--- a/apps/omg_eth/test/support/dev_parity.ex
+++ b/apps/omg_eth/test/support/dev_parity.ex
@@ -31,11 +31,16 @@ defmodule OMG.Eth.DevParity do
     {:ok, _} = Application.ensure_all_started(:ethereumex)
     {:ok, homedir} = Briefly.create(directory: true)
 
-    parity_pid = launch("parity --chain dev --geth --jsonrpc-apis personal,eth,web3,parity_accounts --base-path #{homedir} 2>&1")
+    parity_pid =
+      launch("parity --chain dev --geth --jsonrpc-apis personal,eth,web3,parity_accounts --base-path #{homedir} 2>&1")
 
     {:ok, :ready} = Eth.WaitFor.eth_rpc()
+    {:ok, dev_period} = OMG.Eth.DevMiningHelper.start()
 
-    on_exit = fn -> stop(parity_pid) end
+    on_exit = fn ->
+      Process.exit(dev_period, :kill)
+      stop(parity_pid)
+    end
 
     {:ok, on_exit}
   end

--- a/apps/omg_eth/test/support/dev_parity.ex
+++ b/apps/omg_eth/test/support/dev_parity.ex
@@ -31,7 +31,7 @@ defmodule OMG.Eth.DevParity do
     {:ok, _} = Application.ensure_all_started(:ethereumex)
     {:ok, homedir} = Briefly.create(directory: true)
 
-    parity_pid = launch("parity --chain dev --geth --jsonrpc-apis personal,eth,web3 --base-path #{homedir} 2>&1")
+    parity_pid = launch("parity --chain dev --geth --jsonrpc-apis personal,eth,web3,parity_accounts --base-path #{homedir} 2>&1")
 
     {:ok, :ready} = Eth.WaitFor.eth_rpc()
 

--- a/apps/omg_eth/test/support/dev_parity.ex
+++ b/apps/omg_eth/test/support/dev_parity.ex
@@ -1,4 +1,4 @@
-# Copyright 2018 OmiseGO Pte Ltd
+# Copyright 2019 OmiseGO Pte Ltd
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,13 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-defmodule OMG.Eth.DevGeth do
+defmodule OMG.Eth.DevParity do
   @moduledoc """
-  Helper module for deployment of contracts to dev geth.
+  Helper module for deployment of contracts to dev parity.
   """
 
   @doc """
-  Run geth in temp dir, kill it with SIGKILL when done.
+  Run parity in temp dir, stop it with SIGHUP when done.
   """
 
   require Logger
@@ -31,10 +31,11 @@ defmodule OMG.Eth.DevGeth do
     {:ok, _} = Application.ensure_all_started(:ethereumex)
     {:ok, homedir} = Briefly.create(directory: true)
 
-    geth_pid = launch("geth --dev --dev.period=1 --rpc --rpcapi=personal,eth,web3 --datadir #{homedir} 2>&1")
+    parity_pid = launch("parity --chain dev --geth --jsonrpc-apis personal,eth,web3 --base-path #{homedir} 2>&1")
+
     {:ok, :ready} = Eth.WaitFor.eth_rpc()
 
-    on_exit = fn -> stop(geth_pid) end
+    on_exit = fn -> stop(parity_pid) end
 
     {:ok, on_exit}
   end
@@ -44,31 +45,31 @@ defmodule OMG.Eth.DevGeth do
   defp stop(pid) do
     # NOTE: monitor is required to stop_and_wait, don't know why? `monitor: true` on run doesn't work
     _ = Process.monitor(pid)
-    {:exit_status, 35_072} = Exexec.stop_and_wait(pid)
+    {:exit_status, 33_024} = Exexec.stop_and_wait(pid)
     :ok
   end
 
   defp launch(cmd) do
-    _ = Logger.debug("Starting geth")
+    _ = Logger.debug("Starting parity")
 
-    {:ok, geth_proc, _ref, [{:stream, geth_out, _stream_server}]} =
-      Exexec.run(cmd, stdout: :stream, kill_command: "pkill -9 geth")
+    {:ok, parity_proc, _ref, [{:stream, parity_out, _stream_server}]} =
+      Exexec.run(cmd, stdout: :stream, kill_command: "pkill -HUP parity")
 
-    wait_for_geth_start(geth_out)
+    wait_for_parity_start(parity_out)
 
     _ =
       if Application.get_env(:omg_eth, :node_logging_in_debug) do
         %Task{} =
           fn ->
-            geth_out |> Enum.each(&OMG.Eth.DevNode.default_logger/1)
+            parity_out |> Enum.each(&OMG.Eth.DevNode.default_logger/1)
           end
           |> Task.async()
       end
 
-    geth_proc
+    parity_proc
   end
 
-  defp wait_for_geth_start(geth_out) do
-    OMG.Eth.DevNode.wait_for_start(geth_out, "IPC endpoint opened", 15_000)
+  defp wait_for_parity_start(parity_out) do
+    OMG.Eth.DevNode.wait_for_start(parity_out, "Public node URL", 15_000)
   end
 end

--- a/apps/omg_performance/config/dev.exs
+++ b/apps/omg_performance/config/dev.exs
@@ -1,3 +1,3 @@
 use Mix.Config
 
-config :omg_eth, geth_logging_in_debug: false
+config :omg_eth, node_logging_in_debug: false

--- a/apps/omg_rpc/test/fixtures.exs
+++ b/apps/omg_rpc/test/fixtures.exs
@@ -17,6 +17,7 @@ defmodule OMG.RPC.Fixtures do
 
   @doc "run only endpoint to make request"
   deffixture phoenix_sandbox do
+    DeferredConfig.populate(:omg_eth)
     {:ok, pid} = Supervisor.start_link([OMG.RPC.Web.Endpoint], strategy: :one_for_one, name: OMG.RPC.Supervisor)
 
     on_exit(fn ->

--- a/apps/omg_watcher/lib/application.ex
+++ b/apps/omg_watcher/lib/application.ex
@@ -19,6 +19,7 @@ defmodule OMG.Watcher.Application do
   use OMG.API.LoggerExt
 
   def start(_type, _args) do
+    DeferredConfig.populate(:omg_eth)
     DeferredConfig.populate(:omg_watcher)
     DeferredConfig.populate(:omg_rpc)
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -45,6 +45,9 @@ sudo apt-get update
 sudo apt-get -y install geth
 ```
 
+### Installing Parity
+[Parity]((https://www.parity.io/ethereum/)) is supported. To use it, download the binary and put it into your PATH.
+
 ## Install solc
 ```
 sudo apt-get install libssl-dev solc
@@ -75,4 +78,9 @@ mix test
 To run integration tests (requires compiling contracts and **not** having `geth` running in the background):
 ```
 mix test --only integration
+```
+
+To run test with parity as a backend, set it via `export ETH_NODE=parity` environmental variable or via config. E.g. 
+```
+ETH_NODE=parity mix test --only integration
 ```

--- a/docs/manual_service_startup.md
+++ b/docs/manual_service_startup.md
@@ -54,6 +54,12 @@ geth --rinkeby --rpc --rpcapi personal,web3,eth,net  --rpcaddr 127.0.0.1
 
 **NOTE** Contrary to working with developer instance, operator's account must be manually funded with testnet Ether.
 
+#### Using Parity
+
+Parity can be used instead of Geth. Two environment variables must be set:
+* `ETH_NODE=parity` - to tell watcher and or child-chain to use parity.
+* `SIGNER_PASSPHRASE=your-passphrase` - for the child chain server, to [unlock](https://github.com/paritytech/parity-ethereum/issues/1215#issuecomment-224317361) the account.
+
 #### Prepare and configure the root chain contract
 
 The following step will:


### PR DESCRIPTION
Status.
* support for parity quirks
* docs

Integration test fail if run with parity because of postgres sandbox leaking changes to database, compromising isolation between tests. Wrappers tests work fine though.