### PR TITLE
Remove content-type requirement for /status.get

### DIFF
--- a/apps/omg_watcher/test/support/test_helper.ex
+++ b/apps/omg_watcher/test/support/test_helper.ex
@@ -56,10 +56,10 @@ defmodule OMG.Watcher.TestHelper do
     data
   end
 
-  def rpc_call(path, body \\ nil, expected_resp_status \\ 200) do
+  def rpc_call(path, body \\ nil, expected_resp_status \\ 200, content_type \\ "application/json") do
     request =
       conn(:post, path, body)
-      |> put_req_header("content-type", "application/json")
+      |> put_req_header("content-type", content_type)
 
     response = request |> send_request
     assert response.status == expected_resp_status

--- a/apps/omg_watcher/test/web/controllers/status_test.exs
+++ b/apps/omg_watcher/test/web/controllers/status_test.exs
@@ -49,4 +49,24 @@ defmodule OMG.Watcher.Web.Controller.StatusTest do
 
     started_apps |> Enum.each(fn app -> :ok = Application.stop(app) end)
   end
+
+  @tag fixtures: [:watcher_sandbox, :root_chain_contract_config]
+  test "status endpoint returns expected response format without worrying about the Content-Type header" do
+    response_body = TestHelper.rpc_call("status.get", nil, 200, "text/plain")
+    %{"version" => "1.0", "success" => true, "data" => data} = response_body
+
+    assert %{
+             "last_validated_child_block_number" => last_validated_child_block_number,
+             "last_mined_child_block_number" => last_mined_child_block_number,
+             "last_mined_child_block_timestamp" => last_mined_child_block_timestamp,
+             "eth_syncing" => eth_syncing,
+             "byzantine_events" => byzantine_events
+           } = data
+
+    assert is_integer(last_validated_child_block_number)
+    assert is_integer(last_mined_child_block_number)
+    assert is_integer(last_mined_child_block_timestamp)
+    assert is_atom(eth_syncing)
+    assert is_list(byzantine_events)
+  end
 end

--- a/apps/omg_watcher/test/web/controllers/status_test.exs
+++ b/apps/omg_watcher/test/web/controllers/status_test.exs
@@ -53,20 +53,6 @@ defmodule OMG.Watcher.Web.Controller.StatusTest do
   @tag fixtures: [:watcher_sandbox, :root_chain_contract_config]
   test "status endpoint returns expected response format without worrying about the Content-Type header" do
     response_body = TestHelper.rpc_call("status.get", nil, 200, "text/plain")
-    %{"version" => "1.0", "success" => true, "data" => data} = response_body
-
-    assert %{
-             "last_validated_child_block_number" => last_validated_child_block_number,
-             "last_mined_child_block_number" => last_mined_child_block_number,
-             "last_mined_child_block_timestamp" => last_mined_child_block_timestamp,
-             "eth_syncing" => eth_syncing,
-             "byzantine_events" => byzantine_events
-           } = data
-
-    assert is_integer(last_validated_child_block_number)
-    assert is_integer(last_mined_child_block_number)
-    assert is_integer(last_mined_child_block_timestamp)
-    assert is_atom(eth_syncing)
-    assert is_list(byzantine_events)
+    assert %{"version" => "1.0", "success" => true, "data" => _data} = response_body
   end
 end


### PR DESCRIPTION
closes #601 ~~(@pnowosie: I'd keep the issue to clean implementation, but not hold this PR open)~~ 

# Overview

This PR removes the `Content-Type` requirement for the `/status.get` endpoint. The solution implemented in this PR is __not optimal__ and just a quick fix. The content-type / body parsing should be left to Phoenix instead of being done inside a custom plug function. 