### PR TITLE
fix: make utxo and challenge related endpoints tolerate bad utxo_pos

### DIFF
--- a/apps/omg/lib/omg/state/core.ex
+++ b/apps/omg/lib/omg/state/core.ex
@@ -390,7 +390,7 @@ defmodule OMG.State.Core do
   end
 
   def exit_utxos([encoded_utxo_pos | _] = exit_infos, %Core{} = state) when is_integer(encoded_utxo_pos) do
-    exit_infos |> Enum.map(&Utxo.Position.decode/1) |> exit_utxos(state)
+    exit_infos |> Enum.map(&Utxo.Position.decode!/1) |> exit_utxos(state)
   end
 
   def exit_utxos([%{call_data: %{in_flight_tx: _}} | _] = in_flight_txs, %Core{} = state) do

--- a/apps/omg/lib/omg/utxo/position.ex
+++ b/apps/omg/lib/omg/utxo/position.ex
@@ -41,14 +41,22 @@ defmodule OMG.Utxo.Position do
   def encode(Utxo.position(blknum, txindex, oindex)),
     do: blknum * @block_offset + txindex * @transaction_offset + oindex
 
-  @spec decode(pos_integer()) :: t()
+  @spec decode!(pos_integer()) :: t()
+  def decode!(encoded) do
+    {:ok, decoded} = decode(encoded)
+    decoded
+  end
+
+  @spec decode(pos_integer()) :: {:ok, t()} | {:error, :encoded_utxo_position_too_low}
   def decode(encoded) when encoded >= @block_offset do
     blknum = div(encoded, @block_offset)
     txindex = encoded |> rem(@block_offset) |> div(@transaction_offset)
     oindex = rem(encoded, @transaction_offset)
 
-    Utxo.position(blknum, txindex, oindex)
+    {:ok, Utxo.position(blknum, txindex, oindex)}
   end
+
+  def decode(encoded) when is_number(encoded), do: {:error, :encoded_utxo_position_too_low}
 
   @spec non_zero?(t()) :: boolean()
   def non_zero?(Utxo.position(0, 0, 0)), do: false

--- a/apps/omg/lib/omg/utxo/position.ex
+++ b/apps/omg/lib/omg/utxo/position.ex
@@ -41,7 +41,10 @@ defmodule OMG.Utxo.Position do
   def encode(Utxo.position(blknum, txindex, oindex)),
     do: blknum * @block_offset + txindex * @transaction_offset + oindex
 
-  @spec decode!(pos_integer()) :: t()
+  # NOTE: the `__MODULE__` in the below spec if clearly redundant, but one gets:
+  #       "Type specification is a supertype of the success typing." if it isn't there.
+  #       Fix thanks to Ino. No idea why would this affect dialyzing
+  @spec decode!(pos_integer()) :: __MODULE__.t()
   def decode!(encoded) do
     {:ok, decoded} = decode(encoded)
     decoded

--- a/apps/omg/test/omg/utxo/position_test.exs
+++ b/apps/omg/test/omg/utxo/position_test.exs
@@ -23,6 +23,11 @@ defmodule OMG.Utxo.PositionTest do
   test "encode and decode the utxo position checking" do
     decoded = Utxo.position(4, 5, 1)
     assert 4_000_050_001 = encoded = Utxo.Position.encode(decoded)
-    assert decoded == Utxo.Position.decode(encoded)
+    assert decoded == Utxo.Position.decode!(encoded)
+    assert {:ok, decoded} == Utxo.Position.decode(encoded)
+  end
+
+  test "verbose error on too low encoded position" do
+    assert {:error, :encoded_utxo_position_too_low} = Utxo.Position.decode(100)
   end
 end

--- a/apps/omg_performance/lib/omg_performance/sender_manager.ex
+++ b/apps/omg_performance/lib/omg_performance/sender_manager.ex
@@ -60,7 +60,7 @@ defmodule OMG.Performance.SenderManager do
     initial_blknums =
       utxos
       |> Enum.map(fn %{utxo_pos: utxo_pos} ->
-        {:utxo_position, blknum, _txindex, _oindex} = Utxo.Position.decode(utxo_pos)
+        Utxo.position(blknum, _txindex, _oindex) = Utxo.Position.decode!(utxo_pos)
         blknum
       end)
 

--- a/apps/omg_performance/lib/omg_performance/sender_server.ex
+++ b/apps/omg_performance/lib/omg_performance/sender_server.ex
@@ -196,7 +196,7 @@ defmodule OMG.Performance.SenderServer do
   #   Generates module's initial state
   @spec init_state(pos_integer(), map(), pos_integer()) :: __MODULE__.state()
   defp init_state(seqnum, %{owner: spender, utxo_pos: utxo_pos, amount: amount}, ntx_to_send) do
-    {:utxo_position, blknum, txindex, oindex} = Utxo.Position.decode(utxo_pos)
+    Utxo.position(blknum, txindex, oindex) = Utxo.Position.decode!(utxo_pos)
 
     %__MODULE__{
       seqnum: seqnum,

--- a/apps/omg_watcher/lib/omg_watcher/db/eth_event.ex
+++ b/apps/omg_watcher/lib/omg_watcher/db/eth_event.ex
@@ -80,7 +80,7 @@ defmodule OMG.Watcher.DB.EthEvent do
   end
 
   @spec utxo_pos_from_exit_event(%{call_data: %{utxo_pos: pos_integer()}}) :: Utxo.Position.t()
-  defp utxo_pos_from_exit_event(%{call_data: %{utxo_pos: utxo_pos}}), do: Utxo.Position.decode(utxo_pos)
+  defp utxo_pos_from_exit_event(%{call_data: %{utxo_pos: utxo_pos}}), do: Utxo.Position.decode!(utxo_pos)
 
   @spec insert_exit!(Utxo.Position.t()) :: {:ok, %__MODULE__{}} | {:error, Ecto.Changeset.t()}
   defp insert_exit!(Utxo.position(blknum, txindex, _oindex) = position) do

--- a/apps/omg_watcher/lib/omg_watcher/exit_processor.ex
+++ b/apps/omg_watcher/lib/omg_watcher/exit_processor.ex
@@ -225,7 +225,7 @@ defmodule OMG.Watcher.ExitProcessor do
       exits
       |> Enum.map(fn %{exit_id: exit_id} ->
         {:ok, {_, _, _, utxo_pos}} = Eth.RootChain.get_standard_exit(exit_id)
-        Utxo.Position.decode(utxo_pos)
+        Utxo.Position.decode!(utxo_pos)
       end)
 
     {:ok, db_updates_from_state, validities} = State.exit_utxos(exits)

--- a/apps/omg_watcher/lib/omg_watcher/exit_processor/core.ex
+++ b/apps/omg_watcher/lib/omg_watcher/exit_processor/core.ex
@@ -154,7 +154,7 @@ defmodule OMG.Watcher.ExitProcessor.Core do
       |> Enum.zip(exit_contract_statuses)
       |> Enum.map(fn {event, contract_status} ->
         %{eth_height: eth_height, call_data: %{utxo_pos: utxo_pos, output_tx: txbytes}} = event
-        Utxo.position(_, _, oindex) = utxo_pos_decoded = Utxo.Position.decode(utxo_pos)
+        Utxo.position(_, _, oindex) = utxo_pos_decoded = Utxo.Position.decode!(utxo_pos)
         {:ok, raw_tx} = Transaction.decode(txbytes)
         %{amount: amount, currency: currency, owner: owner} = raw_tx |> Transaction.get_outputs() |> Enum.at(oindex)
 
@@ -283,7 +283,7 @@ defmodule OMG.Watcher.ExitProcessor.Core do
 
   defp get_positions_from_events(exits) do
     exits
-    |> Enum.map(fn %{utxo_pos: utxo_pos} = _finalization_info -> Utxo.Position.decode(utxo_pos) end)
+    |> Enum.map(fn %{utxo_pos: utxo_pos} = _finalization_info -> Utxo.Position.decode!(utxo_pos) end)
   end
 
   defp delete_positions(utxo_positions),

--- a/apps/omg_watcher/lib/omg_watcher/exit_processor/in_flight_exit_info.ex
+++ b/apps/omg_watcher/lib/omg_watcher/exit_processor/in_flight_exit_info.ex
@@ -220,10 +220,10 @@ defmodule OMG.Watcher.ExitProcessor.InFlightExitInfo do
   def challenge(ife, competitor_position)
 
   def challenge(%__MODULE__{oldest_competitor: nil} = ife, competitor_position),
-    do: %{ife | is_canonical: false, oldest_competitor: Utxo.Position.decode(competitor_position)}
+    do: %{ife | is_canonical: false, oldest_competitor: Utxo.Position.decode!(competitor_position)}
 
   def challenge(%__MODULE__{oldest_competitor: current_oldest} = ife, competitor_position) do
-    with decoded_competitor_pos <- Utxo.Position.decode(competitor_position),
+    with decoded_competitor_pos <- Utxo.Position.decode!(competitor_position),
          true <- is_older?(decoded_competitor_pos, current_oldest) do
       %{ife | is_canonical: false, oldest_competitor: decoded_competitor_pos}
     else
@@ -249,12 +249,12 @@ defmodule OMG.Watcher.ExitProcessor.InFlightExitInfo do
   def respond_to_challenge(ife, tx_position)
 
   def respond_to_challenge(%__MODULE__{oldest_competitor: nil, contract_tx_pos: nil} = ife, tx_position) do
-    decoded = Utxo.Position.decode(tx_position)
+    decoded = Utxo.Position.decode!(tx_position)
     {:ok, %{ife | oldest_competitor: decoded, is_canonical: true, contract_tx_pos: decoded}}
   end
 
   def respond_to_challenge(%__MODULE__{oldest_competitor: current_oldest, contract_tx_pos: nil} = ife, tx_position) do
-    decoded = Utxo.Position.decode(tx_position)
+    decoded = Utxo.Position.decode!(tx_position)
 
     if is_older?(decoded, current_oldest) do
       {:ok, %{ife | oldest_competitor: decoded, is_canonical: true, contract_tx_pos: decoded}}

--- a/apps/omg_watcher/lib/omg_watcher/web/controllers/challenge.ex
+++ b/apps/omg_watcher/lib/omg_watcher/web/controllers/challenge.ex
@@ -27,7 +27,7 @@ defmodule OMG.Watcher.Web.Controller.Challenge do
   """
   def get_utxo_challenge(conn, params) do
     with {:ok, utxo_pos} <- expect(params, "utxo_pos", :pos_integer),
-         utxo <- Utxo.Position.decode(utxo_pos) do
+         {:ok, utxo} <- Utxo.Position.decode(utxo_pos) do
       utxo
       |> API.Utxo.create_challenge()
       |> api_response(conn, :challenge)

--- a/apps/omg_watcher/lib/omg_watcher/web/controllers/utxo.ex
+++ b/apps/omg_watcher/lib/omg_watcher/web/controllers/utxo.ex
@@ -20,12 +20,12 @@ defmodule OMG.Watcher.Web.Controller.Utxo do
 
   use OMG.Watcher.Web, :controller
 
-  alias OMG.Utxo.Position
+  alias OMG.Utxo
   alias OMG.Watcher.API
 
   def get_utxo_exit(conn, params) do
     with {:ok, utxo_pos} <- expect(params, "utxo_pos", :pos_integer),
-         utxo <- Position.decode(utxo_pos) do
+         {:ok, utxo} <- Utxo.Position.decode(utxo_pos) do
       utxo
       |> API.Utxo.compose_utxo_exit()
       |> api_response(conn, :utxo_exit)

--- a/apps/omg_watcher/test/omg_watcher/web/controllers/challenge_test.exs
+++ b/apps/omg_watcher/test/omg_watcher/web/controllers/challenge_test.exs
@@ -75,4 +75,10 @@ defmodule OMG.Watcher.Web.Controller.ChallengeTest do
              }
            } == TestHelper.no_success?("utxo.get_challenge_data", %{"utxo_pos" => "1200000120000"})
   end
+
+  @tag fixtures: [:phoenix_ecto_sandbox]
+  test "utxo.get_exit_data handles too low utxo position inputs" do
+    assert %{"object" => "error", "code" => "get_utxo_challenge:encoded_utxo_position_too_low"} =
+             TestHelper.no_success?("utxo.get_challenge_data", %{"utxo_pos" => 1000})
+  end
 end

--- a/apps/omg_watcher/test/omg_watcher/web/controllers/utxo_test.exs
+++ b/apps/omg_watcher/test/omg_watcher/web/controllers/utxo_test.exs
@@ -69,7 +69,7 @@ defmodule OMG.Watcher.Web.Controller.UtxoTest do
     [%{"utxo_pos" => utxo_pos, "blknum" => blknum, "txindex" => txindex, "oindex" => oindex} | _] =
       TestHelper.get_utxos(alice.addr)
 
-    assert Utxo.position(^blknum, ^txindex, ^oindex) = utxo_pos |> Utxo.Position.decode()
+    assert Utxo.position(^blknum, ^txindex, ^oindex) = utxo_pos |> Utxo.Position.decode!()
   end
 
   @tag fixtures: [:initial_blocks, :bob, :carol]
@@ -243,5 +243,11 @@ defmodule OMG.Watcher.Web.Controller.UtxoTest do
                }
              }
            } == TestHelper.no_success?("utxo.get_exit_data", %{"utxo_pos" => "1200000120000"})
+  end
+
+  @tag fixtures: [:phoenix_ecto_sandbox]
+  test "utxo.get_exit_data handles too low utxo position inputs" do
+    assert %{"object" => "error", "code" => "get_utxo_exit:encoded_utxo_position_too_low"} =
+             TestHelper.no_success?("utxo.get_exit_data", %{"utxo_pos" => 1000})
   end
 end

--- a/apps/omg_watcher/test/support/test_helper.ex
+++ b/apps/omg_watcher/test/support/test_helper.ex
@@ -112,7 +112,7 @@ defmodule OMG.Watcher.TestHelper do
   end
 
   def get_exit_data(blknum, txindex, oindex) do
-    utxo_pos = Utxo.Position.encode({:utxo_position, blknum, txindex, oindex})
+    utxo_pos = Utxo.Position.encode(Utxo.position(blknum, txindex, oindex))
 
     data = success?("utxo.get_exit_data", %{utxo_pos: utxo_pos})
 


### PR DESCRIPTION
fixes #594

also smuggles some tidies, where `{:utxo_positions,...}` internal representation of `Utxo.Position` leaked.
`Utxo.position` macros should be used instead.

Background: the `Utxo.Position.decode!` was missed as it was originally intended to serve only internally.
Since it is also used in handling of user inputs, we introduce it and make the "non-`!`" version return a verbose error