### PR TITLE
fix: start sasl for alarms

### DIFF
--- a/apps/omg_watcher/mix.exs
+++ b/apps/omg_watcher/mix.exs
@@ -31,7 +31,7 @@ defmodule OMG.Watcher.Mixfile do
         convenience_api_mode: false
       ],
       mod: {OMG.Watcher.Application, []},
-      extra_applications: [:logger, :runtime_tools]
+      extra_applications: [:logger, :runtime_tools, :sasl]
     ]
   end
 


### PR DESCRIPTION
Adds sasl to application list so that alarms can be installed.