### PR TITLE
Fix /transaction.all slow responses

### DIFF
--- a/apps/omg_watcher/lib/db/transaction.ex
+++ b/apps/omg_watcher/lib/db/transaction.ex
@@ -25,8 +25,7 @@ defmodule OMG.Watcher.DB.Transaction do
 
   require Utxo
 
-  # , only: [from: 2, where: 3, join: 5]
-  import Ecto.Query
+  import Ecto.Query, only: [from: 2, where: 3, select: 3, join: 5, distinct: 2]
 
   @type mined_block() :: %{
           transactions: [OMG.API.State.Transaction.Recovered.t()],

--- a/apps/omg_watcher/lib/db/txoutput.ex
+++ b/apps/omg_watcher/lib/db/txoutput.ex
@@ -26,7 +26,7 @@ defmodule OMG.Watcher.DB.TxOutput do
 
   require Utxo
 
-  import Ecto.Query, only: [from: 2, where: 2, where: 3, select: 3]
+  import Ecto.Query, only: [from: 2, where: 2]
 
   @type balance() :: %{
           currency: binary(),
@@ -56,14 +56,6 @@ defmodule OMG.Watcher.DB.TxOutput do
 
     belongs_to(:spending_transaction, DB.Transaction, foreign_key: :spending_txhash, references: :txhash, type: :binary)
     belongs_to(:exit, DB.EthEvent, foreign_key: :spending_exit, references: :hash, type: :binary)
-  end
-
-  @spec get_all_by_address(String.t()) :: [%TxOuput{}]
-  def get_all_by_address(address) do
-    TxOutput
-    |> where([o], o.owner == ^address)
-    |> select([o], {o.creating_txhash, o.spending_txhash})
-    |> Repo.all()
   end
 
   @spec compose_utxo_exit(Utxo.Position.t()) :: {:ok, exit_t()} | {:error, :utxo_not_found}

--- a/apps/omg_watcher/lib/db/txoutput.ex
+++ b/apps/omg_watcher/lib/db/txoutput.ex
@@ -26,7 +26,7 @@ defmodule OMG.Watcher.DB.TxOutput do
 
   require Utxo
 
-  import Ecto.Query, only: [from: 2, where: 2]
+  import Ecto.Query, only: [from: 2, where: 2, where: 3, select: 3]
 
   @type balance() :: %{
           currency: binary(),
@@ -56,6 +56,14 @@ defmodule OMG.Watcher.DB.TxOutput do
 
     belongs_to(:spending_transaction, DB.Transaction, foreign_key: :spending_txhash, references: :txhash, type: :binary)
     belongs_to(:exit, DB.EthEvent, foreign_key: :spending_exit, references: :hash, type: :binary)
+  end
+
+  @spec get_all_by_address(String.t()) :: [%TxOuput{}]
+  def get_all_by_address(address) do
+    TxOutput
+    |> where([o], o.owner == ^address)
+    |> select([o], {o.creating_txhash, o.spending_txhash})
+    |> Repo.all()
   end
 
   @spec compose_utxo_exit(Utxo.Position.t()) :: {:ok, exit_t()} | {:error, :utxo_not_found}

--- a/apps/omg_watcher/priv/repo/migrations/20190408131000_add_missing_indices_to_txoutputs.exs
+++ b/apps/omg_watcher/priv/repo/migrations/20190408131000_add_missing_indices_to_txoutputs.exs
@@ -1,0 +1,11 @@
+defmodule OMG.Watcher.Repo.Migrations.AddMissingIndicesToTxOuputs do
+  use Ecto.Migration
+
+  def change do
+    create index(:txoutputs, [:creating_txhash])
+    create index(:txoutputs, [:creating_deposit])
+    create index(:txoutputs, [:spending_txhash])
+    create index(:txoutputs, [:spending_exit])
+    create index(:txoutputs, [:owner])
+  end
+end

--- a/apps/omg_watcher/priv/repo/migrations/20190408131000_add_missing_indices_to_txoutputs.exs
+++ b/apps/omg_watcher/priv/repo/migrations/20190408131000_add_missing_indices_to_txoutputs.exs
@@ -5,7 +5,7 @@ defmodule OMG.Watcher.Repo.Migrations.AddMissingIndicesToTxOuputs do
     create index(:txoutputs, [:creating_txhash, :spending_txhash])
     create index(:txoutputs, [:creating_deposit])
     create index(:txoutputs, [:spending_txhash])
-    create index(:txoutputs, [:spending_exit])
+    create index(:txoutputs, [:spending_exit], where: "spending_exit IS NOT NULL")
     create index(:txoutputs, [:owner])
   end
 end

--- a/apps/omg_watcher/priv/repo/migrations/20190408131000_add_missing_indices_to_txoutputs.exs
+++ b/apps/omg_watcher/priv/repo/migrations/20190408131000_add_missing_indices_to_txoutputs.exs
@@ -2,7 +2,7 @@ defmodule OMG.Watcher.Repo.Migrations.AddMissingIndicesToTxOuputs do
   use Ecto.Migration
 
   def change do
-    create index(:txoutputs, [:creating_txhash])
+    create index(:txoutputs, [:creating_txhash, :spending_txhash])
     create index(:txoutputs, [:creating_deposit])
     create index(:txoutputs, [:spending_txhash])
     create index(:txoutputs, [:spending_exit])

--- a/apps/omg_watcher/test/db/transaction_test.exs
+++ b/apps/omg_watcher/test/db/transaction_test.exs
@@ -27,7 +27,7 @@ defmodule OMG.Watcher.DB.TransactionTest do
   describe "get_by_filters/3" do
     @tag fixtures: [:alice, :initial_blocks]
     test "gets all transactions for an address", %{alice: alice} do
-      transactions = DB.Transaction.get_by_filters(alice.addr)
+      transactions = DB.Transaction.get_by_filters(alice.addr, nil, nil)
 
       assert length(transactions) == 5
     end

--- a/apps/omg_watcher/test/db/transaction_test.exs
+++ b/apps/omg_watcher/test/db/transaction_test.exs
@@ -31,6 +31,13 @@ defmodule OMG.Watcher.DB.TransactionTest do
 
       assert length(transactions) == 5
     end
+
+    @tag fixtures: [:alice, :initial_blocks]
+    test "gets all transactions for an address with limit = 1", %{alice: alice} do
+      transactions = DB.Transaction.get_by_filters(alice.addr, nil, 1)
+
+      assert length(transactions) == 1
+    end
   end
 
   @tag fixtures: [:initial_blocks]

--- a/apps/omg_watcher/test/db/transaction_test.exs
+++ b/apps/omg_watcher/test/db/transaction_test.exs
@@ -24,6 +24,15 @@ defmodule OMG.Watcher.DB.TransactionTest do
 
   require Utxo
 
+  describe "get_by_filters/3" do
+    @tag fixtures: [:alice, :initial_blocks]
+    test "gets all transactions for an address", %{alice: alice} do
+      transactions = DB.Transaction.get_by_filters(alice.addr)
+
+      assert length(transactions) == 5
+    end
+  end
+
   @tag fixtures: [:initial_blocks]
   test "verifies all expected transaction were inserted", %{initial_blocks: initial_blocks} do
     initial_blocks

--- a/docker-compose-non-mac.yml
+++ b/docker-compose-non-mac.yml
@@ -62,7 +62,7 @@ services:
       - ETHEREUM_RPC_URL=http://localhost:8545
       - CHILD_CHAIN_URL=http://localhost:9656
       - ETHEREUM_NETWORK=LOCALCHAIN
-      - DATABASE_URL=postgres://omisego_dev:omisego_dev@localhost:5432/omisego_dev
+      - DATABASE_URL=postgres://omisego_dev:omisego_dev@localhost:5433/omisego_dev
     restart: always
     ports:
       - "7434:7434"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -93,7 +93,7 @@ services:
       - ETHEREUM_RPC_URL=http://docker.for.mac.localhost:8545
       - CHILD_CHAIN_URL=http://docker.for.mac.localhost:9656
       - ETHEREUM_NETWORK=LOCALCHAIN
-      - DATABASE_URL=postgres://omisego_dev:omisego_dev@docker.for.mac.localhost:5432/omisego_dev
+      - DATABASE_URL=postgres://omisego_dev:omisego_dev@docker.for.mac.localhost:5433/omisego_dev
     restart: always
     ports:
       - "7434:7434"


### PR DESCRIPTION
closes #589

# Overview

This PR switches from using a double left join to using a single inner with a bunch of added indices for increased performance. 

# Note

Also cherry picked [this commit](https://github.com/omisego/elixir-omg/commit/946197ccb372b9be6971abe6587d133e777a63a4) to get it into 0.1 (it was preventing Docker from starting).