### PR TITLE
fix: silence the Phoenix.Socket connect logs to debug too

### DIFF
--- a/apps/omg_watcher/lib/web/sockets/socket.ex
+++ b/apps/omg_watcher/lib/web/sockets/socket.ex
@@ -18,7 +18,7 @@ defmodule OMG.Watcher.Web.Socket do
   channels to which providers/clients can connect to listen and receive events.
   """
 
-  use Phoenix.Socket
+  use Phoenix.Socket, log: :debug
 
   ## Channels
   channel("transfer:*", OMG.Watcher.Web.Channel.Transfer)


### PR DESCRIPTION
follow up to #577. Gets rid of 
```
2019-04-05 12:27:43.859 [info] module=Phoenix.Logger function=phoenix_socket_connect/3 ⋅CONNECT OMG.Watcher.Web.Socket
  Transport: :websocket
  Connect Info: %{}
  Parameters: %{"vsn" => "2.0.0"}⋅
2019-04-05 12:27:43.859 [info] module=Phoenix.Socket function=log_connect_result/3 ⋅Replied OMG.Watcher.Web.Socket :ok⋅
```