### PR TITLE
fix: alarms raised in the appropriate application and passed as param, removed supervision tree

### DIFF
--- a/apps/omg/lib/omg/root_chain_coordinator.ex
+++ b/apps/omg/lib/omg/root_chain_coordinator.ex
@@ -81,10 +81,11 @@ defmodule OMG.RootChainCoordinator do
     {:noreply, state}
   end
 
-  def handle_call({:check_in, synced_height, service_name}, {pid, _}, state) do
+  def handle_call({:check_in, synced_height, service_name}, {pid, _ref}, state) do
     _ = Logger.debug("#{inspect(service_name)} checks in on height #{inspect(synced_height)}")
+
     {:ok, state} = Core.check_in(state, pid, synced_height, service_name)
-    {:reply, :ok, state, 60_000}
+    {:reply, :ok, state}
   end
 
   def handle_call(:get_sync_info, {pid, _}, state) do
@@ -99,11 +100,6 @@ defmodule OMG.RootChainCoordinator do
 
   def handle_info({:DOWN, _ref, :process, pid, _}, state) do
     {:ok, state} = Core.check_out(state, pid)
-    {:noreply, state}
-  end
-
-  def handle_info(:timeout, state) do
-    _ = Logger.warn("No new activity for 60 seconds. Are we dead?")
     {:noreply, state}
   end
 

--- a/apps/omg/lib/omg/state.ex
+++ b/apps/omg/lib/omg/state.ex
@@ -85,13 +85,15 @@ defmodule OMG.State do
   Start processing state using the database entries
   """
   def init(:ok) do
-    {:ok, %{}, {:continue, :setup}}
+    # Get utxos() is essential for the State and Blockgetter. And it takes a while. TODO - measure it!
+    # Our approach is simply blocking the supervision boot tree
+    # until we've processed history.
+    {:ok, DB.utxos(), {:continue, :setup}}
   end
 
-  def handle_continue(:setup, %{}) do
+  def handle_continue(:setup, {:ok, utxos_query_result}) do
     {:ok, height_query_result} = DB.get_single_value(:child_top_block_number)
     {:ok, last_deposit_query_result} = DB.get_single_value(:last_deposit_child_blknum)
-    {:ok, utxos_query_result} = DB.utxos()
     {:ok, child_block_interval} = Eth.RootChain.get_child_block_interval()
 
     {:ok, state} =

--- a/apps/omg_api/lib/omg_api/alert/alarm_handler.ex
+++ b/apps/omg_api/lib/omg_api/alert/alarm_handler.ex
@@ -17,7 +17,12 @@ defmodule OMG.API.Alert.AlarmHandler do
   Handler for OMG API app.
   """
 
-  def install, do: :alarm_handler.add_alarm_handler(__MODULE__)
+  def install do
+    case Enum.member?(:gen_event.which_handlers(:alarm_handler), __MODULE__) do
+      true -> :ok
+      _ -> :alarm_handler.add_alarm_handler(__MODULE__)
+    end
+  end
 
   @callback ethereum_client_connection_issue(node(), module()) :: {atom(), map()}
 

--- a/apps/omg_api/lib/omg_api/alert/alarm_handler.ex
+++ b/apps/omg_api/lib/omg_api/alert/alarm_handler.ex
@@ -24,10 +24,6 @@ defmodule OMG.API.Alert.AlarmHandler do
   # subscribing to alarms of type
   def alarm_types, do: [:ethereum_client_connection]
 
-  def start_link(_args) do
-    GenServer.start_link(__MODULE__, [], name: __MODULE__)
-  end
-
   def init(_args) do
     {:ok, %{alarms: []}}
   end

--- a/apps/omg_api/lib/omg_api/ethereum_client_monitor.ex
+++ b/apps/omg_api/lib/omg_api/ethereum_client_monitor.ex
@@ -16,38 +16,80 @@ defmodule OMG.API.EthereumClientMonitor do
   @moduledoc """
   This module periodically checks Geth (every second or less) and raises an alarm
   when it can't reach the client and clears the alarm when the client connection is established again.
+
+  The module implements a genserver that repeatedly checks the health of the ethereum client and it also implements
+  alarm handler callbacks. When the genserver raises an alarm, we get a callback and get notified - and we update our state (raised = true).
   """
   use GenServer
   require Logger
-  alias OMG.API.Alert.Alarm
   alias OMG.Eth
 
   @default_interval 500
   @type t :: %__MODULE__{
           interval: pos_integer(),
-          tref: reference() | nil
+          tref: reference() | nil,
+          alarm_module: module(),
+          raised: boolean()
         }
-  defstruct interval: @default_interval, tref: nil
+  defstruct interval: @default_interval, tref: nil, alarm_module: nil, raised: true
 
-  def start_link(_args) do
-    GenServer.start_link(__MODULE__, [], name: __MODULE__)
+  def start_link(args) do
+    GenServer.start_link(__MODULE__, args, name: __MODULE__)
   end
 
-  def init(_args) do
-    state = %__MODULE__{}
-    _ = raise_clear(check())
+  def init([alarm_module]) do
+    install()
+    state = %__MODULE__{alarm_module: alarm_module}
+    :ok = alarm_module.raise({:ethereum_client_connection, :erlang.node(), __MODULE__})
+    _ = raise_clear(alarm_module, state.raised, check())
     {:ok, tref} = :timer.send_after(state.interval, :health_check)
     _ = Logger.info("Starting Ethereum client monitor.")
     {:ok, %{state | tref: tref}}
   end
 
+  # gen_event
+  def init(_args) do
+    {:ok, %{}}
+  end
+
   def handle_info(:health_check, state) do
-    _ = raise_clear(check())
+    _ = raise_clear(state.alarm_module, state.raised, check())
     {:ok, tref} = :timer.send_after(state.interval, :health_check)
     {:noreply, %{state | tref: tref}}
   end
 
+  def handle_cast(:clear_alarm, state) do
+    {:noreply, %{state | raised: false}}
+  end
+
+  def handle_cast(:set_alarm, state) do
+    {:noreply, %{state | raised: true}}
+  end
+
   def terminate(_, _), do: :ok
+
+  #
+  # gen_event
+  #
+  def handle_call(_request, state), do: {:ok, :ok, state}
+
+  def handle_event({:clear_alarm, {:ethereum_client_connection, %{reporter: __MODULE__}}}, state) do
+    _ = Logger.warn("Health check established connection to the client. :ethereum_client_connection alarm clearead.")
+    :ok = GenServer.cast(__MODULE__, :clear_alarm)
+    {:ok, state}
+  end
+
+  def handle_event({:set_alarm, {:ethereum_client_connection, %{reporter: __MODULE__}}}, state) do
+    _ = Logger.warn("Health check raised :ethereum_client_connection alarm.")
+    :ok = GenServer.cast(__MODULE__, :set_alarm)
+    {:ok, state}
+  end
+
+  # flush
+  def handle_event(event, state) do
+    _ = Logger.info("Eth client monitor got event: #{inspect(event)}. Ignoring.")
+    {:ok, state}
+  end
 
   @spec check :: non_neg_integer() | :error
   defp check do
@@ -57,9 +99,21 @@ defmodule OMG.API.EthereumClientMonitor do
     _ -> :error
   end
 
-  @spec raise_clear(:error | non_neg_integer()) :: :ok | :duplicate
-  defp raise_clear(:error), do: Alarm.raise({:ethereum_client_connection, :erlang.node(), __MODULE__})
-  defp raise_clear(_), do: Alarm.clear({:ethereum_client_connection, :erlang.node(), __MODULE__})
+  # if an alarm is raised, we don't have to raise it again.
+  # if an alarm is cleared, we don't need to clear it again
+  # we want to avoid pushing events again
+  @spec raise_clear(module(), boolean(), :error | non_neg_integer()) :: :ok | :duplicate
+  defp raise_clear(_alarm_module, true, :error), do: :ok
+
+  defp raise_clear(alarm_module, false, :error),
+    do: alarm_module.raise({:ethereum_client_connection, :erlang.node(), __MODULE__})
+
+  defp raise_clear(alarm_module, true, _),
+    do: alarm_module.clear({:ethereum_client_connection, :erlang.node(), __MODULE__})
+
+  defp raise_clear(_alarm_module, false, _), do: :ok
 
   defp eth, do: Application.get_env(:omg_api, :eth_integration_module, Eth)
+
+  defp install, do: :alarm_handler.add_alarm_handler(__MODULE__)
 end

--- a/apps/omg_api/lib/omg_api/ethereum_client_monitor.ex
+++ b/apps/omg_api/lib/omg_api/ethereum_client_monitor.ex
@@ -40,7 +40,7 @@ defmodule OMG.API.EthereumClientMonitor do
   def init([alarm_module]) do
     install()
     state = %__MODULE__{alarm_module: alarm_module}
-    :ok = alarm_module.raise({:ethereum_client_connection, :erlang.node(), __MODULE__})
+    _ = alarm_module.raise({:ethereum_client_connection, :erlang.node(), __MODULE__})
     _ = raise_clear(alarm_module, state.raised, check())
     {:ok, tref} = :timer.send_after(state.interval, :health_check)
     _ = Logger.info("Starting Ethereum client monitor.")
@@ -115,5 +115,10 @@ defmodule OMG.API.EthereumClientMonitor do
 
   defp eth, do: Application.get_env(:omg_api, :eth_integration_module, Eth)
 
-  defp install, do: :alarm_handler.add_alarm_handler(__MODULE__)
+  defp install do
+    case Enum.member?(:gen_event.which_handlers(:alarm_handler), __MODULE__) do
+      true -> :ok
+      _ -> :alarm_handler.add_alarm_handler(__MODULE__)
+    end
+  end
 end

--- a/apps/omg_api/lib/omg_api/monitor.ex
+++ b/apps/omg_api/lib/omg_api/monitor.ex
@@ -166,5 +166,10 @@ defmodule OMG.API.Monitor do
     |> is_map()
   end
 
-  defp install, do: :alarm_handler.add_alarm_handler(__MODULE__)
+  defp install do
+    case Enum.member?(:gen_event.which_handlers(:alarm_handler), __MODULE__) do
+      true -> :ok
+      _ -> :alarm_handler.add_alarm_handler(__MODULE__)
+    end
+  end
 end

--- a/apps/omg_api/lib/omg_api/sup.ex
+++ b/apps/omg_api/lib/omg_api/sup.ex
@@ -18,6 +18,7 @@ defmodule OMG.API.Sup do
   """
   use Supervisor
   use OMG.LoggerExt
+  alias OMG.API.Alert.Alarm
 
   def start_link do
     Supervisor.start_link(__MODULE__, :ok, name: __MODULE__)
@@ -61,8 +62,8 @@ defmodule OMG.API.Sup do
       {OMG.State, []},
       {OMG.API.FreshBlocks, []},
       {OMG.API.FeeServer, []},
-      {OMG.API.EthereumClientMonitor, []},
-      {OMG.API.Monitor, monitor_children}
+      {OMG.API.EthereumClientMonitor, [Alarm]},
+      {OMG.API.Monitor, [Alarm, monitor_children]}
     ]
 
     opts = [strategy: :one_for_one]

--- a/apps/omg_api/test/omg_api/ethereum_client_monitor_test.exs
+++ b/apps/omg_api/test/omg_api/ethereum_client_monitor_test.exs
@@ -25,7 +25,7 @@ defmodule OMG.API.EthereumClientMonitorTest do
     :ok = AlarmHandler.install()
     Mock.start_link()
     Application.put_env(:omg_api, :eth_integration_module, Mock)
-    {:ok, _} = EthereumClientMonitor.start_link([])
+    {:ok, _} = EthereumClientMonitor.start_link([Alarm])
 
     on_exit(fn ->
       Application.put_env(:omg_api, :eth_integration_module, nil)

--- a/apps/omg_watcher/lib/omg_watcher/alert/alarm_handler.ex
+++ b/apps/omg_watcher/lib/omg_watcher/alert/alarm_handler.ex
@@ -17,7 +17,12 @@ defmodule OMG.Watcher.Alert.AlarmHandler do
   Handler for OMG Watcher app.
   """
 
-  def install, do: :alarm_handler.add_alarm_handler(__MODULE__)
+  def install do
+    case Enum.member?(:gen_event.which_handlers(:alarm_handler), __MODULE__) do
+      true -> :ok
+      _ -> :alarm_handler.add_alarm_handler(__MODULE__)
+    end
+  end
 
   @callback ethereum_client_connection_issue(node(), module()) :: {atom(), map()}
 

--- a/apps/omg_watcher/lib/omg_watcher/alert/alarm_handler.ex
+++ b/apps/omg_watcher/lib/omg_watcher/alert/alarm_handler.ex
@@ -24,10 +24,6 @@ defmodule OMG.Watcher.Alert.AlarmHandler do
   # subscribing to alarms of type
   def alarm_types, do: [:ethereum_client_connection]
 
-  def start_link(_args) do
-    GenServer.start_link(__MODULE__, [], name: __MODULE__)
-  end
-
   def init(_args) do
     {:ok, %{alarms: []}}
   end

--- a/apps/omg_watcher/lib/omg_watcher/application.ex
+++ b/apps/omg_watcher/lib/omg_watcher/application.ex
@@ -24,6 +24,7 @@ defmodule OMG.Watcher.Application do
     DeferredConfig.populate(:omg_rpc)
 
     _ = Logger.info("Starting #{inspect(__MODULE__)}")
+
     :ok = AlarmHandler.install()
     start_root_supervisor()
   end

--- a/apps/omg_watcher/lib/omg_watcher/sync_supervisor.ex
+++ b/apps/omg_watcher/lib/omg_watcher/sync_supervisor.ex
@@ -23,6 +23,7 @@ defmodule OMG.Watcher.SyncSupervisor do
   alias OMG.Eth
   alias OMG.EthereumEventListener
   alias OMG.Watcher
+  alias OMG.Watcher.Alert.Alarm
   alias OMG.Watcher.CoordinatorSetup
 
   def start_link do
@@ -31,8 +32,8 @@ defmodule OMG.Watcher.SyncSupervisor do
 
   def init(:ok) do
     children = [
-      {OMG.API.EthereumClientMonitor, []},
-      {OMG.API.Monitor, monitor_children()}
+      {OMG.API.EthereumClientMonitor, [Alarm]},
+      {OMG.API.Monitor, [Alarm, monitor_children()]}
     ]
 
     opts = [strategy: :one_for_one]


### PR DESCRIPTION
- Because of the pub/sub to alarms I was able to remove all the timers in monitoring and by that, simplified the implementation and testing a lot (there's no race conditions anymore), and ethereum client monitor now doesn't constantly publish it's cleared or raised events.
- I've also made these two modules parametrized so that they are usable from both childchain and watcher. 
- The supervision tree `OMG.Watcher.BlockGetter.Supervisor` was removed and all his children moved one level up. They're all eth client dependent and we're handling them in the custom monitor.