### PR TITLE
refactor: put all mix config entries in `config.exs` files, document

### DIFF
--- a/apps/omg/config/config.exs
+++ b/apps/omg/config/config.exs
@@ -1,5 +1,7 @@
 use Mix.Config
 
+# see [here](README.md) for documentation
+
 config :omg,
   deposit_finality_margin: 10,
   ethereum_events_check_interval_ms: 500,

--- a/apps/omg/mix.exs
+++ b/apps/omg/mix.exs
@@ -19,14 +19,6 @@ defmodule OMG.MixProject do
 
   def application do
     [
-      env: [
-        # we're using a shared (in `omg` app) config entry. The reason here is to minimize risk of Child Chain server's
-        # and Watcher's configuration entries diverging (it would be bad, as they must share the same value of this).
-        # However, this sharing isn't elegant, as this setting is never read in `:omg` app per se
-        deposit_finality_margin: 10,
-        ethereum_events_check_interval_ms: 500,
-        coordinator_eth_height_check_interval_ms: 6_000
-      ],
       extra_applications: [:logger, :appsignal]
     ]
   end

--- a/apps/omg_api/config/config.exs
+++ b/apps/omg_api/config/config.exs
@@ -1,9 +1,12 @@
 use Mix.Config
 
+# see [here](README.md) for documentation
+
 config :omg_api,
   submission_finality_margin: 20,
   block_queue_eth_height_check_interval_ms: 6_000,
   child_block_minimal_enqueue_gap: 1,
-  fee_specs_file_path: "./fee_specs.json"
+  fee_specs_file_path: "./fee_specs.json",
+  ignore_fees: false
 
 import_config "#{Mix.env()}.exs"

--- a/apps/omg_api/mix.exs
+++ b/apps/omg_api/mix.exs
@@ -19,12 +19,6 @@ defmodule OMG.API.MixProject do
 
   def application do
     [
-      env: [
-        submission_finality_margin: 20,
-        block_queue_eth_height_check_interval_ms: 6_000,
-        child_block_minimal_enqueue_gap: 1,
-        fee_specs_file_path: nil
-      ],
       extra_applications: [:logger, :appsignal],
       mod: {OMG.API.Application, []}
     ]

--- a/apps/omg_db/config/config.exs
+++ b/apps/omg_db/config/config.exs
@@ -1,5 +1,7 @@
 use Mix.Config
 
+# see [here](README.md) for documentation
+
 config :omg_db,
   leveldb_path: Path.join([System.get_env("HOME"), ".omg/data"]),
   server_module: OMG.DB.LevelDBServer,

--- a/apps/omg_db/mix.exs
+++ b/apps/omg_db/mix.exs
@@ -19,11 +19,6 @@ defmodule OMG.DB.MixProject do
 
   def application do
     [
-      env: [
-        leveldb_path: Path.join([System.get_env("HOME"), ".omg/data"]),
-        server_module: OMG.DB.LevelDBServer,
-        server_name: OMG.DB.LevelDBServer
-      ],
       extra_applications: [:logger],
       mod: {OMG.DB.Application, []}
     ]

--- a/apps/omg_eth/config/config.exs
+++ b/apps/omg_eth/config/config.exs
@@ -1,5 +1,7 @@
 use Mix.Config
 
+# see [here](README.md) for documentation
+
 ethereum_client_timeout_ms = 20_000
 
 config :ethereumex,

--- a/apps/omg_eth/mix.exs
+++ b/apps/omg_eth/mix.exs
@@ -21,9 +21,6 @@ defmodule OMG.Eth.MixProject do
 
   def application do
     [
-      env: [
-        child_block_interval: 1000
-      ],
       extra_applications: [:logger]
     ]
   end

--- a/apps/omg_watcher/config/config.exs
+++ b/apps/omg_watcher/config/config.exs
@@ -6,6 +6,7 @@
 use Mix.Config
 
 # General application configuration
+# see [here](README.md) for documentation
 config :omg_watcher,
   namespace: OMG.Watcher,
   ecto_repos: [OMG.Watcher.DB.Repo],
@@ -16,15 +17,15 @@ config :omg_watcher,
   maximum_number_of_unapplied_blocks: 50,
   exit_finality_margin: 12,
   block_getter_reorg_margin: 200,
-  convenience_api_mode: false,
-  enable_cors: true
+  convenience_api_mode: false
 
 # Configures the endpoint
 config :omg_watcher, OMG.Watcher.Web.Endpoint,
   secret_key_base: "grt5Ef/y/jpx7AfLmrlUS/nfYJUOq+2e+1xmU4nphTm2x8WB7nLFCJ91atbSBrv5",
   render_errors: [view: OMG.Watcher.Web.View.ErrorView, accepts: ~w(json)],
   pubsub: [name: OMG.Watcher.PubSub, adapter: Phoenix.PubSub.PG2],
-  instrumenters: [Appsignal.Phoenix.Instrumenter]
+  instrumenters: [Appsignal.Phoenix.Instrumenter],
+  enable_cors: true
 
 config :omg_watcher, OMG.Watcher.DB.Repo,
   adapter: Ecto.Adapters.Postgres,

--- a/apps/omg_watcher/lib/omg_watcher/web/endpoint.ex
+++ b/apps/omg_watcher/lib/omg_watcher/web/endpoint.ex
@@ -43,7 +43,7 @@ defmodule OMG.Watcher.Web.Endpoint do
   plug(Plug.MethodOverride)
   plug(Plug.Head)
 
-  if Application.get_env(:omg_watcher, :enable_cors),
+  if Application.get_env(:omg_watcher, OMG.Watcher.Web.Endpoint)[:enable_cors],
     do: plug(CORSPlug)
 
   plug(OMG.Watcher.Web.Router)

--- a/apps/omg_watcher/mix.exs
+++ b/apps/omg_watcher/mix.exs
@@ -21,15 +21,6 @@ defmodule OMG.Watcher.Mixfile do
 
   def application do
     [
-      env: [
-        exit_processor_sla_margin: 4 * 4 * 60,
-        maximum_block_withholding_time_ms: 1_200_000,
-        block_getter_loops_interval_ms: 500,
-        maximum_number_of_unapplied_blocks: 50,
-        exit_finality_margin: 12,
-        block_getter_reorg_margin: 200,
-        convenience_api_mode: false
-      ],
       mod: {OMG.Watcher.Application, []},
       extra_applications: [:logger, :runtime_tools, :sasl]
     ]


### PR DESCRIPTION
Turns out, we don't need to put all the config entries twice, the entries in `mix.exs` were redundant, contrary to how Mix docs were understood.

This PR puts all the config entries into `config/config.exs` files of the respective apps

Also, exhaustive documentation about the entries was added, per an old suggestion from @pthomalla :+1:

fixes #560