### PR TITLE
fix: allow processing exits when they were immediately challenged

### DIFF
--- a/apps/omg_api/lib/state/core.ex
+++ b/apps/omg_api/lib/state/core.ex
@@ -418,6 +418,10 @@ defmodule OMG.API.State.Core do
     exit_infos |> Enum.map(& &1.utxo_pos) |> exit_utxos(state)
   end
 
+  def exit_utxos([%{call_data: %{utxo_pos: _}} | _] = exit_infos, %Core{} = state) do
+    exit_infos |> Enum.map(& &1.call_data) |> exit_utxos(state)
+  end
+
   def exit_utxos([encoded_utxo_pos | _] = exit_infos, %Core{} = state) when is_integer(encoded_utxo_pos) do
     exit_infos |> Enum.map(&Utxo.Position.decode/1) |> exit_utxos(state)
   end

--- a/apps/omg_api/lib/sup.ex
+++ b/apps/omg_api/lib/sup.ex
@@ -51,11 +51,7 @@ defmodule OMG.API.Sup do
         service_name: :exiter,
         synced_height_update_key: :last_exiter_eth_height,
         get_events_callback: &OMG.Eth.RootChain.get_standard_exits/2,
-        process_events_callback: fn exits ->
-          exits
-          |> Enum.map(&OMG.Eth.RootChain.get_standard_exit_utxo_pos/1)
-          |> exit_and_ignore_events_and_validities()
-        end
+        process_events_callback: &exit_and_ignore_events_and_validities/1
       ),
       {OMG.RPC.Web.Endpoint, []}
     ]

--- a/apps/omg_api/test/block_queue/core_test.exs
+++ b/apps/omg_api/test/block_queue/core_test.exs
@@ -624,7 +624,7 @@ defmodule OMG.API.BlockQueue.CoreTest do
       |> Core.enqueue_block(<<0>>, 7 * @child_block_interval, 1)
       |> Core.enqueue_block(<<0>>, 8 * @child_block_interval, 1)
 
-      state =
+      _ =
         Enum.reduce(80..(eth_height - 1), state, fn eth_height, state ->
           {_, state} = set_ethereum_status(state, eth_height, 0, false)
           assert gas_price == state.gas_price_to_use

--- a/apps/omg_api/test/state/core_test.exs
+++ b/apps/omg_api/test/state/core_test.exs
@@ -518,6 +518,11 @@ defmodule OMG.API.State.CoreTest do
 
     assert exit_utxos_response_reference ==
              utxo_pos_exits
+             |> Enum.map(&%{call_data: %{utxo_pos: Utxo.Position.encode(&1)}})
+             |> Core.exit_utxos(state)
+
+    assert exit_utxos_response_reference ==
+             utxo_pos_exits
              |> Enum.map(&%{utxo_pos: Utxo.Position.encode(&1)})
              |> Core.exit_utxos(state)
 

--- a/apps/omg_watcher/lib/db/eth_event.ex
+++ b/apps/omg_watcher/lib/db/eth_event.ex
@@ -74,8 +74,13 @@ defmodule OMG.Watcher.DB.EthEvent do
   """
   @spec insert_exits!([non_neg_integer()]) :: :ok
   def insert_exits!(exits) do
-    Enum.each(exits, &(&1 |> Utxo.Position.decode() |> insert_exit!()))
+    exits
+    |> Stream.map(&utxo_pos_from_exit_event/1)
+    |> Enum.each(&insert_exit!/1)
   end
+
+  @spec utxo_pos_from_exit_event(%{call_data: %{utxo_pos: pos_integer()}}) :: Utxo.Position.t()
+  defp utxo_pos_from_exit_event(%{call_data: %{utxo_pos: utxo_pos}}), do: Utxo.Position.decode(utxo_pos)
 
   @spec insert_exit!(Utxo.Position.t()) :: {:ok, %__MODULE__{}} | {:error, Ecto.Changeset.t()}
   defp insert_exit!(Utxo.position(blknum, txindex, _oindex) = position) do

--- a/apps/omg_watcher/lib/supervisor.ex
+++ b/apps/omg_watcher/lib/supervisor.ex
@@ -100,10 +100,7 @@ defmodule OMG.Watcher.Supervisor do
         synced_height_update_key: :last_convenience_exit_processor_eth_height,
         get_events_callback: &Eth.RootChain.get_standard_exits/2,
         process_events_callback: fn exits ->
-          exits
-          |> Enum.map(&OMG.Eth.RootChain.get_standard_exit_utxo_pos/1)
-          |> Watcher.DB.EthEvent.insert_exits!()
-
+          exits |> Watcher.DB.EthEvent.insert_exits!()
           {:ok, []}
         end
       ),

--- a/apps/omg_watcher/test/db/eth_event_test.exs
+++ b/apps/omg_watcher/test/db/eth_event_test.exs
@@ -78,7 +78,7 @@ defmodule OMG.Watcher.DB.EthEventTest do
     alices_utxo_pos = Utxo.position(3000, 1, 1)
     alices_utxo_exit_hash = DB.EthEvent.generate_unique_key(alices_utxo_pos, :exit)
 
-    to_insert = Enum.map([bobs_deposit_pos, alices_utxo_pos], &Utxo.Position.encode/1)
+    to_insert = prepare_to_insert([bobs_deposit_pos, alices_utxo_pos])
     :ok = DB.EthEvent.insert_exits!(to_insert)
 
     assert %DB.EthEvent{blknum: 2, txindex: 0, event_type: :exit, hash: ^bobs_deposit_exit_hash} =
@@ -99,7 +99,11 @@ defmodule OMG.Watcher.DB.EthEventTest do
     # try to insert again existing deposit (from initial_blocks)
     assert :ok = DB.EthEvent.insert_deposits!([%{owner: alice.addr, currency: @eth, amount: 333, blknum: 1}])
 
-    to_insert = Enum.map([Utxo.position(1, 0, 0), Utxo.position(1, 0, 0)], &Utxo.Position.encode/1)
+    to_insert = prepare_to_insert([Utxo.position(1, 0, 0), Utxo.position(1, 0, 0)])
+
     assert :ok = DB.EthEvent.insert_exits!(to_insert)
   end
+
+  defp prepare_to_insert(positions),
+    do: Enum.map(positions, &%{call_data: %{utxo_pos: Utxo.Position.encode(&1)}})
 end

--- a/apps/omg_watcher/test/exit_processor/persistence_test.exs
+++ b/apps/omg_watcher/test/exit_processor/persistence_test.exs
@@ -48,10 +48,30 @@ defmodule OMG.Watcher.ExitProcessor.PersistenceTest do
     empty
   end
 
-  deffixture exits(alice) do
+  # TODO: DRY against `exit_processor/core_test.exs` or refactor to make unnecessary in any other way
+  deffixture transactions(alice, carol) do
+    [
+      Transaction.new([{1, 0, 0}, {1, 2, 1}], [{alice.addr, @eth, 1}, {carol.addr, @eth, 2}]),
+      Transaction.new([{2, 1, 0}, {2, 2, 1}], [{alice.addr, @eth, 1}, {carol.addr, @eth, 2}])
+    ]
+  end
+
+  deffixture exits(alice, transactions) do
+    [txbytes1, txbytes2] = transactions |> Enum.map(&Transaction.encode/1)
+
     {[
-       %{owner: alice.addr, eth_height: 2, exit_id: 1},
-       %{owner: alice.addr, eth_height: 4, exit_id: 2}
+       %{
+         owner: alice.addr,
+         eth_height: 2,
+         exit_id: 1,
+         call_data: %{utxo_pos: Utxo.Position.encode(@utxo_pos1), output_tx: txbytes1}
+       },
+       %{
+         owner: alice.addr,
+         eth_height: 4,
+         exit_id: 2,
+         call_data: %{utxo_pos: Utxo.Position.encode(@utxo_pos2), output_tx: txbytes2}
+       }
      ],
      [
        {alice.addr, @eth, 10, Utxo.Position.encode(@utxo_pos1)},


### PR DESCRIPTION
otherwise, when a `ExitProcessor.Core.new_exits/2` is called, when an exit already had been challenged,
there's a failed attempt to decode a `Utxo.Position.decode(0)`

The reason is that the "current" contract state of the exit already is wiped clean.

Instead, to limit the fix to the Watcher we take the necessary details of an exit from the relevant `call_data`