### PR TITLE
OMG-218 refactor: vm stats

### DIFF
--- a/apps/omg_db/lib/omg_db/recorder.ex
+++ b/apps/omg_db/lib/omg_db/recorder.ex
@@ -18,7 +18,6 @@ defmodule OMG.DB.Recorder do
   """
   use GenServer
   @default_interval 5_000
-  @table __MODULE__
   @write :leveldb_write
   @read :leveldb_read
   @multiread :leveldb_multiread
@@ -43,18 +42,18 @@ defmodule OMG.DB.Recorder do
             node: nil,
             table: nil
 
-  @spec update_write :: integer()
-  def update_write(table \\ @table) do
+  @spec update_write(atom()) :: integer()
+  def update_write(table) do
     :ets.update_counter(table, @write, {2, 1}, {@write, 0})
   end
 
-  @spec update_read :: integer()
-  def update_read(table \\ @table) do
+  @spec update_read(atom()) :: integer()
+  def update_read(table) do
     :ets.update_counter(table, @read, {2, 1}, {@read, 0})
   end
 
-  @spec update_multiread :: integer()
-  def update_multiread(table \\ @table) do
+  @spec update_multiread(atom()) :: integer()
+  def update_multiread(table) do
     :ets.update_counter(table, @multiread, {2, 1}, {@multiread, 0})
   end
 
@@ -63,7 +62,6 @@ defmodule OMG.DB.Recorder do
   end
 
   def init(opts) do
-    table = create_stats_table(opts)
     {:ok, tref} = :timer.send_interval(opts.interval, self(), :gather)
 
     {:ok,
@@ -73,7 +71,7 @@ defmodule OMG.DB.Recorder do
          interval: get_interval(opts.name) || @default_interval,
          tref: tref,
          node: Atom.to_string(:erlang.node()),
-         table: table
+         table: opts.table
      }}
   end
 
@@ -95,18 +93,6 @@ defmodule OMG.DB.Recorder do
     {:noreply, state}
   end
 
-  def create_stats_table(%{name: name}) do
-    case :ets.whereis(name) do
-      :undefined ->
-        true = name == :ets.new(name, table_settings())
-
-        name
-
-      _ ->
-        name
-    end
-  end
-
   # check configuration and system env variable, otherwise use the default
   defp get_interval(name) do
     case Application.get_env(:omg_status, String.to_atom("#{name}_interval")) do
@@ -121,6 +107,4 @@ defmodule OMG.DB.Recorder do
         num
     end
   end
-
-  defp table_settings, do: [:named_table, :set, :public, write_concurrency: true]
 end

--- a/apps/omg_db/test/omg_db/recorder_test.exs
+++ b/apps/omg_db/test/omg_db/recorder_test.exs
@@ -31,8 +31,8 @@ defmodule OMG.RecorderTest do
           :pass
 
         {:registered_name, _} ->
-          result = :ets.lookup(Map.get(:sys.get_state(pid), :table), :write)
-          assert [write: 1] == result
+          result = :ets.lookup(Map.get(:sys.get_state(pid), :table), :leveldb_write)
+          assert [leveldb_write: 1] == result
       end
     end)
   end
@@ -47,8 +47,8 @@ defmodule OMG.RecorderTest do
           :pass
 
         {:registered_name, _} ->
-          result = :ets.lookup(Map.get(:sys.get_state(pid), :table), :read)
-          assert [read: 1] == result
+          result = :ets.lookup(Map.get(:sys.get_state(pid), :table), :leveldb_read)
+          assert [leveldb_read: 1] == result
       end
     end)
   end
@@ -63,8 +63,8 @@ defmodule OMG.RecorderTest do
           :pass
 
         {:registered_name, _} ->
-          result = :ets.lookup(Map.get(:sys.get_state(pid), :table), :multiread)
-          assert [multiread: 1] == result
+          result = :ets.lookup(Map.get(:sys.get_state(pid), :table), :leveldb_multiread)
+          assert [leveldb_multiread: 1] == result
       end
     end)
   end

--- a/apps/omg_status/config/config.exs
+++ b/apps/omg_status/config/config.exs
@@ -3,4 +3,17 @@ use Mix.Config
 config :omg_status,
   metrics: true
 
+config :vmstats,
+  base_key: 'vmstats',
+  interval: 1000,
+  key_separator: '$.',
+  sched_time: true,
+  memory_metrics: [
+    total: :total,
+    processes_used: :procs_used,
+    atom_used: :atom_used,
+    binary: :binary,
+    ets: :ets
+  ]
+
 import_config "#{Mix.env()}.exs"

--- a/apps/omg_status/mix.exs
+++ b/apps/omg_status/mix.exs
@@ -28,5 +28,5 @@ defmodule OMG.Status.Mixfile do
     ]
   end
 
-  defp deps, do: []
+  defp deps, do: [{:vmstats, "~> 2.3", runtime: false}]
 end

--- a/config/config.exs
+++ b/config/config.exs
@@ -23,5 +23,3 @@ config :appsignal, :config,
   name: "OmiseGO Plasma MoreVP Implementation",
   env: Mix.env(),
   active: true
-
-import_config "#{Mix.env()}.exs"

--- a/config/config.exs
+++ b/config/config.exs
@@ -23,3 +23,5 @@ config :appsignal, :config,
   name: "OmiseGO Plasma MoreVP Implementation",
   env: Mix.env(),
   active: true
+
+import_config "#{Mix.env()}.exs"

--- a/mix.exs
+++ b/mix.exs
@@ -54,7 +54,7 @@ defmodule OMG.Umbrella.MixProject do
     [
       flags: [:error_handling, :race_conditions, :underspecs, :unknown, :unmatched_returns],
       ignore_warnings: "dialyzer.ignore-warnings",
-      plt_add_apps: [:mix, :iex, :ex_unit, :ranch, :plug, :jason, :cowboy]
+      plt_add_apps: [:mix, :iex, :ex_unit, :ranch, :plug, :jason, :cowboy, :vmstats]
     ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -65,4 +65,5 @@
   "socket": {:hex, :socket, "0.3.13", "98a2ab20ce17f95fb512c5cadddba32b57273e0d2dba2d2e5f976c5969d0c632", [:mix], [], "hexpm"},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.4", "f0eafff810d2041e93f915ef59899c923f4568f4585904d010387ed74988e77b", [:make, :mix, :rebar3], [], "hexpm"},
   "unicode_util_compat": {:hex, :unicode_util_compat, "0.4.1", "d869e4c68901dd9531385bb0c8c40444ebf624e60b6962d95952775cac5e90cd", [:rebar3], [], "hexpm"},
+  "vmstats": {:hex, :vmstats, "2.3.1", "fa719deb51c53672955cbf0e131cfe85be51732c700d2b58232157ac0478bf4a", [:rebar3], [], "hexpm"},
 }


### PR DESCRIPTION
This is now the complete VM overview. 
I've added :vm_stats dependency which I've vetted myself. It's written and maintained by Fred Hebert, @mononcqc. It has no other dependencies - because it's just calling VM modules and does the necessary grouping. It works by simply enforcing a behavior  which we need to implement and send off to AppSignal.

I've also rewritten the plotting part. It now makes more sense :D

```
title: VM dashboard
graphs:
  - title: 'Writes, reads and multireads - LevelDB in interval'
    line_label: '%node%'
    format: number
    draw_null_as_zero: true
    metrics:
      - name: leveldb_write
        fields:
          - COUNTER
        tags:
          node: '*'
      - name: leveldb_read
        fields:
          - COUNTER
        tags:
          node: '*'
      - name: leveldb_multiread
        fields:
          - COUNTER
        tags:
          node: '*'
  - title: vmstats$.scheduler_wall_time$.1.total - active
    line_label: '%node%'
    format: number
    draw_null_as_zero: true
    metrics:
      - name: vmstats$.scheduler_wall_time$.1$.total
        fields:
          - GAUGE
        tags:
          node: '*'
      - name: vmstats$.scheduler_wall_time$.1$.active
        fields:
          - GAUGE
        tags:
          node: '*'
  - title: vmstats$.scheduler_wall_time$.2.total - active
    line_label: '%node%'
    format: number
    draw_null_as_zero: true
    metrics:
      - name: vmstats$.scheduler_wall_time$.2$.total
        fields:
          - GAUGE
        tags:
          node: '*'
      - name: vmstats$.scheduler_wall_time$.2$.active
        fields:
          - GAUGE
        tags:
          node: '*'
  - title: vmstats$.scheduler_wall_time$.3.total - active
    line_label: '%node%'
    format: number
    draw_null_as_zero: true
    metrics:
      - name: vmstats$.scheduler_wall_time$.3$.total
        fields:
          - GAUGE
        tags:
          node: '*'
      - name: vmstats$.scheduler_wall_time$.3$.active
        fields:
          - GAUGE
        tags:
          node: '*'
  - title: vmstats$.scheduler_wall_time$.4.total - active
    line_label: '%node%'
    format: number
    draw_null_as_zero: true
    metrics:
      - name: vmstats$.scheduler_wall_time$.4$.total
        fields:
          - GAUGE
        tags:
          node: '*'
      - name: vmstats$.scheduler_wall_time$.4$.active
        fields:
          - GAUGE
        tags:
          node: '*'
  - title: vmstats$.scheduler_wall_time$.5.total - active
    line_label: '%node%'
    format: number
    draw_null_as_zero: true
    metrics:
      - name: vmstats$.scheduler_wall_time$.5$.total
        fields:
          - GAUGE
        tags:
          node: '*'
      - name: vmstats$.scheduler_wall_time$.5$.active
        fields:
          - GAUGE
        tags:
          node: '*'
  - title: vmstats$.scheduler_wall_time$.6.total - active
    line_label: '%node%'
    format: number
    draw_null_as_zero: true
    metrics:
      - name: vmstats$.scheduler_wall_time$.6$.total
        fields:
          - GAUGE
        tags:
          node: '*'
      - name: vmstats$.scheduler_wall_time$.6$.active
        fields:
          - GAUGE
        tags:
          node: '*'
  - title: vmstats$.scheduler_wall_time$.7.total - active
    line_label: '%node%'
    format: number
    draw_null_as_zero: true
    metrics:
      - name: vmstats$.scheduler_wall_time$.7$.total
        fields:
          - GAUGE
        tags:
          node: '*'
      - name: vmstats$.scheduler_wall_time$.7$.active
        fields:
          - GAUGE
        tags:
          node: '*'
  - title: vmstats$.scheduler_wall_time$.8.total - active
    line_label: '%node%'
    format: number
    draw_null_as_zero: true
    metrics:
      - name: vmstats$.scheduler_wall_time$.8$.total
        fields:
          - GAUGE
        tags:
          node: '*'
      - name: vmstats$.scheduler_wall_time$.8$.active
        fields:
          - GAUGE
        tags:
          node: '*'
  - title: vmstats$.reductions
    line_label: '%node%'
    format: number
    draw_null_as_zero: true
    metrics:
      - name: vmstats$.reductions
        fields:
          - COUNTER
        tags:
          node: '*'
  - title: vmstats$.io$.bytes_out
    line_label: '%node%'
    format: size
    format_input: byte
    draw_null_as_zero: true
    metrics:
      - name: vmstats$.io$.bytes_out
        fields:
          - COUNTER
        tags:
          node: '*'
  - title: vmstats$.io$.bytes_in
    line_label: '%node%'
    format: size
    format_input: byte
    draw_null_as_zero: true
    metrics:
      - name: vmstats$.io$.bytes_in
        fields:
          - COUNTER
        tags:
          node: '*'
  - title: vmstats$.gc$.words_reclaimed
    line_label: '%node%'
    format: number
    draw_null_as_zero: true
    metrics:
      - name: vmstats$.gc$.words_reclaimed
        fields:
          - COUNTER
        tags:
          node: '*'
  - title: vmstats$.gc$.count
    line_label: '%node%'
    format: number
    draw_null_as_zero: true
    metrics:
      - name: vmstats$.gc$.count
        fields:
          - COUNTER
        tags:
          node: '*'
  - title: vmstats$.run_queue
    line_label: '%node%'
    format: number
    draw_null_as_zero: true
    metrics:
      - name: vmstats$.run_queue
        fields:
          - GAUGE
        tags:
          node: '*'
  - title: vmstats$.modules
    line_label: '%node%'
    format: number
    draw_null_as_zero: true
    metrics:
      - name: vmstats$.modules
        fields:
          - GAUGE
        tags:
          node: '*'
  - title: vmstats$.port_count
    line_label: '%node%'
    format: number
    draw_null_as_zero: true
    metrics:
      - name: vmstats$.port_count
        fields:
          - GAUGE
        tags:
          node: '*'
  - title: vmstats$.port_limit
    line_label: '%node%'
    format: number
    draw_null_as_zero: true
    metrics:
      - name: vmstats$.port_limit
        fields:
          - GAUGE
        tags:
          node: '*'
  - title: vmstats$.proc_count
    line_label: '%node%'
    format: number
    draw_null_as_zero: true
    metrics:
      - name: vmstats$.proc_count
        fields:
          - GAUGE
        tags:
          node: '*'
  - title: vmstats$.proc_limit
    line_label: '%node%'
    format: number
    draw_null_as_zero: true
    metrics:
      - name: vmstats$.proc_limit
        fields:
          - GAUGE
        tags:
          node: '*'
  - title: vmstats$.messages_in_queues
    line_label: '%node%'
    format: number
    draw_null_as_zero: true
    metrics:
      - name: vmstats$.messages_in_queues
        fields:
          - GAUGE
        tags:
          node: '*'
  - title: vmstats$.memory$.total
    line_label: '%node%'
    format: size
    format_input: byte
    draw_null_as_zero: true
    metrics:
      - name: vmstats$.memory$.total
        fields:
          - GAUGE
        tags:
          node: '*'
  - title: vmstats$.memory$.procs_used
    line_label: '%node%'
    format: size
    format_input: byte
    draw_null_as_zero: true
    metrics:
      - name: vmstats$.memory$.procs_used
        fields:
          - GAUGE
        tags:
          node: '*'
  - title: vmstats$.memory$.ets
    line_label: '%node%'
    format: size
    format_input: byte
    draw_null_as_zero: true
    metrics:
      - name: vmstats$.memory$.ets
        fields:
          - GAUGE
        tags:
          node: '*'
  - title: vmstats$.memory$.binary
    line_label: '%node%'
    format: size
    format_input: byte
    draw_null_as_zero: true
    metrics:
      - name: vmstats$.memory$.binary
        fields:
          - GAUGE
        tags:
          node: '*'
  - title: vmstats$.memory$.atom_used
    line_label: '%node%'
    format: size
    format_input: byte
    draw_null_as_zero: true
    metrics:
      - name: vmstats$.memory$.atom_used
        fields:
          - GAUGE
        tags:
          node: '*'
  - title: vmstats$.error_logger_queue_len
    line_label: '%node%'
    format: number
    draw_null_as_zero: true
    metrics:
      - name: vmstats$.error_logger_queue_len
        fields:
          - GAUGE
        tags:
          node: '*'
  - title: vmstats$.atom_count
    line_label: '%node%'
    format: number
    draw_null_as_zero: true
    metrics:
      - name: vmstats$.atom_count
        fields:
          - GAUGE
        tags:
          node: '*'
```