### PR TITLE
refactor: move emitting exit_finalized events to ExitProcessor

### DIFF
--- a/apps/omg/lib/omg/state.ex
+++ b/apps/omg/lib/omg/state.ex
@@ -62,7 +62,7 @@ defmodule OMG.State do
   end
 
   @spec exit_utxos(utxos :: Core.exiting_utxos_t()) ::
-          {:ok, list(Core.exit_event()), list(Core.db_update()), Core.validities_t()}
+          {:ok, list(Core.db_update()), Core.validities_t()}
   def exit_utxos(utxos) do
     GenServer.call(__MODULE__, {:exit_utxos, utxos})
   end
@@ -149,11 +149,9 @@ defmodule OMG.State do
   Exits (spends) utxos on child chain, explicitly signals all utxos that have already been spent
   """
   def handle_call({:exit_utxos, utxos}, _from, state) do
-    {:ok, {event_triggers, db_updates, validities}, new_state} = Core.exit_utxos(utxos, state)
+    {:ok, {db_updates, validities}, new_state} = Core.exit_utxos(utxos, state)
 
-    EventerAPI.emit_events(event_triggers)
-
-    {:reply, {:ok, event_triggers, db_updates, validities}, new_state}
+    {:reply, {:ok, db_updates, validities}, new_state}
   end
 
   @doc """

--- a/apps/omg/test/omg/state/core_test.exs
+++ b/apps/omg/test/omg/state/core_test.exs
@@ -554,18 +554,12 @@ defmodule OMG.State.CoreTest do
       |> Core.exec(create_recovered([{1, 0, 0, alice}], @eth, [{alice, amount_1}, {alice, amount_2}]), :ignore)
       |> success?
 
-    expected_owner = alice.addr
-
     utxo_pos_exit_1 = Utxo.position(@blknum1, 0, 0)
     utxo_pos_exit_2 = Utxo.position(@blknum1, 0, 1)
     utxo_pos_exits = [utxo_pos_exit_1, utxo_pos_exit_2]
 
-    assert {:ok,
-            {[
-               %{exit: %{owner: ^expected_owner, utxo_pos: ^utxo_pos_exit_1, amount: ^amount_1, currency: @eth}},
-               %{exit: %{owner: ^expected_owner, utxo_pos: ^utxo_pos_exit_2, amount: ^amount_2, currency: @eth}}
-             ], [_ | _], {[^utxo_pos_exit_1, ^utxo_pos_exit_2], []}},
-            state_after_exit} = Core.exit_utxos(utxo_pos_exits, state)
+    assert {:ok, {[_ | _], {[^utxo_pos_exit_1, ^utxo_pos_exit_2], []}}, state_after_exit} =
+             Core.exit_utxos(utxo_pos_exits, state)
 
     state_after_exit
     |> Core.exec(create_recovered([{@blknum1, 0, 0, alice}], @eth, [{alice, 7}]), :ignore)
@@ -582,16 +576,14 @@ defmodule OMG.State.CoreTest do
 
     state = state |> Core.exec(tx, :ignore) |> success?
 
-    expected_owner = alice.addr
     utxo_pos_exits_in_flight = [%{call_data: %{in_flight_tx: Transaction.raw_txbytes(tx)}}]
     utxo_pos_exits_piggyback = [%{tx_hash: Transaction.raw_txhash(tx), output_index: 4}]
     expected_position = Utxo.position(@blknum1, 0, 0)
 
-    assert {:ok, {[], [], {[], _}}, ^state} = Core.exit_utxos(utxo_pos_exits_in_flight, state)
+    assert {:ok, {[], {[], _}}, ^state} = Core.exit_utxos(utxo_pos_exits_in_flight, state)
 
-    assert {:ok,
-            {[%{exit: %{owner: ^expected_owner, utxo_pos: ^expected_position}}], [_ | _], {[^expected_position], []}},
-            state_after_exit} = Core.exit_utxos(utxo_pos_exits_piggyback, state)
+    assert {:ok, {[_ | _], {[^expected_position], []}}, state_after_exit} =
+             Core.exit_utxos(utxo_pos_exits_piggyback, state)
 
     state_after_exit
     |> Core.exec(create_recovered([{@blknum1, 0, 0, alice}], @eth, [{alice, 7}]), :ignore)
@@ -611,13 +603,11 @@ defmodule OMG.State.CoreTest do
 
     tx = create_recovered([{@blknum1, 0, 0, alice}], @eth, [{alice, 3}, {alice, 3}])
 
-    expected_owner = alice.addr
     utxo_pos_exits_in_flight = [%{call_data: %{in_flight_tx: Transaction.raw_txbytes(tx)}}]
     expected_position = Utxo.position(@blknum1, 0, 0)
 
-    assert {:ok,
-            {[%{exit: %{owner: ^expected_owner, utxo_pos: ^expected_position}}], [_ | _], {[^expected_position], _}},
-            state_after_exit} = Core.exit_utxos(utxo_pos_exits_in_flight, state)
+    assert {:ok, {[_ | _], {[^expected_position], _}}, state_after_exit} =
+             Core.exit_utxos(utxo_pos_exits_in_flight, state)
 
     state_after_exit
     |> Core.exec(create_recovered([{@blknum1, 0, 0, alice}], @eth, [{alice, 7}]), :ignore)
@@ -631,7 +621,7 @@ defmodule OMG.State.CoreTest do
   test "notifies about invalid utxo exiting", %{state_empty: state} do
     utxo_pos_exit_1 = Utxo.position(@blknum1, 0, 0)
 
-    assert {:ok, {[], [], {[], [^utxo_pos_exit_1]}}, ^state} = Core.exit_utxos([utxo_pos_exit_1], state)
+    assert {:ok, {[], {[], [^utxo_pos_exit_1]}}, ^state} = Core.exit_utxos([utxo_pos_exit_1], state)
   end
 
   @tag fixtures: [:alice, :state_empty]

--- a/apps/omg/test/omg/state/persistence_test.exs
+++ b/apps/omg/test/omg/state/persistence_test.exs
@@ -171,7 +171,7 @@ defmodule OMG.State.PersistenceTest do
   end
 
   defp persist_exit_utxos(state, utxo_positions, db_pid) do
-    assert {:ok, {_, db_updates, _}, state} = utxo_positions |> Core.exit_utxos(state)
+    assert {:ok, {db_updates, _}, state} = utxo_positions |> Core.exit_utxos(state)
     persist_common(state, db_updates, db_pid)
   end
 

--- a/apps/omg/test/omg/state_test.exs
+++ b/apps/omg/test/omg/state_test.exs
@@ -55,7 +55,7 @@ defmodule OMG.StateTest do
     assert {blknum, _} = State.get_status()
     assert :ok = State.form_block()
     # exits, with invalid ones
-    assert {:ok, _events, _db, _} = State.exit_utxos([Utxo.position(blknum, 0, 0)])
+    assert {:ok, _db, _} = State.exit_utxos([Utxo.position(blknum, 0, 0)])
     # close block
     assert {:ok, _db} = State.close_block(123)
   end

--- a/apps/omg_api/lib/omg_api/sup.ex
+++ b/apps/omg_api/lib/omg_api/sup.ex
@@ -41,19 +41,19 @@ defmodule OMG.API.Sup do
         service_name: :in_flight_exit,
         synced_height_update_key: :last_in_flight_exit_eth_height,
         get_events_callback: &OMG.Eth.RootChain.get_in_flight_exit_starts/2,
-        process_events_callback: &exit_and_ignore_events_and_validities/1
+        process_events_callback: &exit_and_ignore_validities/1
       ),
       OMG.EthereumEventListener.prepare_child(
         service_name: :piggyback,
         synced_height_update_key: :last_piggyback_exit_eth_height,
         get_events_callback: &OMG.Eth.RootChain.get_piggybacks/2,
-        process_events_callback: &exit_and_ignore_events_and_validities/1
+        process_events_callback: &exit_and_ignore_validities/1
       ),
       OMG.EthereumEventListener.prepare_child(
         service_name: :exiter,
         synced_height_update_key: :last_exiter_eth_height,
         get_events_callback: &OMG.Eth.RootChain.get_standard_exits/2,
-        process_events_callback: &exit_and_ignore_events_and_validities/1
+        process_events_callback: &exit_and_ignore_validities/1
       ),
       {OMG.RPC.Web.Endpoint, []}
     ]
@@ -83,8 +83,8 @@ defmodule OMG.API.Sup do
     }
   end
 
-  defp exit_and_ignore_events_and_validities(exits) do
-    {status, _events, db_updates, _validities} = OMG.State.exit_utxos(exits)
+  defp exit_and_ignore_validities(exits) do
+    {status, db_updates, _validities} = OMG.State.exit_utxos(exits)
     {status, db_updates}
   end
 end

--- a/apps/omg_watcher/test/omg_watcher/exit_processor/persistence_test.exs
+++ b/apps/omg_watcher/test/omg_watcher/exit_processor/persistence_test.exs
@@ -211,7 +211,7 @@ defmodule OMG.Watcher.ExitProcessor.PersistenceTest do
   end
 
   defp persist_finalize_exits(processor, validities, db_pid) do
-    {processor, db_updates} = Core.finalize_exits(processor, validities)
+    {processor, _, db_updates} = Core.finalize_exits(processor, validities)
     persist_common(processor, db_updates, db_pid)
   end
 


### PR DESCRIPTION
The functionality to emit the stub of `ExitFinalized` events got placed in `State` following the example of transaction events. But exit finalized don't seem to have a good reason to not be emitted from the `ExitProcessor` for much cleaner code.

Also, fixed a broken test in `ExitProcessor`: [here](https://github.com/omisego/elixir-omg/compare/emit_exit_finalized_from_exit_processor?expand=1#diff-91398068aa8ecf8b7913c807e662c304R344) one should be testing processing of valid exits, as the test title suggests.