### PR TITLE
fix: increase the amount of restarts per max_seconds

### DIFF
--- a/apps/omg_api/lib/application.ex
+++ b/apps/omg_api/lib/application.ex
@@ -68,7 +68,7 @@ defmodule OMG.API.Application do
       {OMG.RPC.Web.Endpoint, []}
     ]
 
-    opts = [strategy: :one_for_one]
+    opts = [strategy: :one_for_one, max_restarts: Enum.count(children) * 10]
 
     _ = Logger.info("Starting #{inspect(__MODULE__)}")
     :ok = :error_logger.add_report_handler(Sentry.Logger)

--- a/apps/omg_watcher/lib/supervisor.ex
+++ b/apps/omg_watcher/lib/supervisor.ex
@@ -160,7 +160,7 @@ defmodule OMG.Watcher.Supervisor do
       }
     ]
 
-    opts = [strategy: :one_for_one]
+    opts = [strategy: :one_for_one, max_restarts: Enum.count(children) * 10]
 
     _ = Logger.info("Starting #{inspect(__MODULE__)}")
     Supervisor.init(children, opts)


### PR DESCRIPTION
When Eth client goes out of reach for a period of time, we're not able to recover in time. This increases the amount of restarts that should hopefully allow us to recover the processes.