### PR TITLE
[Omg 442] transaction.create: making empty transaction incorrect

### DIFF
--- a/apps/omg_watcher/lib/web/controllers/fallback.ex
+++ b/apps/omg_watcher/lib/web/controllers/fallback.ex
@@ -52,6 +52,10 @@ defmodule OMG.Watcher.Web.Controller.Fallback do
     too_many_outputs: %{
       code: "transaction.create:too_many_outputs",
       description: "Total number of payments + change + fees exceed maximum allowed outputs."
+    },
+    empty_transaction: %{
+      code: "transaction.create:empty_transaction",
+      description: "Requested payment transfers no funds."
     }
   }
 

--- a/docs/api_specs/errors.md
+++ b/docs/api_specs/errors.md
@@ -31,3 +31,4 @@ in_flight_exit:tx_for_input_not_found | No transaction that created input.
 transaction:not_found | Transaction doesn't exist for provided search criteria
 transaction.create:insufficient_funds | Account balance is too low to satisfy the payment.
 transaction.create:too_many_outputs | Total number of payments + change + fees exceed maximum allowed outputs in transaction. We need to reserve one output per payment and one output per change for each currency used in the transaction.
+transaction.create:empty_transaction | Requested payment resulted in empty transaction that transfers no funds.


### PR DESCRIPTION
Handles the case for `/transaction.create` endpoint when request is valid but resulting transaction transfers no funds. This means that both payments was empty and zero-fee was set.

__Explaination__
Empty payments is allowed along with non-zero fee which is funds burning that benefits the operator

__Reviewer__
@pgebal 