### PR TITLE
OMG-413 fix: enable PORT env variable for :dev environment + update docs

### DIFF
--- a/apps/omg_rpc/config/dev.exs
+++ b/apps/omg_rpc/config/dev.exs
@@ -7,7 +7,7 @@ use Mix.Config
 # watchers to your application. For example, we use it
 # with webpack to recompile .js and .css sources.
 config :omg_rpc, OMG.RPC.Web.Endpoint,
-  http: [port: 9656],
+  http: [port: {:system, "PORT", 9656, {String, :to_integer}}],
   url: [host: "localhost", port: 9656],
   debug_errors: true,
   check_origin: false,

--- a/apps/omg_watcher/config/dev.exs
+++ b/apps/omg_watcher/config/dev.exs
@@ -7,7 +7,7 @@ use Mix.Config
 # watchers to your application. For example, we use it
 # with brunch.io to recompile .js and .css sources.
 config :omg_watcher, OMG.Watcher.Web.Endpoint,
-  http: [port: 7434],
+  http: [port: {:system, "PORT", 7434, {String, :to_integer}}],
   url: [host: "localhost", port: 7434],
   debug_errors: true,
   code_reloader: true,

--- a/docs/manual_service_startup.md
+++ b/docs/manual_service_startup.md
@@ -21,7 +21,9 @@ Such configuration must become part of the [Mix configuration](https://hexdocs.p
 1. (**Watcher only**) Configure PostgreSQL for `WatcherDB` database
 1. (**Watcher only**) Acquire the configuration file with root chain deployment data
 1. (**Watcher only**, optional) If running on the same machine as the child chain server, customize the location of `OMG.DB` database folder
-1. (**Watcher only**) Configure the child chain url (default is `http://localhost:9656`) by configuring `:omg_rpc, OMG.RPC.Web.Endpoint` with `http: [port: 9656]`
+1. (**Watcher only**) Configure the child chain url (default is `http://localhost:9656`) by:
+    - configuring `:omg_rpc, OMG.RPC.Client` with `child_chain_url: "desired_childchain_url"`
+    - configuring with an environment variable `CHILD_CHAIN_URL=desired_childchain_url`
 1. (**Watcher only**) Initialize the Watcher's `OMG.DB` database
 1. (**Watcher only**) Create and migrate the PostgreSQL `WatcherDB` database
 1. (**Watcher only**) At this point the Watcher should be properly setup to run by starting the `omg_watcher` Mix app
@@ -120,11 +122,15 @@ The database files are put at the default location `~/.omg/data`.
 You need to re-initialize the database, in case you want to start a new child chain from scratch!
 
 #### Start it up!
+
+The child chain server is listening on port `9656` by default.
+To customize, run the child chain server with environment variable `PORT` set to a different value.
+
 * Start up geth if not already started.
 * Start Up the child chain server:
 
 ```bash
-iex -S mix xomg.child_chain.start --config ~/config.exs
+mix xomg.child_chain.start --config ~/config.exs
 ```
 
 ### Setting up a Watcher (a developer environment)
@@ -167,11 +173,14 @@ mix run --no-start -e 'OMG.DB.init()' --config ~/config_watcher.exs
 
 #### Start the Watcher
 
+The watcher is listening on port `7434` by default.
+To customize, run with environment variable `PORT` set to a different value.
+
 It is possible to run the watcher in two different modes: "`security critical`" and "`security critical` + `convenience`"
 The one that should be chosen currently is `security critical` + `convenience` mode, which provides all the expected functionality:
 
 ```bash
-iex -S mix xomg.watcher.start --convenience --config ~/config_watcher.exs
+mix xomg.watcher.start --convenience --config ~/config_watcher.exs
 ```
 
 > "security critical" mode can be started by omitting the `--convenience` flag, but this not fully implemented yet


### PR DESCRIPTION
before that customizing these ports in `dev` environment required one to override the whole Endpoint config in ~/config.exs,
which is impossible due to the way configs work in Elixir (in case of ~/config.exs it is **not** deeply merged)

fixes #451 