### PR TITLE
Omg 189 tidy tx api and tests

### DIFF
--- a/apps/omg/lib/omg/fees.ex
+++ b/apps/omg/lib/omg/fees.ex
@@ -85,32 +85,25 @@ defmodule OMG.Fees do
     |> Enum.all?(fn predicate -> predicate.(recovered_tx) end)
   end
 
-  defp has_same_account?(%Transaction.Recovered{
-         signed_tx: %Transaction.Signed{raw_tx: raw_tx},
-         spenders: spenders
-       }) do
-    raw_tx
+  defp has_same_account?(%Transaction.Recovered{spenders: spenders} = tx) do
+    tx
     |> Transaction.get_outputs()
     |> Enum.map(& &1.owner)
     |> Enum.concat(spenders)
     |> single?()
   end
 
-  defp has_single_currency?(%Transaction.Recovered{
-         signed_tx: %Transaction.Signed{raw_tx: raw_tx}
-       }) do
-    raw_tx
+  defp has_single_currency?(tx) do
+    tx
     |> Transaction.get_outputs()
     |> Enum.map(& &1.currency)
     |> single?()
   end
 
-  defp has_less_outputs_than_inputs?(%Transaction.Recovered{
-         signed_tx: %Transaction.Signed{raw_tx: raw_tx}
-       }) do
+  defp has_less_outputs_than_inputs?(tx) do
     has_less_outputs_than_inputs?(
-      Transaction.get_inputs(raw_tx),
-      Transaction.get_outputs(raw_tx)
+      Transaction.get_inputs(tx),
+      Transaction.get_outputs(tx)
     )
   end
 

--- a/apps/omg/lib/omg/fees.ex
+++ b/apps/omg/lib/omg/fees.ex
@@ -51,8 +51,8 @@ defmodule OMG.Fees do
   Returns fees for particular transaction
   """
   @spec for_tx(Transaction.Recovered.t(), fee_t()) :: fee_t()
-  def for_tx(%Transaction.Recovered{} = recovered_tx, fee_map) do
-    if is_merge_transaction?(recovered_tx),
+  def for_tx(tx, fee_map) do
+    if is_merge_transaction?(tx),
       do: :ignore,
       # TODO: reducing fees to output currencies only is incorrect, let's deffer until fees get large
       else: fee_map

--- a/apps/omg/lib/omg/state.ex
+++ b/apps/omg/lib/omg/state.ex
@@ -40,7 +40,7 @@ defmodule OMG.State do
     GenServer.start_link(__MODULE__, :ok, name: __MODULE__)
   end
 
-  @spec exec(tx :: %Transaction.Recovered{}, fees :: Fees.fee_t()) ::
+  @spec exec(tx :: Transaction.Recovered.t(), fees :: Fees.fee_t()) ::
           {:ok, {Transaction.tx_hash(), pos_integer, non_neg_integer}}
           | {:error, exec_error()}
   def exec(tx, input_fees) do

--- a/apps/omg/lib/omg/state/core.ex
+++ b/apps/omg/lib/omg/state/core.ex
@@ -147,39 +147,33 @@ defmodule OMG.State.Core do
           | {{:error, exec_error}, t()}
   def exec(
         %Core{height: height, tx_index: tx_index} = state,
-        %Transaction.Recovered{
-          signed_tx: %Transaction.Signed{raw_tx: raw_tx},
-          tx_hash: tx_hash
-        } = recovered_tx,
+        %Transaction.Recovered{tx_hash: tx_hash} = tx,
         fees
       ) do
-    outputs = Transaction.get_outputs(raw_tx)
+    outputs = Transaction.get_outputs(tx)
 
     with :ok <- validate_block_size(state),
-         {:ok, input_amounts_by_currency} <- correct_inputs?(state, recovered_tx),
+         {:ok, input_amounts_by_currency} <- correct_inputs?(state, tx),
          output_amounts_by_currency = get_amounts_by_currency(outputs),
          :ok <- amounts_add_up?(input_amounts_by_currency, output_amounts_by_currency),
          :ok <- transaction_covers_fee?(input_amounts_by_currency, output_amounts_by_currency, fees) do
       {:ok, {tx_hash, height, tx_index},
        state
-       |> apply_spend(recovered_tx)
-       |> add_pending_tx(recovered_tx)}
+       |> apply_spend(tx)
+       |> add_pending_tx(tx)}
     else
       {:error, _reason} = error -> {error, state}
     end
   end
 
-  defp correct_inputs?(
-         %Core{utxos: utxos} = state,
-         %Transaction.Recovered{
-           signed_tx: %Transaction.Signed{raw_tx: raw_tx}
-         } = recovered_tx
-       ) do
-    inputs = Transaction.get_inputs(raw_tx)
+  defp correct_inputs?(%Core{utxos: utxos} = state, tx) do
+    inputs = Transaction.get_inputs(tx)
 
     with :ok <- inputs_not_from_future_block?(state, inputs),
-         {:ok, inputs} <- inputs_belong_to_spenders?(utxos, recovered_tx) do
-      {:ok, get_amounts_by_currency(inputs)}
+         {:ok, input_utxos} <- get_input_utxos(utxos, inputs),
+         input_utxos_owners <- Enum.map(input_utxos, fn %{owner: owner} -> owner end),
+         :ok <- Transaction.Recovered.all_spenders_authorized(tx, input_utxos_owners) do
+      {:ok, get_amounts_by_currency(input_utxos)}
     end
   end
 
@@ -191,32 +185,15 @@ defmodule OMG.State.Core do
     if no_utxo_from_future_block, do: :ok, else: {:error, :input_utxo_ahead_of_state}
   end
 
-  defp inputs_belong_to_spenders?(
-         utxos,
-         %Transaction.Recovered{
-           signed_tx: %Transaction.Signed{raw_tx: raw_tx}
-         } = recovered_tx
-       ) do
-    inputs = Transaction.get_inputs(raw_tx)
-
-    with {:ok, input_utxos} <- get_input_utxos(utxos, inputs),
-         input_utxos_owners <- Enum.map(input_utxos, fn %{owner: owner} -> owner end),
-         :ok <- Transaction.Recovered.all_spenders_authorized(recovered_tx, input_utxos_owners) do
-      {:ok, input_utxos}
-    end
-  end
-
   defp get_input_utxos(utxos, inputs) do
     inputs
-    |> Enum.reduce({:ok, []}, fn input, acc -> get_utxos(utxos, input, acc) end)
+    |> Enum.reduce_while({:ok, []}, fn input, acc -> get_utxos(utxos, input, acc) end)
   end
-
-  defp get_utxos(_, _, {:error, _} = err), do: err
 
   defp get_utxos(utxos, position, {:ok, acc}) do
     case Map.get(utxos, position) do
-      nil -> {:error, :utxo_not_found}
-      found -> {:ok, acc ++ [found]}
+      nil -> {:halt, {:error, :utxo_not_found}}
+      found -> {:cont, {:ok, acc ++ [found]}}
     end
   end
 
@@ -241,7 +218,7 @@ defmodule OMG.State.Core do
     |> if(do: :ok, else: {:error, :fees_not_covered})
   end
 
-  defp add_pending_tx(%Core{pending_txs: pending_txs, tx_index: tx_index} = state, new_tx) do
+  defp add_pending_tx(%Core{pending_txs: pending_txs, tx_index: tx_index} = state, %Transaction.Recovered{} = new_tx) do
     %Core{
       state
       | tx_index: tx_index + 1,
@@ -249,33 +226,21 @@ defmodule OMG.State.Core do
     }
   end
 
-  defp apply_spend(
-         %Core{height: height, tx_index: tx_index, utxos: utxos} = state,
-         %Transaction.Recovered{
-           signed_tx: %Transaction.Signed{raw_tx: %Transaction{} = raw_tx}
-         } = recovered_tx
-       ) do
-    new_utxos_map =
-      recovered_tx
-      |> non_zero_utxos_from(height, tx_index)
-      |> Map.new()
+  defp apply_spend(%Core{height: height, tx_index: tx_index, utxos: utxos} = state, tx) do
+    new_utxos_map = tx |> non_zero_utxos_from(height, tx_index) |> Map.new()
 
-    inputs = Transaction.get_inputs(raw_tx)
+    inputs = Transaction.get_inputs(tx)
     utxos = Map.drop(utxos, inputs)
     %Core{state | utxos: Map.merge(utxos, new_utxos_map)}
   end
 
-  defp non_zero_utxos_from(%Transaction.Recovered{} = recovered_tx, height, tx_index) do
-    recovered_tx
+  defp non_zero_utxos_from(tx, height, tx_index) do
+    tx
     |> utxos_from(height, tx_index)
     |> Enum.filter(fn {_key, value} -> is_non_zero_amount?(value) end)
   end
 
-  defp utxos_from(
-         %Transaction.Recovered{signed_tx: %Transaction.Signed{raw_tx: %Transaction{} = tx}, tx_hash: hash},
-         height,
-         tx_index
-       ) do
+  defp utxos_from(%Transaction.Recovered{tx_hash: hash} = tx, height, tx_index) do
     outputs = Transaction.get_outputs(tx)
 
     for {%{owner: owner, currency: currency, amount: amount}, oindex} <- Enum.with_index(outputs) do
@@ -312,16 +277,12 @@ defmodule OMG.State.Core do
     db_updates_new_utxos =
       txs
       |> Enum.with_index()
-      |> Enum.flat_map(fn {tx, tx_idx} ->
-        non_zero_utxos_from(tx, height, tx_idx)
-      end)
+      |> Enum.flat_map(fn {tx, tx_idx} -> non_zero_utxos_from(tx, height, tx_idx) end)
       |> Enum.map(&utxo_to_db_put/1)
 
     db_updates_spent_utxos =
       txs
-      |> Enum.flat_map(fn %Transaction.Recovered{signed_tx: %Transaction.Signed{raw_tx: tx}} ->
-        Transaction.get_inputs(tx)
-      end)
+      |> Enum.flat_map(&Transaction.get_inputs/1)
       |> Enum.flat_map(fn utxo_pos ->
         # NOTE: child chain mode don't need 'spend' data for now. Consider to add only in Watcher's modes - OMG-382
         db_key = Utxo.Position.to_db_key(utxo_pos)
@@ -431,11 +392,10 @@ defmodule OMG.State.Core do
 
   def exit_utxos([%{call_data: %{in_flight_tx: _}} | _] = in_flight_txs, %Core{} = state) do
     in_flight_txs
-    |> Enum.map(fn %{call_data: %{in_flight_tx: tx_bytes}} ->
+    |> Enum.flat_map(fn %{call_data: %{in_flight_tx: tx_bytes}} ->
       {:ok, tx} = Transaction.decode(tx_bytes)
       Transaction.get_inputs(tx)
     end)
-    |> List.flatten()
     |> exit_utxos(state)
   end
 

--- a/apps/omg/lib/omg/state/core.ex
+++ b/apps/omg/lib/omg/state/core.ex
@@ -147,9 +147,10 @@ defmodule OMG.State.Core do
           | {{:error, exec_error}, t()}
   def exec(
         %Core{height: height, tx_index: tx_index} = state,
-        %Transaction.Recovered{tx_hash: tx_hash} = tx,
+        %Transaction.Recovered{} = tx,
         fees
       ) do
+    tx_hash = Transaction.raw_txhash(tx)
     outputs = Transaction.get_outputs(tx)
 
     with :ok <- validate_block_size(state),
@@ -240,7 +241,8 @@ defmodule OMG.State.Core do
     |> Enum.filter(fn {_key, value} -> is_non_zero_amount?(value) end)
   end
 
-  defp utxos_from(%Transaction.Recovered{tx_hash: hash} = tx, height, tx_index) do
+  defp utxos_from(tx, height, tx_index) do
+    hash = Transaction.raw_txhash(tx)
     outputs = Transaction.get_outputs(tx)
 
     for {%{owner: owner, currency: currency, amount: amount}, oindex} <- Enum.with_index(outputs) do

--- a/apps/omg/lib/omg/state/transaction.ex
+++ b/apps/omg/lib/omg/state/transaction.ex
@@ -97,7 +97,10 @@ defmodule OMG.State.Transaction do
           list({Crypto.address_t(), currency(), pos_integer}),
           metadata()
         ) :: t()
-  def new(inputs, outputs, metadata \\ @default_metadata) when is_metadata(metadata) do
+  def new(inputs, outputs, metadata \\ @default_metadata)
+
+  def new(inputs, outputs, metadata)
+      when is_metadata(metadata) and length(inputs) <= @max_inputs and length(outputs) <= @max_outputs do
     inputs =
       inputs
       |> Enum.map(fn {blknum, txindex, oindex} -> %{blknum: blknum, txindex: txindex, oindex: oindex} end)

--- a/apps/omg/lib/omg/state/transaction.ex
+++ b/apps/omg/lib/omg/state/transaction.ex
@@ -36,6 +36,8 @@ defmodule OMG.State.Transaction do
           metadata: metadata()
         }
 
+  @type any_flavor_t() :: t() | __MODULE__.Signed.t() | __MODULE__.Recovered.t()
+
   @type currency() :: Crypto.address_t()
   @type tx_bytes() :: binary()
   @type tx_hash() :: Crypto.hash_t()
@@ -214,7 +216,7 @@ defmodule OMG.State.Transaction do
   @doc """
   Returns all inputs
   """
-  @spec get_inputs(t() | __MODULE__.Signed.t() | __MODULE__.Recovered.t()) :: list(input())
+  @spec get_inputs(any_flavor_t()) :: list(input())
   def get_inputs(%__MODULE__.Recovered{signed_tx: signed_tx}), do: get_inputs(signed_tx)
   def get_inputs(%__MODULE__.Signed{raw_tx: raw_tx}), do: get_inputs(raw_tx)
 
@@ -227,7 +229,7 @@ defmodule OMG.State.Transaction do
   @doc """
   Returns all outputs
   """
-  @spec get_outputs(t() | __MODULE__.Signed.t() | __MODULE__.Recovered.t()) :: list(output())
+  @spec get_outputs(any_flavor_t()) :: list(output())
   def get_outputs(%__MODULE__.Recovered{signed_tx: signed_tx}), do: get_outputs(signed_tx)
   def get_outputs(%__MODULE__.Signed{raw_tx: raw_tx}), do: get_outputs(raw_tx)
 
@@ -240,7 +242,7 @@ defmodule OMG.State.Transaction do
   @doc """
   Returns the encoded bytes of a raw transaction, i.e. without the signatures
   """
-  @spec raw_txbytes(t() | __MODULE__.Signed.t() | __MODULE__.Recovered.t()) :: binary
+  @spec raw_txbytes(any_flavor_t()) :: binary
   def raw_txbytes(%__MODULE__.Recovered{signed_tx: signed_tx}), do: raw_txbytes(signed_tx)
   def raw_txbytes(%__MODULE__.Signed{raw_tx: raw_tx}), do: raw_txbytes(raw_tx)
   def raw_txbytes(%__MODULE__{} = raw_tx), do: encode(raw_tx)
@@ -248,7 +250,7 @@ defmodule OMG.State.Transaction do
   @doc """
   Returns the hash of a raw transaction, i.e. without the signatures
   """
-  @spec raw_txhash(t() | __MODULE__.Signed.t() | __MODULE__.Recovered.t()) :: binary
+  @spec raw_txhash(any_flavor_t()) :: binary
   def raw_txhash(%__MODULE__.Recovered{signed_tx: signed_tx}), do: raw_txhash(signed_tx)
   def raw_txhash(%__MODULE__.Signed{raw_tx: raw_tx}), do: raw_txhash(raw_tx)
   def raw_txhash(%__MODULE__{} = raw_tx), do: hash(raw_tx)

--- a/apps/omg/lib/omg/state/transaction.ex
+++ b/apps/omg/lib/omg/state/transaction.ex
@@ -214,6 +214,10 @@ defmodule OMG.State.Transaction do
   @doc """
   Returns all inputs
   """
+  @spec get_inputs(t() | __MODULE__.Signed.t() | __MODULE__.Recovered.t()) :: list(input())
+  def get_inputs(%__MODULE__.Recovered{signed_tx: signed_tx}), do: get_inputs(signed_tx)
+  def get_inputs(%__MODULE__.Signed{raw_tx: raw_tx}), do: get_inputs(raw_tx)
+
   def get_inputs(%__MODULE__{inputs: inputs}) do
     inputs
     |> Enum.reject(&match?(%{blknum: 0, txindex: 0, oindex: 0}, &1))
@@ -223,11 +227,15 @@ defmodule OMG.State.Transaction do
   @doc """
   Returns all outputs
   """
+  @spec get_outputs(t() | __MODULE__.Signed.t() | __MODULE__.Recovered.t()) :: list(output())
+  def get_outputs(%__MODULE__.Recovered{signed_tx: signed_tx}), do: get_outputs(signed_tx)
+  def get_outputs(%__MODULE__.Signed{raw_tx: raw_tx}), do: get_outputs(raw_tx)
+
   @spec get_outputs(t()) :: list(output())
-  def get_outputs(%__MODULE__{outputs: outputs}),
-    do:
-      outputs
-      |> Enum.reject(&match?(%{owner: @zero_address, currency: @zero_address, amount: 0}, &1))
+  def get_outputs(%__MODULE__{outputs: outputs}) do
+    outputs
+    |> Enum.reject(&match?(%{owner: @zero_address, currency: @zero_address, amount: 0}, &1))
+  end
 
   defp inputs_without_gaps(inputs),
     do: check_for_gaps(inputs, %{blknum: 0, txindex: 0, oindex: 0}, {:error, :inputs_contain_gaps})

--- a/apps/omg/lib/omg/state/transaction.ex
+++ b/apps/omg/lib/omg/state/transaction.ex
@@ -121,10 +121,6 @@ defmodule OMG.State.Transaction do
     %__MODULE__{inputs: inputs, outputs: outputs, metadata: metadata}
   end
 
-  def account_address?(@zero_address), do: false
-  def account_address?(address) when is_binary(address) and byte_size(address) == 20, do: true
-  def account_address?(_), do: false
-
   def reconstruct([inputs_rlp, outputs_rlp | rest_rlp])
       when rest_rlp == [] or length(rest_rlp) == 1 do
     with {:ok, inputs} <- reconstruct_inputs(inputs_rlp),

--- a/apps/omg/lib/omg/state/transaction.ex
+++ b/apps/omg/lib/omg/state/transaction.ex
@@ -222,8 +222,8 @@ defmodule OMG.State.Transaction do
 
   def get_inputs(%__MODULE__{inputs: inputs}) do
     inputs
-    |> Enum.reject(&match?(%{blknum: 0, txindex: 0, oindex: 0}, &1))
     |> Enum.map(fn %{blknum: blknum, txindex: txindex, oindex: oindex} -> Utxo.position(blknum, txindex, oindex) end)
+    |> Enum.filter(&Utxo.Position.non_zero?/1)
   end
 
   @doc """
@@ -233,7 +233,6 @@ defmodule OMG.State.Transaction do
   def get_outputs(%__MODULE__.Recovered{signed_tx: signed_tx}), do: get_outputs(signed_tx)
   def get_outputs(%__MODULE__.Signed{raw_tx: raw_tx}), do: get_outputs(raw_tx)
 
-  @spec get_outputs(t()) :: list(output())
   def get_outputs(%__MODULE__{outputs: outputs}) do
     outputs
     |> Enum.reject(&match?(%{owner: @zero_address, currency: @zero_address, amount: 0}, &1))

--- a/apps/omg/lib/omg/state/transaction.ex
+++ b/apps/omg/lib/omg/state/transaction.ex
@@ -189,7 +189,7 @@ defmodule OMG.State.Transaction do
   end
 
   @spec encode(t()) :: tx_bytes()
-  def encode(transaction) do
+  defp encode(transaction) do
     get_data_for_rlp(transaction)
     |> ExRLP.encode()
   end
@@ -205,7 +205,7 @@ defmodule OMG.State.Transaction do
       ] ++ if(metadata, do: [metadata], else: [])
 
   @spec hash(t()) :: tx_hash()
-  def hash(%__MODULE__{} = tx) do
+  defp hash(%__MODULE__{} = tx) do
     tx
     |> encode
     |> Crypto.hash()
@@ -236,6 +236,22 @@ defmodule OMG.State.Transaction do
     outputs
     |> Enum.reject(&match?(%{owner: @zero_address, currency: @zero_address, amount: 0}, &1))
   end
+
+  @doc """
+  Returns the encoded bytes of a raw transaction, i.e. without the signatures
+  """
+  @spec raw_txbytes(t() | __MODULE__.Signed.t() | __MODULE__.Recovered.t()) :: binary
+  def raw_txbytes(%__MODULE__.Recovered{signed_tx: signed_tx}), do: raw_txbytes(signed_tx)
+  def raw_txbytes(%__MODULE__.Signed{raw_tx: raw_tx}), do: raw_txbytes(raw_tx)
+  def raw_txbytes(%__MODULE__{} = raw_tx), do: encode(raw_tx)
+
+  @doc """
+  Returns the hash of a raw transaction, i.e. without the signatures
+  """
+  @spec raw_txhash(t() | __MODULE__.Signed.t() | __MODULE__.Recovered.t()) :: binary
+  def raw_txhash(%__MODULE__.Recovered{signed_tx: signed_tx}), do: raw_txhash(signed_tx)
+  def raw_txhash(%__MODULE__.Signed{raw_tx: raw_tx}), do: raw_txhash(raw_tx)
+  def raw_txhash(%__MODULE__{} = raw_tx), do: hash(raw_tx)
 
   defp inputs_without_gaps(inputs),
     do: check_for_gaps(inputs, %{blknum: 0, txindex: 0, oindex: 0}, {:error, :inputs_contain_gaps})

--- a/apps/omg/lib/omg/state/transaction/recovered.ex
+++ b/apps/omg/lib/omg/state/transaction/recovered.ex
@@ -76,9 +76,9 @@ defmodule OMG.State.Transaction.Recovered do
   end
 
   @spec recover_from_struct(Transaction.Signed.t()) :: {:ok, t()} | {:error, recover_tx_error()}
-  defp recover_from_struct(%Transaction.Signed{raw_tx: raw_tx} = signed_tx) do
+  defp recover_from_struct(%Transaction.Signed{} = signed_tx) do
     with {:ok, spenders} <- Transaction.Signed.get_spenders(signed_tx),
-         do: {:ok, %__MODULE__{tx_hash: Transaction.hash(raw_tx), spenders: spenders, signed_tx: signed_tx}}
+         do: {:ok, %__MODULE__{tx_hash: Transaction.raw_txhash(signed_tx), spenders: spenders, signed_tx: signed_tx}}
   end
 
   defp valid?(%Transaction.Signed{sigs: sigs} = tx) do

--- a/apps/omg/lib/omg/state/transaction/recovered.ex
+++ b/apps/omg/lib/omg/state/transaction/recovered.ex
@@ -109,8 +109,9 @@ defmodule OMG.State.Transaction.Recovered do
     |> Enum.find(:ok, &(&1 != :ok))
   end
 
-  defp input_signature_valid({Utxo.position(0, _, _), @empty_signature}), do: :ok
-  defp input_signature_valid({Utxo.position(0, _, _), _}), do: {:error, :signature_corrupt}
-  defp input_signature_valid({_, @empty_signature}), do: {:error, :missing_signature}
-  defp input_signature_valid({_, _}), do: :ok
+  defp input_signature_valid({utxo_pos, @empty_signature}),
+    do: if(Utxo.Position.non_zero?(utxo_pos), do: {:error, :missing_signature}, else: :ok)
+
+  defp input_signature_valid({utxo_pos, _}),
+    do: if(Utxo.Position.non_zero?(utxo_pos), do: :ok, else: {:error, :superfluous_signature})
 end

--- a/apps/omg/lib/omg/state/transaction/recovered.ex
+++ b/apps/omg/lib/omg/state/transaction/recovered.ex
@@ -81,11 +81,8 @@ defmodule OMG.State.Transaction.Recovered do
          do: {:ok, %__MODULE__{tx_hash: Transaction.hash(raw_tx), spenders: spenders, signed_tx: signed_tx}}
   end
 
-  defp valid?(%Transaction.Signed{
-         raw_tx: raw_tx,
-         sigs: sigs
-       }) do
-    inputs = Transaction.get_inputs(raw_tx)
+  defp valid?(%Transaction.Signed{sigs: sigs} = tx) do
+    inputs = Transaction.get_inputs(tx)
 
     with :ok <- no_duplicate_inputs?(inputs) do
       all_inputs_signed?(inputs, sigs)

--- a/apps/omg/lib/omg/state/transaction/signed.ex
+++ b/apps/omg/lib/omg/state/transaction/signed.ex
@@ -14,7 +14,9 @@
 
 defmodule OMG.State.Transaction.Signed do
   @moduledoc """
-  Representation of a signed transaction
+  Representation of a signed transaction.
+
+  NOTE: before you use this, make sure you shouldn't use `Transaction` or `Transaction.Recovered`
   """
 
   alias OMG.Crypto

--- a/apps/omg/lib/omg/state/transaction/signed.ex
+++ b/apps/omg/lib/omg/state/transaction/signed.ex
@@ -52,7 +52,7 @@ defmodule OMG.State.Transaction.Signed do
   """
   @spec get_spenders(t()) :: {:ok, list(Crypto.address_t())} | {:error, atom}
   def get_spenders(%Transaction.Signed{raw_tx: raw_tx, sigs: sigs}) do
-    hash_without_sigs = Transaction.hash(raw_tx)
+    hash_without_sigs = Transaction.raw_txhash(raw_tx)
 
     with {:ok, reversed_spenders} <- get_reversed_spenders(hash_without_sigs, sigs),
          do: {:ok, Enum.reverse(reversed_spenders)}

--- a/apps/omg/lib/omg/utxo/position.ex
+++ b/apps/omg/lib/omg/utxo/position.ex
@@ -47,6 +47,10 @@ defmodule OMG.Utxo.Position do
     Utxo.position(blknum, txindex, oindex)
   end
 
+  @spec non_zero?(t()) :: boolean()
+  def non_zero?(Utxo.position(0, 0, 0)), do: false
+  def non_zero?(Utxo.position(_, _, _)), do: true
+
   @spec to_db_key(t()) :: {pos_integer, non_neg_integer, non_neg_integer}
   def to_db_key(Utxo.position(blknum, txindex, oindex)), do: {blknum, txindex, oindex}
 

--- a/apps/omg/test/omg/state/core_test.exs
+++ b/apps/omg/test/omg/state/core_test.exs
@@ -578,17 +578,13 @@ defmodule OMG.State.CoreTest do
   @tag fixtures: [:alice, :state_alice_deposit]
   test "removed utxo after piggyback from available utxo", %{alice: alice, state_alice_deposit: state} do
     # persistence tested in-depth elsewhere
-    %Transaction.Recovered{tx_hash: tx_hash, signed_tx: %Transaction.Signed{raw_tx: raw_tx}} =
-      tx = create_recovered([{1, 0, 0, alice}], @eth, [{alice, 7}, {alice, 3}])
+    tx = create_recovered([{1, 0, 0, alice}], @eth, [{alice, 7}, {alice, 3}])
 
-    state =
-      state
-      |> Core.exec(tx, :ignore)
-      |> success?
+    state = state |> Core.exec(tx, :ignore) |> success?
 
     expected_owner = alice.addr
-    utxo_pos_exits_in_flight = [%{call_data: %{in_flight_tx: Transaction.encode(raw_tx)}}]
-    utxo_pos_exits_piggyback = [%{tx_hash: tx_hash, output_index: 4}]
+    utxo_pos_exits_in_flight = [%{call_data: %{in_flight_tx: Transaction.raw_txbytes(tx)}}]
+    utxo_pos_exits_piggyback = [%{tx_hash: Transaction.raw_txhash(tx), output_index: 4}]
     expected_position = Utxo.position(@blknum1, 0, 0)
 
     assert {:ok, {[], [], {[], _}}, ^state} = Core.exit_utxos(utxo_pos_exits_in_flight, state)
@@ -613,11 +609,10 @@ defmodule OMG.State.CoreTest do
       |> Core.exec(create_recovered([{1, 0, 0, alice}], @eth, [{alice, 7}, {alice, 3}]), :ignore)
       |> success?
 
-    %Transaction.Recovered{signed_tx: %Transaction.Signed{raw_tx: raw_tx}} =
-      create_recovered([{@blknum1, 0, 0, alice}], @eth, [{alice, 3}, {alice, 3}])
+    tx = create_recovered([{@blknum1, 0, 0, alice}], @eth, [{alice, 3}, {alice, 3}])
 
     expected_owner = alice.addr
-    utxo_pos_exits_in_flight = [%{call_data: %{in_flight_tx: Transaction.encode(raw_tx)}}]
+    utxo_pos_exits_in_flight = [%{call_data: %{in_flight_tx: Transaction.raw_txbytes(tx)}}]
     expected_position = Utxo.position(@blknum1, 0, 0)
 
     assert {:ok,

--- a/apps/omg/test/omg/state/persistence_test.exs
+++ b/apps/omg/test/omg/state/persistence_test.exs
@@ -89,11 +89,10 @@ defmodule OMG.State.PersistenceTest do
   @tag fixtures: [:alice, :state_empty]
   test "persists piggyback related exits",
        %{alice: alice, db_pid: db_pid, state_empty: state} do
-    %Transaction.Recovered{tx_hash: tx_hash, signed_tx: %Transaction.Signed{raw_tx: raw_tx}} =
-      tx = create_recovered([{1, 0, 0, alice}], @eth, [{alice, 7}, {alice, 3}])
+    tx = create_recovered([{1, 0, 0, alice}], @eth, [{alice, 7}, {alice, 3}])
 
-    utxo_pos_exits_in_flight = [%{call_data: %{in_flight_tx: Transaction.encode(raw_tx)}}]
-    utxo_pos_exits_piggyback = [%{tx_hash: tx_hash, output_index: 4}]
+    utxo_pos_exits_in_flight = [%{call_data: %{in_flight_tx: Transaction.raw_txbytes(tx)}}]
+    utxo_pos_exits_piggyback = [%{tx_hash: Transaction.raw_txhash(tx), output_index: 4}]
 
     state
     |> persist_deposit([%{owner: alice.addr, currency: @eth, amount: 20, blknum: 1}], db_pid)
@@ -106,9 +105,9 @@ defmodule OMG.State.PersistenceTest do
   @tag fixtures: [:alice, :state_empty]
   test "persists ife related exits",
        %{alice: alice, db_pid: db_pid, state_empty: state} do
-    %Transaction.Signed{raw_tx: raw_tx} = create_signed([{1, 0, 0, alice}], @eth, [{alice, 7}, {alice, 3}])
+    tx = create_signed([{1, 0, 0, alice}], @eth, [{alice, 7}, {alice, 3}])
 
-    utxo_pos_exits_in_flight = [%{call_data: %{in_flight_tx: Transaction.encode(raw_tx)}}]
+    utxo_pos_exits_in_flight = [%{call_data: %{in_flight_tx: Transaction.raw_txbytes(tx)}}]
 
     state
     |> persist_deposit([%{owner: alice.addr, currency: @eth, amount: 20, blknum: 1}], db_pid)

--- a/apps/omg/test/omg/state/transaction/recovered_test.exs
+++ b/apps/omg/test/omg/state/transaction/recovered_test.exs
@@ -97,12 +97,22 @@ defmodule OMG.State.Transaction.RecoveredTest do
   end
 
   @tag fixtures: [:alice]
-  test "transactions with corrupt signatures don't do harm - one signature", %{alice: alice} do
+  test "transactions with superfluous signatures don't do harm", %{alice: alice} do
     full_signed_tx = TestHelper.create_signed([{1, 2, 3, alice}], eth(), [{alice, 7}])
     %Transaction.Signed{sigs: [sig1 | _]} = full_signed_tx
 
+    assert {:error, :superfluous_signature} ==
+             %Transaction.Signed{full_signed_tx | sigs: [sig1, sig1]}
+             |> Transaction.Signed.encode()
+             |> Transaction.Recovered.recover_from()
+  end
+
+  @tag fixtures: [:alice]
+  test "transactions with corrupt signatures don't do harm - one signature", %{alice: alice} do
+    full_signed_tx = TestHelper.create_signed([{1, 2, 3, alice}], eth(), [{alice, 7}])
+
     assert {:error, :signature_corrupt} ==
-             %Transaction.Signed{full_signed_tx | sigs: [<<1::size(520)>>, sig1]}
+             %Transaction.Signed{full_signed_tx | sigs: [<<1::size(520)>>]}
              |> Transaction.Signed.encode()
              |> Transaction.Recovered.recover_from()
   end

--- a/apps/omg/test/omg/state/transaction_test.exs
+++ b/apps/omg/test/omg/state/transaction_test.exs
@@ -13,257 +13,380 @@
 # limitations under the License.
 
 defmodule OMG.State.TransactionTest do
+  @moduledoc """
+  This test the public-most APIs regarging the transaction, being mainly centered around:
+    - recovery and stateless validation done in `Transaction.Recovered`
+    - creation and encoding of raw transactions
+    - some basic checks of internal APIs used elsewhere - getting inputs/outputs, spend authorization, hashing, encoding
+  """
   use ExUnitFixtures
   use ExUnit.Case, async: true
 
   alias OMG.DevCrypto
-  alias OMG.State.Core
+  alias OMG.State
   alias OMG.State.Transaction
   alias OMG.TestHelper
+  alias OMG.Utxo
+
+  require Utxo
 
   @zero_address OMG.Eth.zero_address()
+  @eth OMG.Eth.RootChain.eth_pseudo_address()
+  @utxo_positions [{20, 42, 1}, {2, 21, 0}, {1000, 0, 0}, {10_001, 0, 0}]
+  @transaction Transaction.new(
+                 [{1, 1, 0}, {1, 2, 1}],
+                 [{"alicealicealicealice", @eth, 1}, {"carolcarolcarolcarol", @eth, 2}],
+                 <<0::256>>
+               )
 
-  deffixture transaction do
-    Transaction.new(
-      [{1, 1, 0}, {1, 2, 1}],
-      [{"alicealicealicealice", eth(), 1}, {"carolcarolcarolcarol", eth(), 2}],
-      <<0::256>>
-    )
-  end
+  @empty_signature <<0::size(520)>>
+  @no_owner %{priv: <<>>, addr: nil}
 
-  deffixture utxos do
-    [{20, 42, 1}, {2, 21, 0}]
-  end
+  describe "hashing and metadata field" do
+    test "create transaction with metadata" do
+      tx_with_metadata = Transaction.new(@utxo_positions, [{"Joe Black", @eth, 53}], <<42::256>>)
+      tx_without_metadata = Transaction.new(@utxo_positions, [{"Joe Black", @eth, 53}])
 
-  def eth, do: OMG.Eth.RootChain.eth_pseudo_address()
+      assert Transaction.raw_txhash(tx_with_metadata) != Transaction.raw_txhash(tx_without_metadata)
 
-  @tag fixtures: [:transaction]
-  test "transaction hash is correct", %{transaction: transaction} do
-    {:ok, hash_value} = Base.decode16("09645ee9736332be55eaccf9d08ff572a6fa23e2f6dc2aac42dbf09832d8f60e", case: :lower)
-    assert Transaction.hash(transaction) == hash_value
-  end
-
-  @tag fixtures: [:utxos]
-  test "create transaction with different number inputs and oputputs", %{utxos: utxos} do
-    # 1 - input, 1 - output
-    assert Transaction.new([hd(utxos)], [{"Joe Black", eth(), 99}]) == %Transaction{
-             inputs: [%{blknum: 20, txindex: 42, oindex: 1} | List.duplicate(%{blknum: 0, oindex: 0, txindex: 0}, 3)],
-             outputs: [
-               %{owner: "Joe Black", currency: eth(), amount: 99}
-               | List.duplicate(%{owner: @zero_address, currency: eth(), amount: 0}, 3)
-             ]
-           }
-
-    # 1 - input, 2 - outputs
-    assert Transaction.new(tl(utxos), [{"Joe Black", eth(), 22}, {"McDuck", eth(), 21}]) == %Transaction{
-             inputs: [%{blknum: 2, txindex: 21, oindex: 0} | List.duplicate(%{blknum: 0, txindex: 0, oindex: 0}, 3)],
-             outputs: [
-               %{owner: "Joe Black", currency: eth(), amount: 22},
-               %{owner: "McDuck", currency: eth(), amount: 21}
-               | List.duplicate(%{owner: @zero_address, currency: eth(), amount: 0}, 2)
-             ]
-           }
-
-    # 2 - inputs, 2 - outputs
-    assert Transaction.new(utxos, [{"Joe Black", eth(), 53}, {"McDuck", eth(), 90}]) == %Transaction{
-             inputs: [
-               %{blknum: 20, txindex: 42, oindex: 1},
-               %{blknum: 2, txindex: 21, oindex: 0} | List.duplicate(%{blknum: 0, txindex: 0, oindex: 0}, 2)
-             ],
-             outputs: [
-               %{owner: "Joe Black", currency: eth(), amount: 53},
-               %{owner: "McDuck", currency: eth(), amount: 90}
-               | List.duplicate(%{owner: @zero_address, currency: eth(), amount: 0}, 2)
-             ]
-           }
-
-    # 2 - inputs, 0 - outputs
-    assert Transaction.new(utxos, []) == %Transaction{
-             inputs: [
-               %{blknum: 20, txindex: 42, oindex: 1},
-               %{blknum: 2, txindex: 21, oindex: 0} | List.duplicate(%{blknum: 0, txindex: 0, oindex: 0}, 2)
-             ],
-             outputs: List.duplicate(%{owner: @zero_address, currency: eth(), amount: 0}, 4)
-           }
-  end
-
-  @tag fixtures: [:utxos]
-  test "create transaction with metadata", %{utxos: utxos} do
-    assert Transaction.new(utxos, [{"Joe Black", eth(), 53}], <<42::256>>) == %Transaction{
-             inputs: [
-               %{blknum: 20, txindex: 42, oindex: 1},
-               %{blknum: 2, txindex: 21, oindex: 0} | List.duplicate(%{blknum: 0, txindex: 0, oindex: 0}, 2)
-             ],
-             outputs: [
-               %{owner: "Joe Black", currency: eth(), amount: 53}
-               | List.duplicate(%{owner: @zero_address, currency: eth(), amount: 0}, 3)
-             ],
-             metadata: <<42::256>>
-           }
-  end
-
-  @tag fixtures: [:utxos]
-  test "incorrect metadata", %{utxos: utxos} do
-    # too long metadata
-    assert_raise FunctionClauseError, fn ->
-      Transaction.new(utxos, [%{owner: "Joe Black", currency: eth(), amount: 53}], String.duplicate("0", 90))
+      assert byte_size(Transaction.raw_txbytes(tx_with_metadata)) >
+               byte_size(Transaction.raw_txbytes(tx_without_metadata))
     end
 
-    # incorrect type
-    assert_raise FunctionClauseError, fn ->
-      Transaction.new(utxos, [%{owner: "Joe Black", currency: eth(), amount: 53}], 42)
+    test "raw transaction hash is invariant" do
+      {:ok, hash_value} =
+        Base.decode16("09645ee9736332be55eaccf9d08ff572a6fa23e2f6dc2aac42dbf09832d8f60e", case: :lower)
+
+      assert Transaction.raw_txhash(@transaction) == hash_value
     end
   end
 
-  @tag fixtures: [:alice, :state_alice_deposit, :bob]
-  test "using created transaction in child chain", %{alice: alice, bob: bob, state_alice_deposit: state} do
-    state =
-      state
-      |> TestHelper.do_deposit(alice, %{amount: 10, currency: eth(), blknum: 2})
+  describe "APIs used by the `OMG.State.exec/1`" do
+    @tag fixtures: [:alice, :state_alice_deposit, :bob]
+    test "using created transaction in child chain", %{alice: alice, bob: bob, state_alice_deposit: state} do
+      state = state |> TestHelper.do_deposit(alice, %{amount: 10, currency: @eth, blknum: 2})
 
-    transaction = Transaction.new([{1, 0, 0}, {2, 0, 0}], [{bob.addr, eth(), 12}])
+      Transaction.new([{1, 0, 0}, {2, 0, 0}], [{bob.addr, @eth, 12}])
+      |> DevCrypto.sign([alice.priv, alice.priv])
+      |> assert_tx_usable(state)
+    end
 
-    transaction
-    |> DevCrypto.sign([alice.priv, alice.priv])
-    |> assert_tx_usable(state)
+    @tag fixtures: [:alice, :state_alice_deposit, :bob]
+    test "using created transaction with one input in child chain", %{
+      alice: alice,
+      bob: bob,
+      state_alice_deposit: state
+    } do
+      Transaction.new([{1, 0, 0}], [{bob.addr, @eth, 4}])
+      |> DevCrypto.sign([alice.priv, <<>>])
+      |> assert_tx_usable(state)
+    end
+
+    test "create transaction with different number inputs and outputs" do
+      check_input1 = Utxo.position(20, 42, 1)
+      output1 = {"Joe Black", @eth, 99}
+      check_output2 = %{amount: 99, currency: @eth, owner: "Joe Black"}
+      # 1 - input, 1 - output
+      tx1_1 = Transaction.new([hd(@utxo_positions)], [output1])
+      assert 1 == tx1_1 |> Transaction.get_inputs() |> Enum.filter(&Utxo.Position.non_zero?/1) |> length()
+      assert 1 == tx1_1 |> Transaction.get_outputs() |> Enum.filter(&(&1.amount != 0)) |> length()
+      assert [^check_input1 | _] = Transaction.get_inputs(tx1_1)
+      assert [^check_output2 | _] = Transaction.get_outputs(tx1_1)
+      # 4 - input, 4 - outputs
+      tx4_4 = Transaction.new(@utxo_positions, [output1, {"J", @eth, 929}, {"J", @eth, 929}, {"J", @eth, 199}])
+      assert 4 == tx4_4 |> Transaction.get_inputs() |> Enum.filter(&Utxo.Position.non_zero?/1) |> length()
+      assert 4 == tx4_4 |> Transaction.get_outputs() |> Enum.filter(&(&1.amount != 0)) |> length()
+      assert [^check_input1 | _] = Transaction.get_inputs(tx4_4)
+      assert [^check_output2 | _] = Transaction.get_outputs(tx4_4)
+
+      # NOTE: this is temporary behavior - as soon as we filter out non_zeros from get_inputs, remove this test
+      #       **AND** remove the filterings above
+      assert 4 == tx1_1 |> Transaction.get_inputs() |> length()
+      assert 4 == tx1_1 |> Transaction.get_outputs() |> length()
+    end
+
+    @tag fixtures: [:alice, :bob]
+    test "recovering spenders: different signers, one output", %{alice: alice, bob: bob} do
+      {:ok, recovered} =
+        [{3000, 0, 0}, {3000, 0, 1}]
+        |> Transaction.new([{alice.addr, @eth, 10}])
+        |> DevCrypto.sign([bob.priv, alice.priv])
+        |> Transaction.Signed.encode()
+        |> Transaction.Recovered.recover_from()
+
+      assert recovered.spenders == [bob.addr, alice.addr]
+    end
+
+    @tag fixtures: [:alice, :bob, :carol]
+    test "checks if spenders are authorized", %{alice: alice, bob: bob, carol: carol} do
+      authorized_tx = TestHelper.create_recovered([{1, 1, 0, alice}, {1, 3, 0, bob}], @eth, [{bob, 6}, {alice, 4}])
+
+      :ok = Transaction.Recovered.all_spenders_authorized(authorized_tx, [alice.addr, bob.addr])
+
+      {:error, :unauthorized_spent} = Transaction.Recovered.all_spenders_authorized(authorized_tx, [carol.addr])
+
+      {:error, :unauthorized_spent} =
+        Transaction.Recovered.all_spenders_authorized(authorized_tx, [alice.addr, carol.addr])
+    end
+
+    @tag fixtures: [:alice, :bob]
+    test "restrictive spender checks: signature indices correspond to input indices", %{alice: alice, bob: bob} do
+      # an additional check on the authorization which might be dropped later - for now we require all inputs to be
+      # signed in order, because this is what the contract requires
+      authorized_tx = TestHelper.create_recovered([{1, 1, 0, alice}, {1, 3, 0, bob}], @eth, [{bob, 6}, {alice, 4}])
+
+      {:error, :unauthorized_spent} =
+        Transaction.Recovered.all_spenders_authorized(authorized_tx, [bob.addr, alice.addr])
+
+      {:error, :unauthorized_spent} =
+        Transaction.Recovered.all_spenders_authorized(authorized_tx, [alice.addr, alice.addr, bob.addr])
+    end
+
+    @tag fixtures: [:alice, :bob]
+    test "signed transaction is valid in all input zeroing combinations", %{
+      alice: alice,
+      bob: bob
+    } do
+      [
+        {[{1, 2, 3, alice}, {2, 3, 4, bob}], [{alice, @eth, 7}, {bob, @eth, 3}]},
+        {[{1, 2, 3, alice}, {0, 0, 0, @no_owner}], [{alice, @eth, 7}, {bob, @eth, 3}]},
+        {[{1, 2, 3, alice}, {2, 3, 4, bob}, {0, 0, 0, @no_owner}, {0, 0, 0, @no_owner}],
+         [{alice, @eth, 7}, {bob, @eth, 3}]}
+      ]
+      |> Enum.map(&parametrized_tester/1)
+    end
+
+    @tag fixtures: [:alice, :bob]
+    test "transaction with 4in/4out is valid", %{alice: alice, bob: bob} do
+      [
+        {[{1, 2, 3, alice}, {2, 3, 1, alice}, {2, 3, 2, bob}, {3, 3, 4, bob}],
+         [{alice, @eth, 7}, {alice, @eth, 3}, {bob, @eth, 7}, {bob, @eth, 3}]}
+      ]
+      |> Enum.map(&parametrized_tester/1)
+    end
   end
 
-  @tag fixtures: [:alice, :state_alice_deposit, :bob]
-  test "using created transaction with one input in child chain", %{alice: alice, bob: bob, state_alice_deposit: state} do
-    transaction = Transaction.new([{1, 0, 0}], [{bob.addr, eth(), 4}])
+  describe "encoding/decoding is done properly" do
+    test "Decode raw transaction, a low level encode/decode parity check" do
+      {:ok, decoded} = @transaction |> Transaction.raw_txbytes() |> Transaction.decode()
+      assert decoded == @transaction
+      assert decoded == @transaction |> Transaction.raw_txbytes() |> Transaction.decode!()
+    end
 
-    transaction
-    |> DevCrypto.sign([alice.priv, <<>>])
-    |> assert_tx_usable(state)
+    @tag fixtures: [:alice]
+    test "decoding malformed signed transaction", %{alice: alice} do
+      %Transaction.Signed{sigs: sigs} =
+        tx =
+        Transaction.new([{1, 0, 0}, {2, 0, 0}], [{alice.addr, @eth, 12}])
+        |> DevCrypto.sign([alice.priv, alice.priv])
+
+      [inputs, outputs] = Transaction.raw_txbytes(tx) |> ExRLP.decode()
+
+      assert {:error, :malformed_transaction} = Transaction.Recovered.recover_from(<<192>>)
+      assert {:error, :malformed_transaction} = Transaction.Recovered.recover_from(<<0x80>>)
+      assert {:error, :malformed_transaction} = Transaction.Recovered.recover_from(<<>>)
+      assert {:error, :malformed_transaction} = Transaction.Recovered.recover_from(ExRLP.encode(23))
+      assert {:error, :malformed_transaction} = Transaction.Recovered.recover_from(ExRLP.encode([sigs, []]))
+
+      assert {:error, :malformed_signatures} ==
+               Transaction.Recovered.recover_from(ExRLP.encode([[<<1>>, <<1>>], inputs, outputs]))
+
+      assert {:error, :malformed_signatures} ==
+               Transaction.Recovered.recover_from(ExRLP.encode([<<1>>, inputs, outputs]))
+
+      assert {:error, :malformed_inputs} = Transaction.Recovered.recover_from(ExRLP.encode([sigs, 42, outputs]))
+      assert {:error, :malformed_inputs} = Transaction.Recovered.recover_from(ExRLP.encode([sigs, [[1, 2]], outputs]))
+
+      assert {:error, :malformed_inputs} =
+               Transaction.Recovered.recover_from(ExRLP.encode([sigs, [[1, 2, 'a']], outputs]))
+
+      assert {:error, :malformed_outputs} = Transaction.Recovered.recover_from(ExRLP.encode([sigs, inputs, 42]))
+
+      assert {:error, :malformed_outputs} =
+               Transaction.Recovered.recover_from(ExRLP.encode([sigs, inputs, [[alice.addr, alice.addr]]]))
+
+      assert {:error, :malformed_outputs} =
+               Transaction.Recovered.recover_from(ExRLP.encode([sigs, inputs, [[alice.addr, alice.addr, 'a']]]))
+
+      assert {:error, :malformed_metadata} =
+               Transaction.Recovered.recover_from(ExRLP.encode([sigs, inputs, outputs, ""]))
+
+      assert {:error, :malformed_metadata} =
+               Transaction.Recovered.recover_from(ExRLP.encode([sigs, inputs, outputs, <<0::288>>]))
+    end
+
+    @tag fixtures: [:alice, :bob]
+    test "rlp encoding of a transaction is corrupt", %{alice: alice, bob: bob} do
+      encoded_signed_tx = TestHelper.create_encoded([{1, 2, 3, alice}, {2, 3, 4, bob}], @eth, [{alice, 7}])
+
+      malformed2 = "A" <> encoded_signed_tx
+      assert {:error, :malformed_transaction_rlp} = Transaction.Recovered.recover_from(malformed2)
+
+      <<_, malformed3::binary>> = encoded_signed_tx
+      assert {:error, :malformed_transaction_rlp} = Transaction.Recovered.recover_from(malformed3)
+
+      cropped_size = byte_size(encoded_signed_tx) - 1
+      <<malformed4::binary-size(cropped_size), _::binary-size(1)>> = encoded_signed_tx
+      assert {:error, :malformed_transaction_rlp} = Transaction.Recovered.recover_from(malformed4)
+    end
+
+    @tag fixtures: [:alice, :bob]
+    test "address in encoded transaction malformed", %{alice: alice, bob: bob} do
+      malformed_alice = %{addr: "0x0000000000000000000000000000000000000000"}
+      malformed_eth = "0x0000000000000000000000000000000000000000"
+      malformed_signed1 = TestHelper.create_signed([{1, 2, 3, alice}, {2, 3, 4, bob}], @eth, [{malformed_alice, 7}])
+      malformed_signed2 = TestHelper.create_signed([{1, 2, 3, alice}, {2, 3, 4, bob}], malformed_eth, [{alice, 7}])
+
+      malformed_signed3 =
+        TestHelper.create_signed([{1, 2, 3, alice}, {2, 3, 4, bob}], @eth, [{alice, 7}, {malformed_alice, 3}])
+
+      malformed1 = Transaction.Signed.encode(malformed_signed1)
+      malformed2 = Transaction.Signed.encode(malformed_signed2)
+      malformed3 = Transaction.Signed.encode(malformed_signed3)
+
+      assert {:error, :malformed_address} = Transaction.Recovered.recover_from(malformed1)
+      assert {:error, :malformed_address} = Transaction.Recovered.recover_from(malformed2)
+      assert {:error, :malformed_address} = Transaction.Recovered.recover_from(malformed3)
+    end
+
+    @tag fixtures: [:alice]
+    test "transactions with corrupt signatures don't do harm - one signature", %{alice: alice} do
+      full_signed_tx = TestHelper.create_signed([{1, 2, 3, alice}], @eth, [{alice, 7}])
+
+      assert {:error, :signature_corrupt} ==
+               %Transaction.Signed{full_signed_tx | sigs: [<<1::size(520)>>]}
+               |> Transaction.Signed.encode()
+               |> Transaction.Recovered.recover_from()
+    end
+
+    @tag fixtures: [:alice]
+    test "transactions with corrupt signatures don't do harm - one of many signatures", %{alice: alice} do
+      full_signed_tx = TestHelper.create_signed([{1, 2, 3, alice}, {1, 2, 4, alice}], @eth, [{alice, 7}])
+      %Transaction.Signed{sigs: [sig1, sig2 | _]} = full_signed_tx
+
+      assert {:error, :signature_corrupt} ==
+               %Transaction.Signed{full_signed_tx | sigs: [sig1, <<1::size(520)>>]}
+               |> Transaction.Signed.encode()
+               |> Transaction.Recovered.recover_from()
+
+      assert {:error, :signature_corrupt} ==
+               %Transaction.Signed{full_signed_tx | sigs: [<<1::size(520)>>, sig2]}
+               |> Transaction.Signed.encode()
+               |> Transaction.Recovered.recover_from()
+    end
+  end
+
+  describe "stateless validity critical to the ledger is checked" do
+    @tag fixtures: [:alice]
+    test "transaction must have distinct inputs", %{alice: alice} do
+      duplicate_inputs = TestHelper.create_encoded([{1, 2, 3, alice}, {1, 2, 3, alice}], @eth, [{alice, 7}])
+
+      assert {:error, :duplicate_inputs} = Transaction.Recovered.recover_from(duplicate_inputs)
+    end
+  end
+
+  describe "formal protocol rules are enforced" do
+    @tag fixtures: [:alice]
+    test "Decoding transaction with gaps in inputs returns error", %{alice: alice} do
+      assert {:error, :inputs_contain_gaps} ==
+               TestHelper.create_encoded([{0, 0, 0, alice}, {1000, 0, 0, alice}], @eth, [{alice, 100}])
+               |> Transaction.Recovered.recover_from()
+
+      assert {:error, :inputs_contain_gaps} ==
+               TestHelper.create_encoded(
+                 [{1000, 0, 0, alice}, {0, 0, 0, alice}, {2000, 0, 0, alice}],
+                 @eth,
+                 [{alice, 100}]
+               )
+               |> Transaction.Recovered.recover_from()
+
+      assert {:ok, _} =
+               TestHelper.create_encoded(
+                 [{1000, 0, 0, alice}, {2000, 0, 0, alice}, {3000, 0, 0, alice}],
+                 @eth,
+                 [{alice, 100}]
+               )
+               |> Transaction.Recovered.recover_from()
+    end
+
+    @tag fixtures: [:alice]
+    test "Decoding deposit transaction without inputs is successful", %{alice: alice} do
+      assert {:ok, _} =
+               TestHelper.create_encoded([], @eth, [{alice, 100}])
+               |> Transaction.Recovered.recover_from()
+    end
+
+    @tag fixtures: [:alice]
+    test "Decoding transaction with gaps in outputs returns error", %{alice: alice} do
+      no_account = %{addr: @zero_address}
+
+      assert {:error, :outputs_contain_gaps} ==
+               TestHelper.create_encoded([{1000, 0, 0, alice}], @eth, [{no_account, 0}, {alice, 100}])
+               |> Transaction.Recovered.recover_from()
+
+      assert {:error, :outputs_contain_gaps} ==
+               TestHelper.create_encoded(
+                 [{1000, 0, 0, alice}],
+                 @eth,
+                 [{alice, 100}, {no_account, 0}, {alice, 100}]
+               )
+               |> Transaction.Recovered.recover_from()
+
+      assert {:ok, _} =
+               TestHelper.create_encoded(
+                 [{1000, 0, 0, alice}],
+                 @eth,
+                 [{alice, 100}, {alice, 100}, {no_account, 0}, {no_account, 0}]
+               )
+               |> Transaction.Recovered.recover_from()
+    end
+
+    @tag fixtures: [:alice]
+    test "Decoding transaction without outputs is successful", %{alice: alice} do
+      assert {:ok, _} =
+               TestHelper.create_encoded([{1000, 0, 0, alice}], @eth, [])
+               |> Transaction.Recovered.recover_from()
+    end
+
+    @tag fixtures: [:alice, :bob]
+    test "transaction is not allowed to have input and empty sigs", %{alice: alice} do
+      tx = TestHelper.create_signed([{1, 2, 3, alice}, {2, 3, 4, alice}], @eth, [{alice, 7}])
+      tx_no_sigs = %{tx | sigs: [@empty_signature, @empty_signature]}
+      tx_hash = Transaction.Signed.encode(tx_no_sigs)
+      assert {:error, :missing_signature} == Transaction.Recovered.recover_from(tx_hash)
+    end
+
+    @tag fixtures: [:alice]
+    test "transactions with superfluous signatures don't do harm", %{alice: alice} do
+      full_signed_tx = TestHelper.create_signed([{1, 2, 3, alice}], @eth, [{alice, 7}])
+      %Transaction.Signed{sigs: [sig1 | _]} = full_signed_tx
+
+      assert {:error, :superfluous_signature} ==
+               %Transaction.Signed{full_signed_tx | sigs: [sig1, sig1]}
+               |> Transaction.Signed.encode()
+               |> Transaction.Recovered.recover_from()
+    end
   end
 
   defp assert_tx_usable(signed, state_core) do
     {:ok, transaction} = signed |> Transaction.Signed.encode() |> Transaction.Recovered.recover_from()
-
-    assert {:ok, {_, _, _}, _state} = Core.exec(state_core, transaction, %{eth() => 0})
+    assert {:ok, {_, _, _}, _state} = State.Core.exec(state_core, transaction, :ignore)
   end
 
-  @tag fixtures: [:alice, :bob]
-  test "different signers, one output", %{alice: alice, bob: bob} do
-    tx =
-      [{3000, 0, 0}, {3000, 0, 1}]
-      |> Transaction.new([{alice.addr, eth(), 10}])
-      |> DevCrypto.sign([bob.priv, alice.priv])
-      |> Transaction.Signed.encode()
+  defp parametrized_tester({inputs, outputs}) do
+    tx = TestHelper.create_signed(inputs, outputs)
 
-    {:ok, recovered} = Transaction.Recovered.recover_from(tx)
-    assert recovered.spenders == [bob.addr, alice.addr]
-  end
+    encoded_signed_tx = Transaction.Signed.encode(tx)
 
-  @tag fixtures: [:alice, :bob, :carol]
-  test "checks if spenders are authorized", %{alice: alice, bob: bob, carol: carol} do
-    authorized_tx = TestHelper.create_recovered([{1, 1, 0, alice}, {1, 3, 0, bob}], eth(), [{bob, 6}, {alice, 4}])
+    spenders =
+      inputs
+      |> Enum.filter(fn {_, _, _, %{addr: addr}} -> addr != nil end)
+      |> Enum.map(fn {_, _, _, spender} -> spender.addr end)
 
-    :ok = Transaction.Recovered.all_spenders_authorized(authorized_tx, [alice.addr, bob.addr])
-
-    {:error, :unauthorized_spent} = Transaction.Recovered.all_spenders_authorized(authorized_tx, [bob.addr, alice.addr])
-
-    {:error, :unauthorized_spent} = Transaction.Recovered.all_spenders_authorized(authorized_tx, [carol.addr])
-
-    {:error, :unauthorized_spent} =
-      Transaction.Recovered.all_spenders_authorized(authorized_tx, [alice.addr, carol.addr])
-  end
-
-  @tag fixtures: [:transaction]
-  test "Decode transaction", %{transaction: tx} do
-    {:ok, decoded} = tx |> Transaction.encode() |> Transaction.decode()
-    assert decoded == tx
-    assert decoded == tx |> Transaction.encode() |> Transaction.decode!()
-  end
-
-  @tag fixtures: [:alice]
-  test "decoding malformed signed transaction", %{alice: alice} do
-    %Transaction.Signed{sigs: sigs, raw_tx: raw_tx} =
-      Transaction.new([{1, 0, 0}, {2, 0, 0}], [{alice.addr, eth(), 12}])
-      |> DevCrypto.sign([alice.priv, alice.priv])
-
-    [inputs, outputs] = Transaction.encode(raw_tx) |> ExRLP.decode()
-
-    assert {:error, :malformed_transaction} = Transaction.Signed.decode(ExRLP.encode(23))
-    assert {:error, :malformed_transaction} = Transaction.Signed.decode(ExRLP.encode([sigs, []]))
-
-    assert {:error, :malformed_signatures} == Transaction.Signed.decode(ExRLP.encode([[<<1>>, <<1>>], inputs, outputs]))
-    assert {:error, :malformed_signatures} == Transaction.Signed.decode(ExRLP.encode([<<1>>, inputs, outputs]))
-
-    assert {:error, :malformed_inputs} = Transaction.Signed.decode(ExRLP.encode([sigs, 42, outputs]))
-    assert {:error, :malformed_inputs} = Transaction.Signed.decode(ExRLP.encode([sigs, [[1, 2]], outputs]))
-    assert {:error, :malformed_inputs} = Transaction.Signed.decode(ExRLP.encode([sigs, [[1, 2, 'a']], outputs]))
-
-    assert {:error, :malformed_outputs} = Transaction.Signed.decode(ExRLP.encode([sigs, inputs, 42]))
-
-    assert {:error, :malformed_outputs} =
-             Transaction.Signed.decode(ExRLP.encode([sigs, inputs, [[alice.addr, alice.addr]]]))
-
-    assert {:error, :malformed_outputs} =
-             Transaction.Signed.decode(ExRLP.encode([sigs, inputs, [[alice.addr, alice.addr, 'a']]]))
-
-    assert {:error, :malformed_metadata} = Transaction.Signed.decode(ExRLP.encode([sigs, inputs, outputs, ""]))
-  end
-
-  @tag fixtures: [:alice]
-  test "Decoding transaction with gaps in inputs returns error", %{alice: alice} do
-    assert {:error, :inputs_contain_gaps} ==
-             TestHelper.create_encoded([{0, 0, 0, alice}, {1000, 0, 0, alice}], eth(), [{alice, 100}])
-             |> Transaction.Recovered.recover_from()
-
-    assert {:error, :inputs_contain_gaps} ==
-             TestHelper.create_encoded(
-               [{1000, 0, 0, alice}, {0, 0, 0, alice}, {2000, 0, 0, alice}],
-               eth(),
-               [{alice, 100}]
-             )
-             |> Transaction.Recovered.recover_from()
-
-    assert {:ok, _} =
-             TestHelper.create_encoded(
-               [{1000, 0, 0, alice}, {2000, 0, 0, alice}, {3000, 0, 0, alice}],
-               eth(),
-               [{alice, 100}]
-             )
-             |> Transaction.Recovered.recover_from()
-  end
-
-  @tag fixtures: [:alice]
-  test "Decoding deposit transaction without inputs is successful", %{alice: alice} do
-    assert {:ok, _} =
-             TestHelper.create_encoded([], eth(), [{alice, 100}])
-             |> Transaction.Recovered.recover_from()
-  end
-
-  @tag fixtures: [:alice]
-  test "Decoding transaction with gaps in outputs returns error", %{alice: alice} do
-    no_account = %{addr: @zero_address}
-
-    assert {:error, :outputs_contain_gaps} ==
-             TestHelper.create_encoded([{1000, 0, 0, alice}], eth(), [{no_account, 0}, {alice, 100}])
-             |> Transaction.Recovered.recover_from()
-
-    assert {:error, :outputs_contain_gaps} ==
-             TestHelper.create_encoded(
-               [{1000, 0, 0, alice}],
-               eth(),
-               [{alice, 100}, {no_account, 0}, {alice, 100}]
-             )
-             |> Transaction.Recovered.recover_from()
-
-    assert {:ok, _} =
-             TestHelper.create_encoded(
-               [{1000, 0, 0, alice}],
-               eth(),
-               [{alice, 100}, {alice, 100}, {no_account, 0}, {no_account, 0}]
-             )
-             |> Transaction.Recovered.recover_from()
-  end
-
-  @tag fixtures: [:alice]
-  test "Decoding transaction without outputs is successful", %{alice: alice} do
-    assert {:ok, _} =
-             TestHelper.create_encoded([{1000, 0, 0, alice}], eth(), [])
-             |> Transaction.Recovered.recover_from()
+    assert {:ok,
+            %Transaction.Recovered{
+              signed_tx: ^tx,
+              spenders: ^spenders
+            }} = Transaction.Recovered.recover_from(encoded_signed_tx)
   end
 end

--- a/apps/omg/test/omg/state/transaction_test.exs
+++ b/apps/omg/test/omg/state/transaction_test.exs
@@ -88,21 +88,16 @@ defmodule OMG.State.TransactionTest do
       check_output2 = %{amount: 99, currency: @eth, owner: "Joe Black"}
       # 1 - input, 1 - output
       tx1_1 = Transaction.new([hd(@utxo_positions)], [output1])
-      assert 1 == tx1_1 |> Transaction.get_inputs() |> Enum.filter(&Utxo.Position.non_zero?/1) |> length()
-      assert 1 == tx1_1 |> Transaction.get_outputs() |> Enum.filter(&(&1.amount != 0)) |> length()
+      assert 1 == tx1_1 |> Transaction.get_inputs() |> length()
+      assert 1 == tx1_1 |> Transaction.get_outputs() |> length()
       assert [^check_input1 | _] = Transaction.get_inputs(tx1_1)
       assert [^check_output2 | _] = Transaction.get_outputs(tx1_1)
       # 4 - input, 4 - outputs
       tx4_4 = Transaction.new(@utxo_positions, [output1, {"J", @eth, 929}, {"J", @eth, 929}, {"J", @eth, 199}])
-      assert 4 == tx4_4 |> Transaction.get_inputs() |> Enum.filter(&Utxo.Position.non_zero?/1) |> length()
-      assert 4 == tx4_4 |> Transaction.get_outputs() |> Enum.filter(&(&1.amount != 0)) |> length()
+      assert 4 == tx4_4 |> Transaction.get_inputs() |> length()
+      assert 4 == tx4_4 |> Transaction.get_outputs() |> length()
       assert [^check_input1 | _] = Transaction.get_inputs(tx4_4)
       assert [^check_output2 | _] = Transaction.get_outputs(tx4_4)
-
-      # NOTE: this is temporary behavior - as soon as we filter out non_zeros from get_inputs, remove this test
-      #       **AND** remove the filterings above
-      assert 4 == tx1_1 |> Transaction.get_inputs() |> length()
-      assert 4 == tx1_1 |> Transaction.get_outputs() |> length()
     end
 
     @tag fixtures: [:alice, :bob]

--- a/apps/omg/test/support/crypto.ex
+++ b/apps/omg/test/support/crypto.ex
@@ -46,7 +46,7 @@ defmodule OMG.DevCrypto do
   """
   @spec sign(Transaction.t(), list(Crypto.priv_key_t())) :: Transaction.Signed.t()
   def sign(%Transaction{} = tx, private_keys) do
-    encoded_tx = Transaction.encode(tx)
+    encoded_tx = Transaction.raw_txbytes(tx)
     sigs = Enum.map(private_keys, fn pk -> signature(encoded_tx, pk) end)
 
     transaction = %Transaction.Signed{raw_tx: tx, sigs: sigs}

--- a/apps/omg/test/support/integration/deposit_helper.ex
+++ b/apps/omg/test/support/integration/deposit_helper.ex
@@ -27,7 +27,7 @@ defmodule OMG.Integration.DepositHelper do
   def deposit_to_child_chain(to, value, @eth) do
     {:ok, receipt} =
       Transaction.new([], [{to, @eth, value}])
-      |> Transaction.encode()
+      |> Transaction.raw_txbytes()
       |> Eth.RootChain.deposit(value, to)
       |> Eth.DevHelpers.transact_sync!()
 
@@ -41,7 +41,7 @@ defmodule OMG.Integration.DepositHelper do
 
     {:ok, receipt} =
       Transaction.new([], [{to, token_addr, value}])
-      |> Transaction.encode()
+      |> Transaction.raw_txbytes()
       |> Eth.RootChain.deposit_from(to)
       |> Eth.DevHelpers.transact_sync!()
 

--- a/apps/omg/test/support/prop_test/helper.ex
+++ b/apps/omg/test/support/prop_test/helper.ex
@@ -25,14 +25,9 @@ defmodule OMG.PropTest.Helper do
   @doc """
   Collapse of the recover transaction into a short form use in OMG.PropTest
   """
-  def format_transaction(%Transaction.Recovered{
-        signed_tx: %Transaction.Signed{
-          raw_tx: raw_tx
-        },
-        spenders: [spender1, spender2]
-      }) do
-    inputs = Transaction.get_inputs(raw_tx)
-    outputs = Transaction.get_outputs(raw_tx)
+  def format_transaction(%Transaction.Recovered{spenders: [spender1, spender2]} = tx) do
+    inputs = Transaction.get_inputs(tx)
+    outputs = Transaction.get_outputs(tx)
 
     [%{blknum: blknum1, txindex: txindex1, oindex: oindex1}, %{blknum: blknum2, txindex: txindex2, oindex: oindex2}] =
       inputs

--- a/apps/omg/test/support/test_helper.ex
+++ b/apps/omg/test/support/test_helper.ex
@@ -135,6 +135,11 @@ defmodule OMG.TestHelper do
     DevCrypto.sign(raw_tx, privs)
   end
 
+  def sign_encode(%Transaction{} = tx, priv_keys), do: tx |> DevCrypto.sign(priv_keys) |> Transaction.Signed.encode()
+
+  def sign_recover!(%Transaction{} = tx, priv_keys),
+    do: tx |> sign_encode(priv_keys) |> Transaction.Recovered.recover_from!()
+
   defp get_private_keys(inputs) do
     filler = List.duplicate(<<>>, 4 - length(inputs))
 

--- a/apps/omg_api/test/omg_api/integration/happy_path_test.exs
+++ b/apps/omg_api/test/omg_api/integration/happy_path_test.exs
@@ -22,7 +22,6 @@ defmodule OMG.API.Integration.HappyPathTest do
   use Plug.Test
 
   alias OMG.Block
-  alias OMG.DevCrypto
   alias OMG.Eth
   alias OMG.Integration.DepositHelper
   alias OMG.RPC.Web.Encoding
@@ -48,12 +47,12 @@ defmodule OMG.API.Integration.HappyPathTest do
   } do
     raw_tx = Transaction.new([{deposit_blknum, 0, 0}], [{bob.addr, @eth, 7}, {alice.addr, @eth, 3}], <<0::256>>)
 
-    tx = raw_tx |> DevCrypto.sign([alice.priv, <<>>]) |> Transaction.Signed.encode()
+    tx = raw_tx |> OMG.TestHelper.sign_encode([alice.priv, <<>>])
     # spend the deposit
     assert {:ok, %{"blknum" => spend_child_block}} = submit_transaction(tx)
 
     token_raw_tx = Transaction.new([{token_deposit_blknum, 0, 0}], [{bob.addr, token, 8}, {alice.addr, token, 2}])
-    token_tx = token_raw_tx |> DevCrypto.sign([alice.priv, <<>>]) |> Transaction.Signed.encode()
+    token_tx = token_raw_tx |> OMG.TestHelper.sign_encode([alice.priv, <<>>])
     # spend the token deposit
     assert {:ok, %{"blknum" => spend_token_child_block}} = submit_transaction(token_tx)
 
@@ -78,7 +77,7 @@ defmodule OMG.API.Integration.HappyPathTest do
 
     # repeat spending to see if all works
     raw_tx2 = Transaction.new([{spend_child_block, 0, 0}, {spend_child_block, 0, 1}], [{alice.addr, @eth, 10}])
-    tx2 = raw_tx2 |> DevCrypto.sign([bob.priv, alice.priv]) |> Transaction.Signed.encode()
+    tx2 = raw_tx2 |> OMG.TestHelper.sign_encode([bob.priv, alice.priv])
     # spend the output of the first tx
     assert {:ok, %{"blknum" => spend_child_block2}} = submit_transaction(tx2)
 
@@ -118,7 +117,7 @@ defmodule OMG.API.Integration.HappyPathTest do
     {:ok, _} = Eth.DevHelpers.wait_for_root_chain_block(exit_eth_height + exiters_finality_margin)
 
     invalid_raw_tx = Transaction.new([{spend_child_block2, 0, 0}], [{alice.addr, @eth, 10}])
-    invalid_tx = invalid_raw_tx |> DevCrypto.sign([alice.priv]) |> Transaction.Signed.encode()
+    invalid_tx = invalid_raw_tx |> OMG.TestHelper.sign_encode([alice.priv])
     assert {:error, %{"code" => "submit:utxo_not_found"}} = submit_transaction(invalid_tx)
   end
 

--- a/apps/omg_performance/lib/omg_performance/sender_server.ex
+++ b/apps/omg_performance/lib/omg_performance/sender_server.ex
@@ -152,7 +152,7 @@ defmodule OMG.Performance.SenderServer do
             "[#{inspect(seqnum)}]: Transaction submitted successfully {#{inspect(blknum)}, #{inspect(txindex)}}"
           )
 
-        [%{amount: amount} | _] = Transaction.get_outputs(tx.raw_tx)
+        [%{amount: amount} | _] = Transaction.get_outputs(tx)
         {:ok, blknum, txindex, amount}
     end
   end

--- a/apps/omg_watcher/lib/omg_watcher/api/in_flight_exit.ex
+++ b/apps/omg_watcher/lib/omg_watcher/api/in_flight_exit.ex
@@ -92,9 +92,9 @@ defmodule OMG.Watcher.API.InFlightExit do
     ExitProcessor.get_output_challenge_data(txbytes, output_index)
   end
 
-  defp find_input_data(%Transaction.Signed{raw_tx: raw_tx}) do
+  defp find_input_data(tx) do
     result =
-      raw_tx
+      tx
       |> Transaction.get_inputs()
       |> Enum.map(fn
         Utxo.position(0, 0, 0) ->

--- a/apps/omg_watcher/lib/omg_watcher/api/in_flight_exit.ex
+++ b/apps/omg_watcher/lib/omg_watcher/api/in_flight_exit.ex
@@ -38,16 +38,15 @@ defmodule OMG.Watcher.API.InFlightExit do
   def get_in_flight_exit(txbytes) do
     with {:ok, tx} <- Transaction.Signed.decode(txbytes),
          {:ok, {proofs, input_txs}} <- find_input_data(tx) do
-      %Transaction.Signed{raw_tx: raw_tx, sigs: sigs} = tx
+      %Transaction.Signed{sigs: sigs} = tx
 
-      raw_txbytes = Transaction.encode(raw_tx)
       input_txs = get_input_txs_for_rlp_encoding(input_txs)
       sigs = Enum.join(sigs)
       proofs = Enum.join(proofs)
 
       {:ok,
        %{
-         in_flight_tx: raw_txbytes,
+         in_flight_tx: Transaction.raw_txbytes(tx),
          input_txs: ExRLP.encode(input_txs),
          input_txs_inclusion_proofs: proofs,
          in_flight_tx_sigs: sigs

--- a/apps/omg_watcher/lib/omg_watcher/db/transaction.ex
+++ b/apps/omg_watcher/lib/omg_watcher/db/transaction.ex
@@ -163,20 +163,22 @@ defmodule OMG.Watcher.DB.Transaction do
   @spec process(Transaction.Recovered.t(), pos_integer(), integer(), list()) :: [list()]
   defp process(
          %Transaction.Recovered{
-           tx_hash: tx_hash,
-           signed_tx: %Transaction.Signed{
-             signed_tx_bytes: signed_tx_bytes,
-             raw_tx: %Transaction{metadata: metadata} = raw_tx
-           }
+           signed_tx:
+             %Transaction.Signed{
+               signed_tx_bytes: signed_tx_bytes,
+               raw_tx: %Transaction{metadata: metadata}
+             } = tx
          },
          block_number,
          txindex,
          [tx_list, output_list, input_list]
        ) do
+    tx_hash = Transaction.raw_txhash(tx)
+
     [
       [create(block_number, txindex, tx_hash, signed_tx_bytes, metadata) | tx_list],
-      DB.TxOutput.create_outputs(block_number, txindex, tx_hash, raw_tx) ++ output_list,
-      DB.TxOutput.create_inputs(raw_tx, tx_hash) ++ input_list
+      DB.TxOutput.create_outputs(block_number, txindex, tx_hash, tx) ++ output_list,
+      DB.TxOutput.create_inputs(tx, tx_hash) ++ input_list
     ]
   end
 

--- a/apps/omg_watcher/lib/omg_watcher/db/txoutput.ex
+++ b/apps/omg_watcher/lib/omg_watcher/db/txoutput.ex
@@ -88,7 +88,7 @@ defmodule OMG.Watcher.DB.TxOutput do
       {:ok,
        %{
          utxo_pos: decoded_utxo_pos |> Utxo.Position.encode(),
-         txbytes: tx |> Transaction.encode(),
+         txbytes: tx |> Transaction.raw_txbytes(),
          proof: Block.inclusion_proof(block, 0)
        }}
     else
@@ -105,11 +105,7 @@ defmodule OMG.Watcher.DB.TxOutput do
 
     signed_tx = Enum.at(sorted_tx_bytes, txindex)
 
-    {:ok,
-     %Transaction.Signed{
-       raw_tx: raw_tx,
-       sigs: sigs
-     }} = Transaction.Signed.decode(signed_tx)
+    {:ok, %Transaction.Signed{sigs: sigs} = tx} = Transaction.Signed.decode(signed_tx)
 
     proof =
       %Block{transactions: sorted_tx_bytes}
@@ -120,7 +116,7 @@ defmodule OMG.Watcher.DB.TxOutput do
 
     %{
       utxo_pos: utxo_pos,
-      txbytes: Transaction.encode(raw_tx),
+      txbytes: Transaction.raw_txbytes(tx),
       proof: proof,
       sigs: sigs
     }

--- a/apps/omg_watcher/lib/omg_watcher/db/txoutput.ex
+++ b/apps/omg_watcher/lib/omg_watcher/db/txoutput.ex
@@ -170,7 +170,7 @@ defmodule OMG.Watcher.DB.TxOutput do
     end)
   end
 
-  @spec create_outputs(pos_integer(), integer(), binary(), %Transaction{}) :: [map()]
+  @spec create_outputs(pos_integer(), integer(), binary(), Transaction.any_flavor_t()) :: [map()]
   def create_outputs(
         blknum,
         txindex,
@@ -204,12 +204,13 @@ defmodule OMG.Watcher.DB.TxOutput do
       }
     ]
 
-  @spec create_inputs(%Transaction{}, binary()) :: [tuple()]
-  def create_inputs(%Transaction{inputs: inputs}, spending_txhash) do
-    inputs
+  @spec create_inputs(Transaction.any_flavor_t(), binary()) :: [tuple()]
+  def create_inputs(tx, spending_txhash) do
+    tx
+    |> Transaction.get_inputs()
     |> Enum.with_index()
-    |> Enum.map(fn {%{blknum: blknum, txindex: txindex, oindex: oindex}, index} ->
-      {Utxo.position(blknum, txindex, oindex), index, spending_txhash}
+    |> Enum.map(fn {Utxo.position(_, _, _) = input_utxo_pos, index} ->
+      {input_utxo_pos, index, spending_txhash}
     end)
   end
 

--- a/apps/omg_watcher/lib/omg_watcher/eventer/core.ex
+++ b/apps/omg_watcher/lib/omg_watcher/eventer/core.ex
@@ -63,13 +63,7 @@ defmodule OMG.Watcher.Eventer.Core do
     get_address_received_events(event_trigger) ++ get_address_spent_events(event_trigger)
   end
 
-  defp get_address_spent_events(
-         %{
-           tx: %Transaction.Recovered{
-             spenders: spenders
-           }
-         } = event_trigger
-       ) do
+  defp get_address_spent_events(%{tx: %Transaction.Recovered{spenders: spenders}} = event_trigger) do
     spenders
     |> Enum.filter(&account_address?/1)
     |> Enum.map(&create_address_spent_event(event_trigger, &1))

--- a/apps/omg_watcher/lib/omg_watcher/eventer/core.ex
+++ b/apps/omg_watcher/lib/omg_watcher/eventer/core.ex
@@ -81,14 +81,8 @@ defmodule OMG.Watcher.Eventer.Core do
     {subtopic, "address_spent", struct(Event.AddressSpent, event_trigger)}
   end
 
-  defp get_address_received_events(
-         %{
-           tx: %Transaction.Recovered{
-             signed_tx: %Transaction.Signed{raw_tx: raw_tx}
-           }
-         } = event_trigger
-       ) do
-    raw_tx
+  defp get_address_received_events(%{tx: tx} = event_trigger) do
+    tx
     |> Transaction.get_outputs()
     |> Enum.map(fn %{owner: owner} -> owner end)
     |> Enum.filter(&account_address?/1)

--- a/apps/omg_watcher/lib/omg_watcher/exit_processor/competitor_info.ex
+++ b/apps/omg_watcher/lib/omg_watcher/exit_processor/competitor_info.ex
@@ -73,8 +73,8 @@ defmodule OMG.Watcher.ExitProcessor.CompetitorInfo do
   end
 
   def new(tx_bytes, competing_input_index, competing_input_signature) do
-    with {:ok, raw_tx} <- Transaction.decode(tx_bytes) do
-      {Transaction.hash(raw_tx),
+    with {:ok, %Transaction{} = raw_tx} <- Transaction.decode(tx_bytes) do
+      {Transaction.raw_txhash(raw_tx),
        %__MODULE__{
          tx: %Transaction.Signed{
            raw_tx: raw_tx,

--- a/apps/omg_watcher/lib/omg_watcher/exit_processor/in_flight_exit_info.ex
+++ b/apps/omg_watcher/lib/omg_watcher/exit_processor/in_flight_exit_info.ex
@@ -87,7 +87,7 @@ defmodule OMG.Watcher.ExitProcessor.InFlightExitInfo do
       tx = %Transaction.Signed{raw_tx: raw_tx, sigs: chopped_sigs}
 
       {
-        Transaction.hash(raw_tx),
+        Transaction.raw_txhash(raw_tx),
         %__MODULE__{
           tx: tx,
           timestamp: timestamp,

--- a/apps/omg_watcher/lib/omg_watcher/exit_processor/in_flight_exit_info.ex
+++ b/apps/omg_watcher/lib/omg_watcher/exit_processor/in_flight_exit_info.ex
@@ -286,11 +286,6 @@ defmodule OMG.Watcher.ExitProcessor.InFlightExitInfo do
     end
   end
 
-  @spec get_exiting_utxo_positions(t()) :: list({:utxo_position, non_neg_integer(), non_neg_integer(), non_neg_integer})
-  def get_exiting_utxo_positions(%__MODULE__{tx: %Transaction.Signed{raw_tx: tx}}) do
-    Transaction.get_inputs(tx)
-  end
-
   @spec get_piggybacked_outputs_positions(t()) :: [Utxo.Position.t()]
   def get_piggybacked_outputs_positions(%__MODULE__{tx_seen_in_blocks_at: nil}), do: []
 

--- a/apps/omg_watcher/lib/omg_watcher/exit_processor/tools.ex
+++ b/apps/omg_watcher/lib/omg_watcher/exit_processor/tools.ex
@@ -26,8 +26,8 @@ defmodule OMG.Watcher.ExitProcessor.Tools do
   Finds the exact signature which signed the particular transaction for the given owner address
   """
   @spec find_sig(Transaction.Signed.t(), Crypto.address_t()) :: {:ok, Crypto.sig_t()} | nil
-  def find_sig(%Transaction.Signed{raw_tx: tx, sigs: sigs}, owner) do
-    tx_hash = Transaction.hash(tx)
+  def find_sig(%Transaction.Signed{sigs: sigs} = tx, owner) do
+    tx_hash = Transaction.raw_txhash(tx)
 
     Enum.find(sigs, fn sig ->
       {:ok, owner} == Crypto.recover_address(tx_hash, sig)

--- a/apps/omg_watcher/lib/omg_watcher/utxo_selection.ex
+++ b/apps/omg_watcher/lib/omg_watcher/utxo_selection.ex
@@ -197,7 +197,7 @@ defmodule OMG.Watcher.UtxoSelection do
           outputs |> Enum.map(&{&1.owner, &1.currency, &1.amount}),
           metadata
         )
-        |> Transaction.encode()
+        |> Transaction.raw_txbytes()
   end
 
   defp respond({:ok, transaction}, result), do: {:ok, %{result: result, transactions: [transaction]}}

--- a/apps/omg_watcher/test/omg_watcher/exit_processor/core_test.exs
+++ b/apps/omg_watcher/test/omg_watcher/exit_processor/core_test.exs
@@ -193,11 +193,7 @@ defmodule OMG.Watcher.ExitProcessor.CoreTest do
     ife_id = hd(ife_tx_hashes)
     txbytes = Transaction.raw_txbytes(tx)
     competitor_txbytes = Transaction.raw_txbytes(competitor)
-
-    {:ok, recovered} =
-      DevCrypto.sign(tx, [alice.priv, alice.priv])
-      |> Transaction.Signed.encode()
-      |> Transaction.Recovered.recover_from()
+    recovered = OMG.TestHelper.sign_recover!(tx, [alice.priv, alice.priv])
 
     %{sigs: competitor_signatures} = DevCrypto.sign(competitor, [alice.priv, alice.priv])
 
@@ -242,17 +238,12 @@ defmodule OMG.Watcher.ExitProcessor.CoreTest do
     # the piggybacked-output-spending tx is going to be included in a block, which requires more back&forth
     # 1. transaction which is, ife'd, output piggybacked, and included in a block
     txbytes = Transaction.raw_txbytes(tx)
-
-    {:ok, recovered} =
-      DevCrypto.sign(tx, [alice.priv, alice.priv])
-      |> Transaction.Signed.encode()
-      |> Transaction.Recovered.recover_from()
+    recovered = OMG.TestHelper.sign_recover!(tx, [alice.priv, alice.priv])
 
     # 2. transaction which spends that piggybacked output
     comp = Transaction.new([{3000, 0, 0}], [])
     comp_txbytes = Transaction.raw_txbytes(comp)
-    %{sigs: comp_signatures} = signed = DevCrypto.sign(comp, [alice.priv])
-    {:ok, comp_recovered} = signed |> Transaction.Signed.encode() |> Transaction.Recovered.recover_from()
+    %{signed_tx: %{sigs: comp_signatures}} = comp_recovered = OMG.TestHelper.sign_recover!(comp, [alice.priv])
 
     # 3. stuff happens in the contract; output #4 is a double-spend; #5 is OK
     {state, _} =
@@ -781,10 +772,7 @@ defmodule OMG.Watcher.ExitProcessor.CoreTest do
       processor_filled: processor,
       transactions: [tx1, tx2]
     } do
-      {:ok, recovered_tx1} =
-        DevCrypto.sign(tx1, [alice.priv, alice.priv])
-        |> Transaction.Signed.encode()
-        |> Transaction.Recovered.recover_from()
+      recovered_tx1 = OMG.TestHelper.sign_recover!(tx1, [alice.priv, alice.priv])
 
       exit_processor_request = %ExitProcessor.Request{
         blknum_now: 5000,
@@ -959,8 +947,10 @@ defmodule OMG.Watcher.ExitProcessor.CoreTest do
          } do
       txbytes = Transaction.raw_txbytes(tx)
       comp_txbytes = Transaction.raw_txbytes(comp)
-      %{sigs: [_, other_sig]} = comp_signed = DevCrypto.sign(comp, [alice.priv, alice.priv])
-      {:ok, comp_recovered} = comp_signed |> Transaction.Signed.encode() |> Transaction.Recovered.recover_from()
+
+      %{signed_tx: %{sigs: [_, other_sig]}} =
+        comp_recovered = OMG.TestHelper.sign_recover!(comp, [alice.priv, alice.priv])
+
       {state, _} = Core.new_piggybacks(state, [%{tx_hash: ife_id, output_index: 0}])
 
       comp_blknum = 4000
@@ -996,12 +986,7 @@ defmodule OMG.Watcher.ExitProcessor.CoreTest do
          } do
       # 1. transaction which is, ife'd, output piggybacked, and included in a block
       txbytes = Transaction.raw_txbytes(tx)
-
-      {:ok, recovered} =
-        DevCrypto.sign(tx, [alice.priv, alice.priv])
-        |> Transaction.Signed.encode()
-        |> Transaction.Recovered.recover_from()
-
+      recovered = OMG.TestHelper.sign_recover!(tx, [alice.priv, alice.priv])
       tx_blknum = 3000
 
       # 2. transaction which spends that piggybacked output
@@ -1055,19 +1040,13 @@ defmodule OMG.Watcher.ExitProcessor.CoreTest do
       # this time, the piggybacked-output-spending tx is going to be included in a block, which requires more back&forth
       # 1. transaction which is, ife'd, output piggybacked, and included in a block
       txbytes = Transaction.raw_txbytes(tx)
-
-      {:ok, recovered} =
-        DevCrypto.sign(tx, [alice.priv, alice.priv])
-        |> Transaction.Signed.encode()
-        |> Transaction.Recovered.recover_from()
-
+      recovered = OMG.TestHelper.sign_recover!(tx, [alice.priv, alice.priv])
       tx_blknum = 3000
 
       # 2. transaction which spends that piggybacked output
       comp = Transaction.new([{tx_blknum, 0, 0}], [])
       comp_txbytes = Transaction.raw_txbytes(comp)
-      %{sigs: [comp_signature]} = comp_signed = DevCrypto.sign(comp, [alice.priv])
-      {:ok, comp_recovered} = comp_signed |> Transaction.Signed.encode() |> Transaction.Recovered.recover_from()
+      %{signed_tx: %{sigs: [comp_signature]}} = comp_recovered = OMG.TestHelper.sign_recover!(comp, [alice.priv])
 
       # 3. stuff happens in the contract
       {state, _} = Core.new_piggybacks(state, [%{tx_hash: ife_id, output_index: 4}])
@@ -1113,11 +1092,7 @@ defmodule OMG.Watcher.ExitProcessor.CoreTest do
            transactions: [tx | _],
            ife_tx_hashes: [ife_id | _]
          } do
-      {:ok, recovered} =
-        DevCrypto.sign(tx, [alice.priv, alice.priv])
-        |> Transaction.Signed.encode()
-        |> Transaction.Recovered.recover_from()
-
+      recovered = OMG.TestHelper.sign_recover!(tx, [alice.priv, alice.priv])
       txbytes = Transaction.raw_txbytes(tx)
       tx_blknum = 3000
 
@@ -1168,10 +1143,7 @@ defmodule OMG.Watcher.ExitProcessor.CoreTest do
            ife_tx_hashes: [ife_id | _]
          } do
       # if an output-piggybacking transaction is included in some block, we need to seek blocks that could be spending
-      {:ok, recovered} =
-        DevCrypto.sign(tx, [alice.priv, alice.priv])
-        |> Transaction.Signed.encode()
-        |> Transaction.Recovered.recover_from()
+      recovered = tx |> OMG.TestHelper.sign_recover!([alice.priv, alice.priv])
 
       {processor, _} = Core.new_piggybacks(processor, [%{tx_hash: ife_id, output_index: 4}])
 
@@ -1213,11 +1185,7 @@ defmodule OMG.Watcher.ExitProcessor.CoreTest do
          } do
       tx_blknum = 3000
       txbytes = Transaction.raw_txbytes(tx)
-
-      {:ok, recovered} =
-        DevCrypto.sign(tx, [alice.priv, alice.priv])
-        |> Transaction.Signed.encode()
-        |> Transaction.Recovered.recover_from()
+      recovered = OMG.TestHelper.sign_recover!(tx, [alice.priv, alice.priv])
 
       comp = Transaction.new([{1, 0, 0}, {1, 2, 1}, {tx_blknum, 0, 0}, {tx_blknum, 0, 1}], [])
       comp_txbytes = Transaction.raw_txbytes(comp)
@@ -1397,11 +1365,7 @@ defmodule OMG.Watcher.ExitProcessor.CoreTest do
     test "none if different input spent in some tx from block",
          %{alice: alice, processor_filled: processor, transactions: [tx1 | _], competing_transactions: [_, _, comp3]} do
       txbytes = Transaction.raw_txbytes(tx1)
-
-      {:ok, other_recovered} =
-        DevCrypto.sign(comp3, [alice.priv, alice.priv])
-        |> Transaction.Signed.encode()
-        |> Transaction.Recovered.recover_from()
+      other_recovered = OMG.TestHelper.sign_recover!(comp3, [alice.priv, alice.priv])
 
       exit_processor_request = %ExitProcessor.Request{
         blknum_now: 5000,
@@ -1421,11 +1385,7 @@ defmodule OMG.Watcher.ExitProcessor.CoreTest do
     test "none if input spent in _same_ tx in block",
          %{alice: alice, processor_filled: processor, transactions: [tx1 | _]} do
       txbytes = Transaction.raw_txbytes(tx1)
-
-      {:ok, other_recovered} =
-        DevCrypto.sign(tx1, [alice.priv, alice.priv])
-        |> Transaction.Signed.encode()
-        |> Transaction.Recovered.recover_from()
+      other_recovered = OMG.TestHelper.sign_recover!(tx1, [alice.priv, alice.priv])
 
       exit_processor_request = %ExitProcessor.Request{
         blknum_now: 5000,
@@ -1538,13 +1498,10 @@ defmodule OMG.Watcher.ExitProcessor.CoreTest do
     test "a single competitor included in a block, with proof",
          %{alice: alice, processor_filled: processor, transactions: [tx1 | _], competing_transactions: [comp | _]} do
       txbytes = Transaction.raw_txbytes(tx1)
-
       other_txbytes = Transaction.raw_txbytes(comp)
 
-      {:ok, %{signed_tx: %{sigs: [other_signature, _]}} = other_recovered} =
-        DevCrypto.sign(comp, [alice.priv, alice.priv])
-        |> Transaction.Signed.encode()
-        |> Transaction.Recovered.recover_from()
+      %{signed_tx: %{sigs: [other_signature, _]}} =
+        other_recovered = OMG.TestHelper.sign_recover!(comp, [alice.priv, alice.priv])
 
       other_blknum = 3000
 
@@ -1580,10 +1537,8 @@ defmodule OMG.Watcher.ExitProcessor.CoreTest do
       txbytes = Transaction.raw_txbytes(tx1)
       other_txbytes = Transaction.raw_txbytes(comp)
 
-      {:ok, %{signed_tx: %{sigs: [other_signature, _]}} = other_recovered} =
-        DevCrypto.sign(comp, [alice.priv, alice.priv])
-        |> Transaction.Signed.encode()
-        |> Transaction.Recovered.recover_from()
+      %{signed_tx: %{sigs: [other_signature, _]}} =
+        other_recovered = OMG.TestHelper.sign_recover!(comp, [alice.priv, alice.priv])
 
       other_blknum = 3000
 
@@ -1648,14 +1603,8 @@ defmodule OMG.Watcher.ExitProcessor.CoreTest do
     test "none if IFE is challenged enough already",
          %{alice: alice, processor_filled: processor, transactions: [tx1 | _], competing_transactions: [comp | _]} do
       txbytes = Transaction.raw_txbytes(tx1)
-
       other_txbytes = Transaction.raw_txbytes(comp)
-
-      {:ok, other_recovered} =
-        DevCrypto.sign(comp, [alice.priv, alice.priv])
-        |> Transaction.Signed.encode()
-        |> Transaction.Recovered.recover_from()
-
+      other_recovered = OMG.TestHelper.sign_recover!(comp, [alice.priv, alice.priv])
       other_blknum = 3000
 
       exit_processor_request = %ExitProcessor.Request{
@@ -1716,11 +1665,7 @@ defmodule OMG.Watcher.ExitProcessor.CoreTest do
           |> Enum.count()
           |> (&List.duplicate(alice.priv, &1)).()
 
-        {:ok, other_recovered} =
-          comp
-          |> DevCrypto.sign(required_priv_key_list)
-          |> Transaction.Signed.encode()
-          |> Transaction.Recovered.recover_from()
+        other_recovered = OMG.TestHelper.sign_recover!(comp, required_priv_key_list)
 
         exit_processor_request = %ExitProcessor.Request{
           blknum_now: 5000,
@@ -1756,10 +1701,8 @@ defmodule OMG.Watcher.ExitProcessor.CoreTest do
          } do
       txbytes = Transaction.raw_txbytes(tx1)
 
-      {:ok, %{signed_tx: %{sigs: [_, other_signature]}} = other_recovered} =
-        DevCrypto.sign(competitor, [bob.priv, alice.priv])
-        |> Transaction.Signed.encode()
-        |> Transaction.Recovered.recover_from()
+      %{signed_tx: %{sigs: [_, other_signature]}} =
+        other_recovered = OMG.TestHelper.sign_recover!(competitor, [bob.priv, alice.priv])
 
       exit_processor_request = %ExitProcessor.Request{
         blknum_now: 5000,
@@ -1782,12 +1725,8 @@ defmodule OMG.Watcher.ExitProcessor.CoreTest do
       # first the included competitors
       comp_recent = Transaction.new([{1, 0, 0}], [])
       comp_oldest = Transaction.new([{1, 2, 1}], [])
-
-      {:ok, recovered_recent} =
-        DevCrypto.sign(comp_recent, [alice.priv]) |> Transaction.Signed.encode() |> Transaction.Recovered.recover_from()
-
-      {:ok, recovered_oldest} =
-        DevCrypto.sign(comp_oldest, [alice.priv]) |> Transaction.Signed.encode() |> Transaction.Recovered.recover_from()
+      recovered_recent = OMG.TestHelper.sign_recover!(comp_recent, [alice.priv])
+      recovered_oldest = OMG.TestHelper.sign_recover!(comp_oldest, [alice.priv])
 
       # ife-related competitor
       other_ife_event = %{
@@ -1983,14 +1922,7 @@ defmodule OMG.Watcher.ExitProcessor.CoreTest do
 
       block =
         txs
-        |> Enum.map(fn tx1 ->
-          {:ok, tx1_recovered} =
-            DevCrypto.sign(tx1, [alice.priv, alice.priv])
-            |> Transaction.Signed.encode()
-            |> Transaction.Recovered.recover_from()
-
-          tx1_recovered
-        end)
+        |> Enum.map(&OMG.TestHelper.sign_recover!(&1, [alice.priv, alice.priv]))
         |> Block.hashed_txs_at(other_blknum)
 
       other_blknum = 3000

--- a/apps/omg_watcher/test/omg_watcher/exit_processor/persistence_test.exs
+++ b/apps/omg_watcher/test/omg_watcher/exit_processor/persistence_test.exs
@@ -57,7 +57,7 @@ defmodule OMG.Watcher.ExitProcessor.PersistenceTest do
   end
 
   deffixture exits(alice, transactions) do
-    [txbytes1, txbytes2] = transactions |> Enum.map(&Transaction.encode/1)
+    [txbytes1, txbytes2] = transactions |> Enum.map(&Transaction.raw_txbytes/1)
 
     {[
        %{
@@ -141,14 +141,14 @@ defmodule OMG.Watcher.ExitProcessor.PersistenceTest do
   test "persist new challenges, responses and piggybacks",
        %{processor_empty: processor, alice: alice, db_pid: db_pid} do
     tx = Transaction.new([{2, 1, 0}], [{alice.addr, @eth, 1}, {alice.addr, @eth, 2}])
-    hash = Transaction.hash(tx)
+    hash = Transaction.raw_txhash(tx)
     competing_tx = Transaction.new([{2, 1, 0}, {1, 0, 0}], [{alice.addr, @eth, 2}, {alice.addr, @eth, 1}])
 
     challenge = %{
       tx_hash: hash,
       competitor_position: Utxo.Position.encode(@utxo_pos2),
       call_data: %{
-        competing_tx: Transaction.encode(competing_tx),
+        competing_tx: Transaction.raw_txbytes(competing_tx),
         competing_tx_input_index: 0,
         competing_tx_sig: @zero_sig
       }
@@ -170,7 +170,7 @@ defmodule OMG.Watcher.ExitProcessor.PersistenceTest do
   test "persist ife finalizations",
        %{processor_empty: processor, alice: alice, db_pid: db_pid} do
     tx = Transaction.new([{2, 1, 0}], [{alice.addr, @eth, 1}, {alice.addr, @eth, 2}])
-    hash = Transaction.hash(tx)
+    hash = Transaction.raw_txhash(tx)
 
     piggybacks1 = [%{tx_hash: hash, output_index: 0}, %{tx_hash: hash, output_index: 4}]
     piggybacks2 = [%{tx_hash: hash, output_index: 5}]
@@ -224,7 +224,7 @@ defmodule OMG.Watcher.ExitProcessor.PersistenceTest do
 
   defp persist_new_ifes(processor, txs, priv_keys, statuses \\ nil, db_pid) do
     # TODO: dry against machinery in CoreTest, after other TODO's settle down (`deffixture in_flight_exit_events`)
-    encoded_txs = txs |> Enum.map(&Transaction.encode/1)
+    encoded_txs = txs |> Enum.map(&Transaction.raw_txbytes/1)
 
     sigs =
       txs

--- a/apps/omg_watcher/test/omg_watcher/web/controllers/in_flight_exit_test.exs
+++ b/apps/omg_watcher/test/omg_watcher/web/controllers/in_flight_exit_test.exs
@@ -55,14 +55,9 @@ defmodule OMG.Watcher.Web.Controller.InFlightExitTest do
         input_txs =
           input_txs
           |> ExRLP.decode()
-          |> Enum.map(fn
-            "" ->
-              nil
-
-            rlp_decoded ->
-              {:ok, tx} = Transaction.reconstruct(rlp_decoded)
-              tx
-          end)
+          |> Enum.filter(&(&1 != ""))
+          |> Enum.map(&ExRLP.encode/1)
+          |> Enum.map(&Transaction.decode!/1)
 
         assert input_txs == expected_input_txs
       end
@@ -105,6 +100,11 @@ defmodule OMG.Watcher.Web.Controller.InFlightExitTest do
                  }
                }
              } = TestHelper.no_success?("/in_flight_exit.get_data", %{"txbytes" => "tx"})
+
+      assert %{
+               "code" => "get_in_flight_exit:malformed_transaction_rlp",
+               "object" => "error"
+             } = TestHelper.no_success?("/in_flight_exit.get_data", %{"txbytes" => "0x1234"})
     end
   end
 end

--- a/apps/omg_watcher/test/omg_watcher/web/controllers/transaction_test.exs
+++ b/apps/omg_watcher/test/omg_watcher/web/controllers/transaction_test.exs
@@ -897,10 +897,11 @@ defmodule OMG.Watcher.Web.Controller.TransactionTest do
       recovered_txs =
         txs_bytes
         |> Enum.map(fn "0x" <> tx ->
-          tx
-          |> Base.decode16!(case: :lower)
-          |> Transaction.decode!()
-          |> DevCrypto.sign([spender.priv])
+          raw_tx = tx |> Base.decode16!(case: :lower) |> Transaction.decode!()
+          n_inputs = raw_tx |> Transaction.get_inputs() |> length
+
+          raw_tx
+          |> DevCrypto.sign(List.duplicate(spender.priv, n_inputs))
           |> Transaction.Signed.encode()
           |> Transaction.Recovered.recover_from!()
         end)

--- a/apps/omg_watcher/test/omg_watcher/web/controllers/transaction_test.exs
+++ b/apps/omg_watcher/test/omg_watcher/web/controllers/transaction_test.exs
@@ -905,15 +905,12 @@ defmodule OMG.Watcher.Web.Controller.TransactionTest do
       recovered_txs =
         txs_bytes
         |> Enum.map(fn "0x" <> tx ->
-          {:ok, %Transaction.Recovered{} = recovered} =
-            tx
-            |> Base.decode16!(case: :lower)
-            |> Transaction.decode!()
-            |> DevCrypto.sign([spender.priv])
-            |> Transaction.Signed.encode()
-            |> Transaction.Recovered.recover_from()
-
-          recovered
+          tx
+          |> Base.decode16!(case: :lower)
+          |> Transaction.decode!()
+          |> DevCrypto.sign([spender.priv])
+          |> Transaction.Signed.encode()
+          |> Transaction.Recovered.recover_from!()
         end)
 
       [{blknum, recovered_txs}] |> blocks_inserter.()

--- a/apps/omg_watcher/test/omg_watcher/web/controllers/transaction_test.exs
+++ b/apps/omg_watcher/test/omg_watcher/web/controllers/transaction_test.exs
@@ -519,46 +519,38 @@ defmodule OMG.Watcher.Web.Controller.TransactionTest do
     end
 
     @tag fixtures: [:alice, :bob, :more_utxos]
-    test "returns correctly formed transaction", %{alice: alice, bob: bob} do
+    test "returns correctly formed transaction, identical with the verbose form", %{alice: alice, bob: bob} do
       alias OMG.State.Transaction
-
-      alice_to_bob = 100
-      fee = 5
-      metadata = (alice.addr <> bob.addr) |> OMG.Crypto.hash()
-
-      alice_addr = Encoding.to_hex(alice.addr)
 
       assert %{
                "result" => "complete",
-               "transactions" => [%{"txbytes" => tx_hex}]
+               "transactions" => [
+                 %{
+                   "inputs" => verbose_inputs,
+                   "outputs" => verbose_outputs,
+                   "metadata" => verbose_metadata,
+                   "txbytes" => tx_hex
+                 }
+               ]
              } =
                TestHelper.success?(
                  "transaction.create",
                  %{
-                   "owner" => alice_addr,
-                   "payments" => [
-                     %{"amount" => alice_to_bob, "currency" => @eth_hex, "owner" => Encoding.to_hex(bob.addr)}
-                   ],
-                   "fee" => %{"amount" => fee, "currency" => @eth_hex},
-                   "metadata" => Encoding.to_hex(metadata)
+                   "owner" => Encoding.to_hex(alice.addr),
+                   "payments" => [%{"amount" => 100, "currency" => @eth_hex, "owner" => Encoding.to_hex(bob.addr)}],
+                   "fee" => %{"amount" => 5, "currency" => @eth_hex},
+                   "metadata" => Encoding.to_hex(<<123::256>>)
                  }
                )
 
-      assert {:ok, txbytes} = Encoding.from_hex(tx_hex)
-      assert {:ok, raw_tx} = Transaction.decode(txbytes)
+      verbose_tx =
+        Transaction.new(
+          verbose_inputs |> Enum.map(&{&1["blknum"], &1["txindex"], &1["oindex"]}),
+          verbose_outputs |> Enum.map(&{from_hex!(&1["owner"]), from_hex!(&1["currency"]), &1["amount"]}),
+          from_hex!(verbose_metadata)
+        )
 
-      alice_addr = alice.addr
-      bob_addr = bob.addr
-
-      assert %Transaction{
-               inputs: [%{blknum: 5000} | _],
-               outputs: [
-                 %{owner: ^bob_addr, currency: @eth, amount: ^alice_to_bob},
-                 %{owner: ^alice_addr, currency: @eth}
-                 | _
-               ],
-               metadata: ^metadata
-             } = raw_tx
+      assert tx_hex == verbose_tx |> Transaction.raw_txbytes() |> Encoding.to_hex()
     end
 
     @tag fixtures: [:alice, :bob, :more_utxos, :blocks_inserter]
@@ -1086,5 +1078,10 @@ defmodule OMG.Watcher.Web.Controller.TransactionTest do
                  }
                )
     end
+  end
+
+  defp from_hex!(hex) do
+    {:ok, result} = Encoding.from_hex(hex)
+    result
   end
 end


### PR DESCRIPTION
This is a set of changes which allow to treat Transaction structures in our code a little bit more opaquely. The main feature in terms of code structure is the ability to call `Transaction.get_inputs/outputs/raw_txhash/raw_txbytes(tx)` on various "flavors" of the `tx` `Transaction....` struct.

Some "reaching into the struct's guts" remains, as I'm still a bit reluctant whether this is the way to go.

NOTE: `apps/omg/test/state/transaction_test.exs` got a total makeover, in an attempt to cover all and only the necessary behaviors of the new `Transaction` API, review as if it was a new file.

Apart from the refactor, some minor DRYings and improvements, esp. around test helpers that manage the transaction structures
