### PR TITLE
fix: handle malformed txbytes as inputs to IFE-related endpoints

### DIFF
--- a/apps/omg_watcher/test/omg_watcher/exit_processor/core_test.exs
+++ b/apps/omg_watcher/test/omg_watcher/exit_processor/core_test.exs
@@ -1308,11 +1308,11 @@ defmodule OMG.Watcher.ExitProcessor.CoreTest do
       assert {:error, :unknown_ife} = Core.get_input_challenge_data(request, state, comp3_txbytes, 0)
     end
 
-    @tag fixtures: [:invalid_piggyback_on_input, :competing_transactions]
+    @tag fixtures: [:invalid_piggyback_on_input]
     test "fail when asked to produce proof for wrong badly encoded tx",
-         %{invalid_piggyback_on_input: %{state: state, request: request}, competing_transactions: [_, _, comp3 | _]} do
-      corrupted_txbytes = "corruption" <> Transaction.raw_txbytes(comp3)
-      assert {:error, :malformed_transaction_rlp} = Core.get_input_challenge_data(request, state, corrupted_txbytes, 0)
+         %{invalid_piggyback_on_input: %{state: state, request: request}} do
+      assert {:error, :malformed_transaction} = Core.get_input_challenge_data(request, state, <<0>>, 0)
+      assert {:error, :malformed_transaction} = Core.get_output_challenge_data(request, state, <<0>>, 0)
     end
 
     @tag fixtures: [:invalid_piggyback_on_input]
@@ -1927,6 +1927,14 @@ defmodule OMG.Watcher.ExitProcessor.CoreTest do
                %ExitProcessor.Request{blknum_now: 5000, eth_height_now: 5}
                |> Core.get_competitor_for_ife(processor, txbytes)
     end
+
+    @tag fixtures: [:processor_empty]
+    test "for malformed input txbytes doesn't crash",
+         %{processor_empty: processor} do
+      assert {:error, :malformed_transaction} =
+               %ExitProcessor.Request{blknum_now: 5000, eth_height_now: 5}
+               |> Core.get_competitor_for_ife(processor, <<0>>)
+    end
   end
 
   describe "detects the need and allows to respond to canonicity challenges" do
@@ -1979,6 +1987,11 @@ defmodule OMG.Watcher.ExitProcessor.CoreTest do
       assert {:error, :canonical_not_found} =
                %ExitProcessor.Request{blknum_now: 5000, eth_height_now: 5}
                |> Core.prove_canonical_for_ife(txbytes)
+    end
+
+    test "for malformed input txbytes doesn't crash" do
+      assert {:error, :malformed_transaction} =
+               %ExitProcessor.Request{blknum_now: 5000, eth_height_now: 5} |> Core.prove_canonical_for_ife(<<0>>)
     end
 
     @tag fixtures: [:processor_filled]

--- a/apps/omg_watcher/test/omg_watcher/web/controllers/in_flight_exit_test.exs
+++ b/apps/omg_watcher/test/omg_watcher/web/controllers/in_flight_exit_test.exs
@@ -88,6 +88,12 @@ defmodule OMG.Watcher.Web.Controller.InFlightExitTest do
     end
 
     @tag fixtures: [:phoenix_ecto_sandbox]
+    test "behaves well if input malformed" do
+      assert %{"code" => "get_in_flight_exit:malformed_transaction"} =
+               TestHelper.no_success?("/in_flight_exit.get_data", %{"txbytes" => "0x00"})
+    end
+
+    @tag fixtures: [:phoenix_ecto_sandbox]
     test "responds with error for malformed in-flight transaction bytes" do
       assert %{
                "code" => "operation:bad_request",


### PR DESCRIPTION
port of #592 from `v0.1` to `master`.