### PR TITLE
removed --no-start

### DIFF
--- a/launcher.py
+++ b/launcher.py
@@ -390,7 +390,7 @@ class WatcherLauncher:
         '''
         os.chdir(os.path.expanduser('~') + '/elixir-omg')
         result = subprocess.run(
-            "mix ecto.reset --no-start",
+            "mix ecto.reset",
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             shell=True
@@ -410,7 +410,7 @@ class WatcherLauncher:
         '''
         os.chdir(os.path.expanduser('~') + '/elixir-omg')
         result = subprocess.run(
-            "mix ecto.migrate --no-start",
+            "mix ecto.migrate",
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             shell=True


### PR DESCRIPTION
Currently `docker-compose` on linux returns

`ecto.migrate": 1 error found!\n--no-start : Unknown option`

I removed the `--no-start` args and watcher started working again