### PR TITLE
refactor: rewrite SE challenges, add tests

### DIFF
--- a/apps/omg/lib/omg/utxo/position.ex
+++ b/apps/omg/lib/omg/utxo/position.ex
@@ -76,4 +76,13 @@ defmodule OMG.Utxo.Position do
     oindex = rem(encoded, @transaction_offset)
     {blknum, txindex, oindex}
   end
+
+  @doc """
+  Based on the contract parameters determines whether UTXO position provided was created by a deposit
+  """
+  @spec is_deposit?(__MODULE__.t()) :: boolean()
+  def is_deposit?(Utxo.position(blknum, _, _)) do
+    {:ok, interval} = OMG.Eth.RootChain.get_child_block_interval()
+    rem(blknum, interval) != 0
+  end
 end

--- a/apps/omg_watcher/lib/omg_watcher/db/txoutput.ex
+++ b/apps/omg_watcher/lib/omg_watcher/db/txoutput.ex
@@ -60,7 +60,7 @@ defmodule OMG.Watcher.DB.TxOutput do
 
   @spec compose_utxo_exit(Utxo.Position.t()) :: {:ok, exit_t()} | {:error, :utxo_not_found}
   def compose_utxo_exit(Utxo.position(blknum, txindex, _) = decoded_utxo_pos) do
-    if is_deposit(decoded_utxo_pos) do
+    if Utxo.Position.is_deposit?(decoded_utxo_pos) do
       compose_deposit_exit(decoded_utxo_pos)
     else
       txs = DB.Transaction.get_by_blknum(blknum)
@@ -69,12 +69,6 @@ defmodule OMG.Watcher.DB.TxOutput do
         do: {:ok, compose_output_exit(txs, decoded_utxo_pos)},
         else: {:error, :utxo_not_found}
     end
-  end
-
-  @spec is_deposit(Utxo.Position.t()) :: boolean()
-  defp is_deposit(Utxo.position(blknum, _, _)) do
-    {:ok, interval} = OMG.Eth.RootChain.get_child_block_interval()
-    rem(blknum, interval) != 0
   end
 
   defp compose_deposit_exit(decoded_utxo_pos) do

--- a/apps/omg_watcher/lib/omg_watcher/exit_processor/request.ex
+++ b/apps/omg_watcher/lib/omg_watcher/exit_processor/request.ex
@@ -23,6 +23,8 @@ defmodule OMG.Watcher.ExitProcessor.Request do
         has its problems. Decide and update this note after OMG-384 or OMG-383
 
         EDIT: the multitude and duplication of the fields here is a clear sign that this design loses.
+        EDIT2: probably splitting this struct up, so that there isn't so many fields (`IFEInclusionRequest`,
+        `ValidityRequest`, `SEChallengeRequest` etc), might be the way to go
   """
 
   alias OMG.Block
@@ -42,7 +44,14 @@ defmodule OMG.Watcher.ExitProcessor.Request do
     blocks_result: [],
     ife_input_utxo_exists_result: [],
     piggybacked_spent_blknum_result: [],
-    ife_input_spending_blocks_result: []
+    ife_input_spending_blocks_result: [],
+    se_exiting_pos: nil,
+    se_creating_blocks_to_get: [],
+    se_creating_blocks_result: [],
+    se_spending_blocks_to_get: [],
+    se_spending_blocks_result: [],
+    se_exit_id_to_get: nil,
+    se_exit_id_result: nil
   ]
 
   @type t :: %__MODULE__{
@@ -59,6 +68,13 @@ defmodule OMG.Watcher.ExitProcessor.Request do
           blocks_result: list(Block.t()),
           ife_input_utxo_exists_result: list(boolean),
           piggybacked_spent_blknum_result: list(pos_integer),
-          ife_input_spending_blocks_result: list(Block.t())
+          ife_input_spending_blocks_result: list(Block.t()),
+          se_exiting_pos: nil | Utxo.Position.t(),
+          se_creating_blocks_to_get: list(pos_integer),
+          se_creating_blocks_result: list(Block.t()),
+          se_spending_blocks_to_get: list(Utxo.Position.t()),
+          se_spending_blocks_result: list(Block.t()),
+          se_exit_id_to_get: nil | binary(),
+          se_exit_id_result: nil | pos_integer()
         }
 end

--- a/apps/omg_watcher/lib/omg_watcher/exit_processor/standard_exit_challenge.ex
+++ b/apps/omg_watcher/lib/omg_watcher/exit_processor/standard_exit_challenge.ex
@@ -14,9 +14,10 @@
 
 defmodule OMG.Watcher.ExitProcessor.StandardExitChallenge do
   @moduledoc """
-  Represents a challenge to a standard exit
+  Part of Core to handle SE challenges
   """
 
+  # struct Represents a challenge to a standard exit
   defstruct [:exit_id, :txbytes, :input_index, :sig]
 
   @type t() :: %__MODULE__{
@@ -25,4 +26,127 @@ defmodule OMG.Watcher.ExitProcessor.StandardExitChallenge do
           input_index: non_neg_integer(),
           sig: String.t()
         }
+
+  alias OMG.Block
+  alias OMG.State.Transaction
+  alias OMG.Utxo
+  require Utxo
+  alias OMG.Watcher.ExitProcessor
+  alias OMG.Watcher.ExitProcessor.Core
+  alias OMG.Watcher.ExitProcessor.ExitInfo
+  alias OMG.Watcher.ExitProcessor.TxAppendix
+
+  @doc """
+  Determines the utxo-creating and utxo-spending blocks to get from `OMG.DB`
+  `se_spending_blocks_to_get` are requested by the UTXO position they spend
+  `se_creating_blocks_to_get` are requested by blknum
+  """
+  @spec determine_standard_challenge_queries(ExitProcessor.Request.t(), Core.t()) :: ExitProcessor.Request.t()
+  def determine_standard_challenge_queries(
+        %ExitProcessor.Request{se_exiting_pos: Utxo.position(creating_blknum, _, _) = exiting_pos} = request,
+        %Core{exits: exits} = state
+      ) do
+    with %ExitInfo{} = _exit_info <- Map.get(exits, exiting_pos, {:error, :exit_not_found}) do
+      spending_blocks_to_get = if get_ife_based_on_utxo(exiting_pos, state), do: [], else: [exiting_pos]
+      creating_blocks_to_get = if Utxo.Position.is_deposit?(exiting_pos), do: [], else: [creating_blknum]
+
+      %ExitProcessor.Request{
+        request
+        | se_spending_blocks_to_get: spending_blocks_to_get,
+          se_creating_blocks_to_get: creating_blocks_to_get
+      }
+    end
+  end
+
+  @doc """
+  Determines the txbytes of the particular transaction related to the SE - aka "output tx" - which creates the exiting
+  utxo
+  """
+  @spec determine_exit_txbytes(ExitProcessor.Request.t(), Core.t()) ::
+          ExitProcessor.Request.t()
+  def determine_exit_txbytes(
+        %ExitProcessor.Request{se_exiting_pos: exiting_pos, se_creating_blocks_result: creating_blocks_result} =
+          request,
+        %Core{exits: exits}
+      ) do
+    exit_id_to_get_by_txbytes =
+      if Utxo.Position.is_deposit?(exiting_pos) do
+        %ExitInfo{owner: owner, currency: currency, amount: amount} = exits[exiting_pos]
+        Transaction.new([], [{owner, currency, amount}])
+      else
+        [%Block{transactions: transactions}] = creating_blocks_result
+        Utxo.position(_, txindex, _) = exiting_pos
+
+        {:ok, signed_bytes} = Enum.fetch(transactions, txindex)
+        {:ok, tx} = Transaction.Signed.decode(signed_bytes)
+        tx
+      end
+      |> Transaction.raw_txbytes()
+
+    %ExitProcessor.Request{request | se_exit_id_to_get: exit_id_to_get_by_txbytes}
+  end
+
+  @doc """
+  Creates the final challenge response, if possible
+  """
+  @spec create_challenge(ExitProcessor.Request.t(), Core.t()) ::
+          {:ok, __MODULE__.t()} | {:error, :utxo_not_spent} | {:error, :exit_not_found}
+  def create_challenge(
+        %ExitProcessor.Request{
+          se_exiting_pos: exiting_pos,
+          se_spending_blocks_result: spending_blocks_result,
+          se_exit_id_result: exit_id
+        },
+        %Core{exits: exits} = state
+      ) do
+    %ExitInfo{owner: owner} = exits[exiting_pos]
+    ife_result = get_ife_based_on_utxo(exiting_pos, state)
+
+    with {:ok, spending_tx_or_block} <- ensure_challengeable(spending_blocks_result, ife_result) do
+      {challenging_signed, input_index} = get_spending_transaction_with_index(spending_tx_or_block, exiting_pos)
+
+      {:ok,
+       %__MODULE__{
+         exit_id: exit_id,
+         input_index: input_index,
+         txbytes: challenging_signed |> Transaction.raw_txbytes(),
+         sig: Core.find_sig!(challenging_signed, owner)
+       }}
+    end
+  end
+
+  defp ensure_challengeable(spending_blknum_response, ife_response)
+
+  defp ensure_challengeable([%Block{} = block], _), do: {:ok, block}
+  defp ensure_challengeable(_, ife_response) when not is_nil(ife_response), do: {:ok, ife_response}
+  defp ensure_challengeable(_, _), do: {:error, :utxo_not_spent}
+
+  @spec get_ife_based_on_utxo(Utxo.Position.t(), Core.t()) :: Transaction.Signed.t() | nil
+  defp get_ife_based_on_utxo(Utxo.position(_, _, _) = utxo_exit, %Core{} = state) do
+    state
+    |> TxAppendix.get_all()
+    |> Enum.find(&Enum.member?(Transaction.get_inputs(&1), utxo_exit))
+  end
+
+  # finds transaction in given block and input index spending given utxo
+  @spec get_spending_transaction_with_index(Block.t() | Transaction.Signed.t(), Utxo.Position.t()) ::
+          {Transaction.Signed.t(), non_neg_integer()} | nil
+  defp get_spending_transaction_with_index(%Block{transactions: txs}, utxo_pos) do
+    txs
+    |> Enum.map(&Transaction.Signed.decode/1)
+    |> Enum.find_value(fn {:ok, tx_signed} ->
+      # `Enum.find_value/2` allows to find tx that spends `utxo_pos` and return it along with input index in one run
+      get_spending_transaction_with_index(tx_signed, utxo_pos)
+    end)
+  end
+
+  defp get_spending_transaction_with_index(tx, utxo_pos) do
+    inputs = Transaction.get_inputs(tx)
+
+    if input_index = Enum.find_index(inputs, &(&1 == utxo_pos)) do
+      {tx, input_index}
+    else
+      nil
+    end
+  end
 end

--- a/apps/omg_watcher/test/omg_watcher/exit_processor/core/standard_exit_challenge_test.exs
+++ b/apps/omg_watcher/test/omg_watcher/exit_processor/core/standard_exit_challenge_test.exs
@@ -1,0 +1,359 @@
+# Copyright 2018 OmiseGO Pte Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defmodule OMG.Watcher.ExitProcessor.Core.StandardExitChallengeTest do
+  @moduledoc """
+  Test of the logic of exit processor, in the area of producing challenges to standard exits
+  """
+
+  use ExUnit.Case, async: true
+
+  alias OMG.Block
+  alias OMG.State.Transaction
+  alias OMG.TestHelper
+  alias OMG.Utxo
+  alias OMG.Watcher.ExitProcessor
+  alias OMG.Watcher.ExitProcessor.Core
+
+  require Utxo
+
+  @eth OMG.Eth.RootChain.eth_pseudo_address()
+
+  @deposit_blknum1 1
+  @deposit_blknum2 2
+  @blknum 1_000
+
+  @utxo_pos_tx Utxo.position(@blknum, 0, 0)
+  @utxo_pos_deposit Utxo.position(@deposit_blknum1, 0, 0)
+
+  @deposit_input2 {@deposit_blknum2, 0, 0}
+
+  @exit_id 123
+  @ife_exit_id 1234
+
+  setup do
+    {:ok, empty} = Core.init([], [], [])
+    %{processor_empty: empty, alice: TestHelper.generate_entity(), bob: TestHelper.generate_entity()}
+  end
+
+  describe "Core.determine_standard_challenge_queries" do
+    test "asks for correct data: deposit utxo double spent in IFE",
+         %{alice: alice, processor_empty: processor} do
+      ife_tx = TestHelper.create_recovered([{@deposit_blknum1, 0, 0, alice}], @eth, [])
+      processor = processor |> start_se_from_deposit(@utxo_pos_deposit, alice) |> start_ife(ife_tx)
+
+      assert %ExitProcessor.Request{se_creating_blocks_to_get: [], se_spending_blocks_to_get: []} =
+               %ExitProcessor.Request{se_exiting_pos: @utxo_pos_deposit}
+               |> Core.determine_standard_challenge_queries(processor)
+    end
+
+    test "asks for correct data: deposit utxo double spent not in IFE",
+         %{alice: alice, processor_empty: processor} do
+      processor = processor |> start_se_from_deposit(@utxo_pos_deposit, alice)
+
+      assert %ExitProcessor.Request{se_creating_blocks_to_get: [], se_spending_blocks_to_get: [@utxo_pos_deposit]} =
+               %ExitProcessor.Request{se_exiting_pos: @utxo_pos_deposit}
+               |> Core.determine_standard_challenge_queries(processor)
+    end
+
+    test "asks for correct data: tx utxo double spent in an IFE",
+         %{alice: alice, processor_empty: processor} do
+      ife_tx = TestHelper.create_recovered([{@blknum, 0, 0, alice}], @eth, [])
+      processor = processor |> start_se_from_block_tx(@utxo_pos_tx, alice) |> start_ife(ife_tx)
+
+      assert %ExitProcessor.Request{se_creating_blocks_to_get: [@blknum], se_spending_blocks_to_get: []} =
+               %ExitProcessor.Request{se_exiting_pos: @utxo_pos_tx}
+               |> Core.determine_standard_challenge_queries(processor)
+    end
+
+    test "asks for correct data: tx utxo double spent not in IFE",
+         %{alice: alice, processor_empty: processor} do
+      processor = processor |> start_se_from_block_tx(@utxo_pos_tx, alice)
+
+      assert %ExitProcessor.Request{se_creating_blocks_to_get: [@blknum], se_spending_blocks_to_get: [@utxo_pos_tx]} =
+               %ExitProcessor.Request{se_exiting_pos: @utxo_pos_tx}
+               |> Core.determine_standard_challenge_queries(processor)
+    end
+
+    test "stops immediately, if exit not found",
+         %{processor_empty: processor} do
+      assert {:error, :exit_not_found} =
+               %ExitProcessor.Request{se_exiting_pos: @utxo_pos_tx}
+               |> Core.determine_standard_challenge_queries(processor)
+    end
+  end
+
+  describe "Core.determine_exit_txbytes" do
+    test "produces valid exit txbytes for exits from deposits",
+         %{alice: alice, processor_empty: processor} do
+      tx = Transaction.new([], [{alice.addr, @eth, 10}])
+      deposit_txbytes = Transaction.raw_txbytes(tx)
+      processor = processor |> start_se(@utxo_pos_deposit, tx, alice)
+
+      assert %ExitProcessor.Request{se_exit_id_to_get: ^deposit_txbytes} =
+               %ExitProcessor.Request{se_exiting_pos: @utxo_pos_deposit}
+               |> Core.determine_exit_txbytes(processor)
+    end
+
+    test "produces valid exit txbytes for exits from txs in child blocks",
+         %{alice: alice, processor_empty: processor} do
+      creating_recovered = TestHelper.create_recovered([{@deposit_blknum2, 0, 0, alice}], @eth, [{alice, 10}])
+      creating_txbytes = Transaction.raw_txbytes(creating_recovered)
+      processor = processor |> start_se(@utxo_pos_tx, creating_recovered, alice)
+
+      assert %ExitProcessor.Request{se_exit_id_to_get: ^creating_txbytes} =
+               %ExitProcessor.Request{
+                 se_exiting_pos: @utxo_pos_tx,
+                 se_creating_blocks_result: [Block.hashed_txs_at([creating_recovered], @blknum)]
+               }
+               |> Core.determine_exit_txbytes(processor)
+    end
+
+    test "crashes if asked to produce exit txbytes when creating block not found or db response empty",
+         %{alice: alice, processor_empty: processor} do
+      processor = processor |> start_se_from_block_tx(@utxo_pos_tx, alice)
+
+      assert_raise(MatchError, fn ->
+        %ExitProcessor.Request{se_exiting_pos: @utxo_pos_tx, se_creating_blocks_result: []}
+        |> Core.determine_exit_txbytes(processor)
+      end)
+
+      assert_raise(MatchError, fn ->
+        %ExitProcessor.Request{se_exiting_pos: @utxo_pos_tx, se_creating_blocks_result: [:not_found]}
+        |> Core.determine_exit_txbytes(processor)
+      end)
+    end
+  end
+
+  describe "Core.create_challenge" do
+    test "creates challenge: deposit utxo double spent in IFE",
+         %{alice: alice, processor_empty: processor} do
+      ife_tx = TestHelper.create_recovered([{@deposit_blknum1, 0, 0, alice}], @eth, [])
+      {txbytes, alice_sig} = get_bytes_sig(ife_tx)
+      processor = processor |> start_se_from_deposit(@utxo_pos_deposit, alice) |> start_ife(ife_tx)
+
+      assert {:ok, %{exit_id: @exit_id, input_index: 0, txbytes: ^txbytes, sig: ^alice_sig}} =
+               %ExitProcessor.Request{se_exiting_pos: @utxo_pos_deposit, se_exit_id_result: @exit_id}
+               |> Core.create_challenge(processor)
+    end
+
+    test "creates challenge: deposit utxo double spent not in IFE",
+         %{alice: alice, processor_empty: processor} do
+      processor = processor |> start_se_from_deposit(@utxo_pos_deposit, alice)
+
+      recovered_spend = TestHelper.create_recovered([{1, 0, 0, alice}], @eth, [{alice, 10}])
+      {txbytes, alice_sig} = get_bytes_sig(recovered_spend)
+
+      assert {:ok, %{exit_id: @exit_id, input_index: 0, txbytes: ^txbytes, sig: ^alice_sig}} =
+               %ExitProcessor.Request{
+                 se_exiting_pos: @utxo_pos_deposit,
+                 se_spending_blocks_result: [Block.hashed_txs_at([recovered_spend], @blknum)],
+                 se_exit_id_result: @exit_id
+               }
+               |> Core.create_challenge(processor)
+    end
+
+    test "creates challenge: tx utxo double spent in an IFE",
+         %{alice: alice, processor_empty: processor} do
+      # quite similar to the deposit utxo case, but leaving the test in for completeness
+      ife_tx = TestHelper.create_recovered([{@blknum, 0, 0, alice}], @eth, [])
+      {txbytes, alice_sig} = get_bytes_sig(ife_tx)
+      processor = processor |> start_se_from_block_tx(@utxo_pos_tx, alice) |> start_ife(ife_tx)
+
+      assert {:ok, %{exit_id: @exit_id, input_index: 0, txbytes: ^txbytes, sig: ^alice_sig}} =
+               %ExitProcessor.Request{se_exiting_pos: @utxo_pos_tx, se_exit_id_result: @exit_id}
+               |> Core.create_challenge(processor)
+    end
+
+    test "creates challenge: tx utxo double spent not in IFE",
+         %{alice: alice, processor_empty: processor} do
+      # quite similar to the deposit utxo case, but leaving the test in for completeness
+      processor = processor |> start_se_from_block_tx(@utxo_pos_tx, alice)
+
+      recovered_spend = TestHelper.create_recovered([{@blknum, 0, 0, alice}], @eth, [{alice, 10}])
+      {txbytes, alice_sig} = get_bytes_sig(recovered_spend)
+
+      assert {:ok, %{exit_id: @exit_id, input_index: 0, txbytes: ^txbytes, sig: ^alice_sig}} =
+               %ExitProcessor.Request{
+                 se_exiting_pos: @utxo_pos_tx,
+                 se_spending_blocks_result: [Block.hashed_txs_at([recovered_spend], @blknum)],
+                 se_exit_id_result: @exit_id
+               }
+               |> Core.create_challenge(processor)
+    end
+
+    test "creates challenge: tx utxo double spent on input various positions",
+         %{alice: alice, processor_empty: processor} do
+      processor = processor |> start_se_from_block_tx(@utxo_pos_tx, alice)
+
+      input = {@blknum, 0, 0, alice}
+
+      recovered_spends = [
+        TestHelper.create_recovered([input], @eth, [{alice, 10}]),
+        TestHelper.create_recovered([{1, 0, 0, alice}, input], @eth, [{alice, 10}]),
+        TestHelper.create_recovered([{1, 0, 0, alice}, {2, 0, 0, alice}, input], @eth, [{alice, 10}]),
+        TestHelper.create_recovered([{1, 0, 0, alice}, {2, 0, 0, alice}, {3, 0, 0, alice}, input], @eth, [{alice, 10}])
+      ]
+
+      recovered_spends
+      |> Enum.with_index()
+      |> Enum.map(fn {recovered_spend, expected_index} ->
+        {txbytes, alice_sig} = get_bytes_sig(recovered_spend)
+
+        assert {:ok, %{exit_id: @exit_id, input_index: ^expected_index, txbytes: ^txbytes, sig: ^alice_sig}} =
+                 %ExitProcessor.Request{
+                   se_exiting_pos: @utxo_pos_tx,
+                   se_spending_blocks_result: [Block.hashed_txs_at([recovered_spend], @blknum)],
+                   se_exit_id_result: @exit_id
+                 }
+                 |> Core.create_challenge(processor)
+      end)
+    end
+
+    test "creates challenge: tx utxo double spent signed_by different signers",
+         %{alice: alice, bob: bob, processor_empty: processor} do
+      processor1 =
+        processor |> start_se(@utxo_pos_tx, Transaction.new([@deposit_input2], [{alice.addr, @eth, 10}]), alice)
+
+      processor2 =
+        processor |> start_se(@utxo_pos_tx, Transaction.new([@deposit_input2], [{bob.addr, @eth, 10}]), alice)
+
+      recovered_spends = [
+        TestHelper.create_recovered([{1, 0, 0, bob}, {@blknum, 0, 0, alice}], @eth, [{alice, 10}]),
+        TestHelper.create_recovered([{1, 0, 0, alice}, {@blknum, 0, 0, bob}], @eth, [{alice, 10}])
+      ]
+
+      recovered_spends
+      |> Enum.zip([processor1, processor2])
+      |> Enum.map(fn {recovered_spend, processor} ->
+        {txbytes, second_sig} = get_bytes_sig(recovered_spend, 1)
+
+        assert {:ok, %{exit_id: @exit_id, input_index: 1, txbytes: ^txbytes, sig: ^second_sig}} =
+                 %ExitProcessor.Request{
+                   se_exiting_pos: @utxo_pos_tx,
+                   se_spending_blocks_result: [Block.hashed_txs_at([recovered_spend], @blknum)],
+                   se_exit_id_result: @exit_id
+                 }
+                 |> Core.create_challenge(processor)
+      end)
+    end
+
+    test "creates challenge: both utxos spent don't interfere",
+         %{alice: alice, processor_empty: processor} do
+      processor =
+        processor
+        |> start_se(
+          @utxo_pos_tx,
+          Transaction.new([@deposit_input2], [{alice.addr, @eth, 10}, {alice.addr, @eth, 10}]),
+          alice
+        )
+
+      recovered_spend = TestHelper.create_recovered([{@blknum, 0, 0, alice}], @eth, [{alice, 10}])
+      recovered_spend2 = TestHelper.create_recovered([{@blknum, 0, 1, alice}], @eth, [{alice, 10}])
+      {txbytes, alice_sig} = get_bytes_sig(recovered_spend)
+
+      assert {:ok, %{exit_id: @exit_id, input_index: 0, txbytes: ^txbytes, sig: ^alice_sig}} =
+               %ExitProcessor.Request{
+                 se_exiting_pos: @utxo_pos_tx,
+                 se_spending_blocks_result: [Block.hashed_txs_at([recovered_spend, recovered_spend2], @blknum)],
+                 se_exit_id_result: @exit_id
+               }
+               |> Core.create_challenge(processor)
+    end
+
+    test "creates challenge: tx utxo double spent in both block and IFE don't interfere",
+         %{alice: alice, processor_empty: processor} do
+      ife_tx = TestHelper.create_recovered([{@blknum, 0, 0, alice}], @eth, [])
+      {txbytes, alice_sig} = get_bytes_sig(ife_tx)
+      processor = processor |> start_se_from_block_tx(@utxo_pos_tx, alice) |> start_ife(ife_tx)
+
+      # same tx spends in both
+      assert {:ok, %{exit_id: @exit_id, input_index: 0, txbytes: ^txbytes, sig: ^alice_sig}} =
+               %ExitProcessor.Request{
+                 se_exiting_pos: @utxo_pos_tx,
+                 se_spending_blocks_result: [Block.hashed_txs_at([ife_tx], @blknum)],
+                 se_exit_id_result: @exit_id
+               }
+               |> Core.create_challenge(processor)
+
+      # different txs spend, block tx takes preference
+      recovered_spend2 = TestHelper.create_recovered([{@blknum, 0, 0, alice}], @eth, [{alice, 10}])
+
+      {block_txbytes, alice_sig2} = get_bytes_sig(recovered_spend2)
+
+      assert {:ok, %{exit_id: @exit_id, input_index: 0, txbytes: ^block_txbytes, sig: ^alice_sig2}} =
+               %ExitProcessor.Request{
+                 se_exiting_pos: @utxo_pos_tx,
+                 se_spending_blocks_result: [Block.hashed_txs_at([recovered_spend2], @blknum)],
+                 se_exit_id_result: @exit_id
+               }
+               |> Core.create_challenge(processor)
+    end
+
+    test "doesn't create challenge: tx utxo not double spent",
+         %{alice: alice, processor_empty: processor} do
+      processor = processor |> start_se_from_block_tx(@utxo_pos_tx, alice)
+
+      assert {:error, :utxo_not_spent} =
+               %ExitProcessor.Request{
+                 se_exiting_pos: @utxo_pos_tx,
+                 se_spending_blocks_result: [],
+                 se_exit_id_result: @exit_id
+               }
+               |> Core.create_challenge(processor)
+
+      assert {:error, :utxo_not_spent} =
+               %ExitProcessor.Request{
+                 se_exiting_pos: @utxo_pos_tx,
+                 se_spending_blocks_result: [:not_found],
+                 se_exit_id_result: @exit_id
+               }
+               |> Core.create_challenge(processor)
+    end
+  end
+
+  defp start_se(processor, exiting_pos, tx, alice) do
+    txbytes = Transaction.raw_txbytes(tx)
+    enc_pos = Utxo.Position.encode(exiting_pos)
+
+    event = %{owner: alice.addr, eth_height: 2, exit_id: @exit_id, call_data: %{utxo_pos: enc_pos, output_tx: txbytes}}
+    status = {alice.addr, @eth, 10, enc_pos}
+
+    {processor, _} = Core.new_exits(processor, [event], [status])
+    processor
+  end
+
+  defp start_se_from_deposit(processor, exiting_pos, alice) do
+    processor |> start_se(exiting_pos, Transaction.new([], [{alice.addr, @eth, 10}]), alice)
+  end
+
+  defp start_se_from_block_tx(processor, exiting_pos, alice) do
+    processor |> start_se(exiting_pos, Transaction.new([@deposit_input2], [{alice.addr, @eth, 10}]), alice)
+  end
+
+  defp get_bytes_sig(tx, sig_idx \\ 0) do
+    txbytes = Transaction.raw_txbytes(tx)
+    %{signed_tx: %{sigs: sigs}} = tx
+    {txbytes, Enum.at(sigs, sig_idx)}
+  end
+
+  defp start_ife(processor, tx) do
+    {txbytes, alice_sig} = get_bytes_sig(tx)
+    ife_event = %{call_data: %{in_flight_tx: txbytes, in_flight_tx_sigs: alice_sig}, eth_height: 2}
+    ife_status = {1, @ife_exit_id}
+
+    {processor, _} = Core.new_in_flight_exits(processor, [ife_event], [ife_status])
+    processor
+  end
+end


### PR DESCRIPTION
The section of the ExitProcessor to handle standard exit challenges became very messy.

Now handling is pipelined and testable, as in IFE handling.
New tests were added, thanks to the improved testability.
As a bonus - the SE-challenge functionality & tests have their own files/modules now

Covers part of #608 