### PR TITLE
fix: silence channel join logs

### DIFF
--- a/apps/omg_watcher/lib/omg_watcher/web/channels/exit.ex
+++ b/apps/omg_watcher/lib/omg_watcher/web/channels/exit.ex
@@ -17,7 +17,7 @@ defmodule OMG.Watcher.Web.Channel.Exit do
   Channel Exit
   """
 
-  use Phoenix.Channel
+  use Phoenix.Channel, log_join: :debug
 
   def join("exit:" <> _address, _params, socket) do
     {:ok, socket}

--- a/apps/omg_watcher/lib/omg_watcher/web/channels/transfer.ex
+++ b/apps/omg_watcher/lib/omg_watcher/web/channels/transfer.ex
@@ -17,7 +17,7 @@ defmodule OMG.Watcher.Web.Channel.Transfer do
   Channel Transfer
   """
 
-  use Phoenix.Channel
+  use Phoenix.Channel, log_join: :debug
 
   def join("transfer:" <> _address, _params, socket) do
     {:ok, socket}


### PR DESCRIPTION
without this, the log level being `:info` for `join` events we were getting a flood of:


```
2019-04-03 14:16:52.350 [info] module=Phoenix.Logger function=phoenix_socket_connect/3 ⋅CONNECT OMG.Watcher.Web.Socket
```