### PR TITLE
fix: protecting OMG.DB from refactors in OMG.Block

### DIFF
--- a/apps/omg/lib/block.ex
+++ b/apps/omg/lib/block.ex
@@ -61,8 +61,6 @@ defmodule OMG.Block do
     %{transactions: transactions, hash: hash, number: number}
   end
 
-  def from_db_value(%__MODULE__{} = block), do: from_db_value(Map.from_struct(block))
-
   def from_db_value(%{transactions: transactions, hash: hash, number: number})
       when is_list(transactions) and is_binary(hash) and is_integer(number) do
     value = %{transactions: transactions, hash: hash, number: number}

--- a/apps/omg/lib/block.ex
+++ b/apps/omg/lib/block.ex
@@ -55,6 +55,20 @@ defmodule OMG.Block do
     |> Map.put(:blknum, blknum)
   end
 
+  # NOTE: we have no migrations, so we handle data compatibility here (make_db_update/1 and from_db_kv/1), OMG-421
+  def to_db_value(%__MODULE__{transactions: transactions, hash: hash, number: number})
+      when is_list(transactions) and is_binary(hash) and is_integer(number) do
+    %{transactions: transactions, hash: hash, number: number}
+  end
+
+  def from_db_value(%__MODULE__{} = block), do: from_db_value(Map.from_struct(block))
+
+  def from_db_value(%{transactions: transactions, hash: hash, number: number})
+      when is_list(transactions) and is_binary(hash) and is_integer(number) do
+    value = %{transactions: transactions, hash: hash, number: number}
+    struct!(__MODULE__, value)
+  end
+
   @doc """
   Calculates inclusion proof for the transaction in the block
   """

--- a/apps/omg/lib/state/core.ex
+++ b/apps/omg/lib/state/core.ex
@@ -330,7 +330,7 @@ defmodule OMG.State.Core do
         [{:delete, :utxo, db_key}, {:put, :spend, {db_key, height}}]
       end)
 
-    db_updates_block = [{:put, :block, block}]
+    db_updates_block = [{:put, :block, Block.to_db_value(block)}]
 
     db_updates_top_block_number = [{:put, :child_top_block_number, height}]
 

--- a/apps/omg/lib/utxo.ex
+++ b/apps/omg/lib/utxo.ex
@@ -50,8 +50,6 @@ defmodule OMG.Utxo do
     %{owner: owner, currency: currency, amount: amount, creating_txhash: creating_txhash}
   end
 
-  def from_db_value(%__MODULE__{} = utxo), do: from_db_value(Map.from_struct(utxo))
-
   def from_db_value(%{owner: owner, currency: currency, amount: amount, creating_txhash: creating_txhash})
       when is_binary(owner) and is_binary(currency) and is_integer(amount) and is_nil_or_binary(creating_txhash) do
     value = %{owner: owner, currency: currency, amount: amount, creating_txhash: creating_txhash}

--- a/apps/omg/lib/utxo.ex
+++ b/apps/omg/lib/utxo.ex
@@ -38,11 +38,23 @@ defmodule OMG.Utxo do
     end
   end
 
+  defmacrop is_nil_or_binary(binary) do
+    quote do
+      is_binary(unquote(binary)) or is_nil(unquote(binary))
+    end
+  end
+
   # NOTE: we have no migrations, so we handle data compatibility here (make_db_update/1 and from_db_kv/1), OMG-421
-  def to_db_value(%__MODULE__{} = utxo) do
-    Map.take(utxo, [:owner, :currency, :amount, :creating_txhash])
+  def to_db_value(%__MODULE__{owner: owner, currency: currency, amount: amount, creating_txhash: creating_txhash})
+      when is_binary(owner) and is_binary(currency) and is_integer(amount) and is_nil_or_binary(creating_txhash) do
+    %{owner: owner, currency: currency, amount: amount, creating_txhash: creating_txhash}
   end
 
   def from_db_value(%__MODULE__{} = utxo), do: from_db_value(Map.from_struct(utxo))
-  def from_db_value(utxo_map), do: struct!(__MODULE__, utxo_map)
+
+  def from_db_value(%{owner: owner, currency: currency, amount: amount, creating_txhash: creating_txhash})
+      when is_binary(owner) and is_binary(currency) and is_integer(amount) and is_nil_or_binary(creating_txhash) do
+    value = %{owner: owner, currency: currency, amount: amount, creating_txhash: creating_txhash}
+    struct!(__MODULE__, value)
+  end
 end

--- a/apps/omg/test/state/core_test.exs
+++ b/apps/omg/test/state/core_test.exs
@@ -397,10 +397,8 @@ defmodule OMG.State.CoreTest do
   end
 
   @tag fixtures: [:alice, :state_empty]
-  test "deposits emit event triggers, they don't leak into next block", %{
-    alice: alice,
-    state_empty: state
-  } do
+  test "deposits emit event triggers, they don't leak into next block",
+       %{alice: %{addr: alice}, state_empty: state} do
     assert {:ok, {[trigger], _}, state} = Core.deposit([%{owner: alice, currency: @eth, amount: 4, blknum: 1}], state)
 
     assert trigger == %{deposit: %{owner: alice, amount: 4}}
@@ -780,7 +778,7 @@ defmodule OMG.State.CoreTest do
     {_, {block, _, db_updates}, _} = result = Core.form_block(@interval, state)
 
     # check if block returned and sent to db_updates is the same
-    assert Enum.member?(db_updates, {:put, :block, block})
+    assert Enum.member?(db_updates, {:put, :block, Block.to_db_value(block)})
     # check if that's the only db_update for block
     is_block_put? = fn {operation, type, _} -> operation == :put && type == :block end
     assert Enum.count(db_updates, is_block_put?) == 1

--- a/apps/omg/test/state/persistence_test.exs
+++ b/apps/omg/test/state/persistence_test.exs
@@ -19,6 +19,7 @@ defmodule OMG.State.PersistenceTest do
   use ExUnitFixtures
   use OMG.DB.Case, async: true
 
+  alias OMG.Block
   alias OMG.State.Core
   alias OMG.State.Transaction
   alias OMG.Utxo
@@ -134,7 +135,10 @@ defmodule OMG.State.PersistenceTest do
     |> persist_form(db_pid)
 
     assert {:ok, [hash]} = OMG.DB.block_hashes([@blknum1], db_pid)
-    assert {:ok, [%{number: @blknum1, transactions: [block_tx], hash: ^hash}]} = OMG.DB.blocks([hash], db_pid)
+
+    assert {:ok, [db_block]} = OMG.DB.blocks([hash], db_pid)
+    %Block{number: @blknum1, transactions: [block_tx], hash: ^hash} = Block.from_db_value(db_block)
+
     assert {:ok, tx} == Transaction.Recovered.recover_from(block_tx)
     assert {:ok, 1000} == OMG.DB.spent_blknum({1, 0, 0}, db_pid)
   end

--- a/apps/omg_api/lib/fresh_blocks/core.ex
+++ b/apps/omg_api/lib/fresh_blocks/core.ex
@@ -46,7 +46,8 @@ defmodule OMG.API.FreshBlocks.Core do
   def combine_getting_results(nil = _fresh_block, {:ok, [:not_found] = _fetched_blocks} = _db_result),
     do: {:error, :not_found}
 
-  def combine_getting_results(nil = _fresh_block, {:ok, [db_block] = _fetched_blocks} = _db_result), do: {:ok, db_block}
+  def combine_getting_results(nil = _fresh_block, {:ok, [db_block] = _fetched_blocks} = _db_result),
+    do: {:ok, Block.from_db_value(db_block)}
 
   def combine_getting_results(fresh_block, _db_result), do: {:ok, fresh_block}
 end

--- a/apps/omg_api/test/fresh_blocks_test.exs
+++ b/apps/omg_api/test/fresh_blocks_test.exs
@@ -67,7 +67,9 @@ defmodule OMG.API.FreshBlocksTest do
 
     # db block
     {nil = fresh_block, [0]} = FreshBlocks.get(0, state)
-    assert {:ok, %Block{hash: 0}} = FreshBlocks.combine_getting_results(fresh_block, {:ok, [%Block{hash: 0}]})
+
+    db_block = %Block{transactions: [], hash: <<0>>, number: 1000}
+    assert {:ok, %Block{hash: <<0>>}} = FreshBlocks.combine_getting_results(fresh_block, {:ok, [db_block]})
 
     # missing block
     {nil = fresh_block, [11]} = FreshBlocks.get(11, state)
@@ -75,7 +77,7 @@ defmodule OMG.API.FreshBlocksTest do
 
     # tolerate spurrious/erroneous/missing db result, if found a fresh block
     {fresh_block, []} = FreshBlocks.get(9, state)
-    assert {:ok, ^fresh_block} = FreshBlocks.combine_getting_results(fresh_block, {:ok, [%Block{hash: 0}]})
+    assert {:ok, ^fresh_block} = FreshBlocks.combine_getting_results(fresh_block, {:ok, [db_block]})
     assert {:ok, ^fresh_block} = FreshBlocks.combine_getting_results(fresh_block, {:ok, [%Block{hash: 9}]})
     assert {:ok, ^fresh_block} = FreshBlocks.combine_getting_results(fresh_block, {:ok, [:not_found]})
   end

--- a/docs/demo_01.md
+++ b/docs/demo_01.md
@@ -18,6 +18,8 @@ alias OMG.State.Transaction
 alias OMG.TestHelper
 alias OMG.Integration.DepositHelper
 
+DeferredConfig.populate(:omg_eth)
+
 alice = TestHelper.generate_entity()
 bob = TestHelper.generate_entity()
 eth = Eth.RootChain.eth_pseudo_address()

--- a/docs/demo_02.md
+++ b/docs/demo_02.md
@@ -23,6 +23,8 @@ alias OMG.TestHelper
 alias OMG.Integration.DepositHelper
 alias OMG.Eth.Encoding
 
+DeferredConfig.populate(:omg_eth)
+
 alice = TestHelper.generate_entity()
 bob = TestHelper.generate_entity()
 eth = Eth.RootChain.eth_pseudo_address()

--- a/docs/demo_03.md
+++ b/docs/demo_03.md
@@ -29,6 +29,8 @@ alias OMG.Crypto
 alias OMG.DevCrypto
 alias OMG.TestHelper
 
+DeferredConfig.populate(:omg_eth)
+
 {:ok, contract_addr} = Application.fetch_env!(:omg_eth, :contract_addr) |> Crypto.decode_address()
 
 # defaults

--- a/docs/demo_04.md
+++ b/docs/demo_04.md
@@ -19,6 +19,8 @@ alias OMG.State.Transaction
 alias OMG.TestHelper
 alias OMG.Eth.Encoding
 
+DeferredConfig.populate(:omg_eth)
+
 alice = TestHelper.generate_entity()
 bob = TestHelper.generate_entity()
 eth = Eth.RootChain.eth_pseudo_address()


### PR DESCRIPTION
a continuation of #464 movement, which turned out to be necessary for Blocks and Utxo values too