### PR TITLE
tidy exit processor pt3 - `ExitProcessor.CoreTest`

### DIFF
--- a/apps/omg/lib/omg/block.ex
+++ b/apps/omg/lib/omg/block.ex
@@ -106,7 +106,7 @@ defmodule OMG.Block do
   @spec create_tx_proof(nonempty_list(binary()), non_neg_integer()) :: binary()
   defp create_tx_proof(hashed_txs, txindex),
     do:
-      MerkleTree.new(hashed_txs,
+      MerkleTree.build(hashed_txs,
         hash_function: &Crypto.hash/1,
         hash_leaves: false,
         height: @transaction_merkle_tree_height,
@@ -119,10 +119,10 @@ defmodule OMG.Block do
 
   defp merkle_hash(hashed_txs),
     do:
-      MerkleTree.new(hashed_txs,
+      MerkleTree.fast_root(hashed_txs,
         hash_function: &Crypto.hash/1,
         hash_leaves: false,
         height: @transaction_merkle_tree_height,
         default_data_block: @default_leaf
-      ).root.value
+      )
 end

--- a/apps/omg/mix.exs
+++ b/apps/omg/mix.exs
@@ -31,7 +31,7 @@ defmodule OMG.MixProject do
   defp deps do
     [
       {:ex_rlp, "~> 0.5.2"},
-      {:merkle_tree, "~> 1.5.0"},
+      {:merkle_tree, "~> 1.6"},
       {:deferred_config, "~> 0.1.1"},
       {:appsignal, "~> 1.0"},
       {:phoenix_pubsub, "~> 1.0"},

--- a/apps/omg/test/fixtures.exs
+++ b/apps/omg/test/fixtures.exs
@@ -15,7 +15,6 @@
 defmodule OMG.Fixtures do
   use ExUnitFixtures.FixtureModule
 
-  alias OMG.Eth
   alias OMG.State.Core
 
   import OMG.TestHelper
@@ -33,8 +32,7 @@ defmodule OMG.Fixtures do
   deffixture(stable_mallory(entities), do: entities.stable_mallory)
 
   deffixture state_empty() do
-    {:ok, child_block_interval} = Eth.RootChain.get_child_block_interval()
-
+    {:ok, child_block_interval} = OMG.Eth.RootChain.get_child_block_interval()
     {:ok, state} = Core.extract_initial_state([], 0, 0, child_block_interval)
     state
   end

--- a/apps/omg_watcher/test/omg_watcher/exit_processor/core/state_interaction_test.exs
+++ b/apps/omg_watcher/test/omg_watcher/exit_processor/core/state_interaction_test.exs
@@ -1,0 +1,219 @@
+# Copyright 2018 OmiseGO Pte Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defmodule OMG.Watcher.ExitProcessor.Core.StateInteractionTest do
+  @moduledoc """
+  Test talking to OMG.State.Core
+  """
+  use ExUnitFixtures
+  use ExUnit.Case, async: true
+  use OMG.Fixtures
+
+  alias OMG.State
+  alias OMG.TestHelper
+  alias OMG.Utxo
+  alias OMG.Watcher.Event
+  alias OMG.Watcher.ExitProcessor
+  alias OMG.Watcher.ExitProcessor.Core
+
+  require Utxo
+
+  import OMG.Watcher.ExitProcessor.TestHelper
+
+  @eth OMG.Eth.RootChain.eth_pseudo_address()
+
+  @early_blknum 1_000
+  @late_blknum 10_000
+
+  @utxo_pos1 Utxo.position(2, 0, 0)
+  @utxo_pos2 Utxo.position(@late_blknum - 1_000, 0, 1)
+
+  @tag fixtures: [:processor_empty, :state_empty, :alice]
+  test "can work with State to determine and notify invalid exits", %{
+    processor_empty: processor,
+    state_empty: state,
+    alice: alice
+  } do
+    exiting_position = Utxo.Position.encode(@utxo_pos1)
+
+    standard_exit_tx = TestHelper.create_recovered([{1, 0, 0, alice}], @eth, [{alice, 10}])
+    processor = processor |> start_se_from(standard_exit_tx, @utxo_pos1)
+
+    assert {:ok, [%Event.InvalidExit{utxo_pos: ^exiting_position}]} =
+             %ExitProcessor.Request{eth_height_now: 5, blknum_now: @late_blknum}
+             |> Core.determine_utxo_existence_to_get(processor)
+             |> mock_utxo_exists(state)
+             |> Core.check_validity(processor)
+  end
+
+  @tag fixtures: [:processor_empty, :state_empty, :alice]
+  test "can work with State to determine invalid exits entered too late", %{
+    processor_empty: processor,
+    state_empty: state,
+    alice: alice
+  } do
+    exiting_position = Utxo.Position.encode(@utxo_pos1)
+    standard_exit_tx = TestHelper.create_recovered([{1, 0, 0, alice}], @eth, [{alice, 10}])
+    processor = processor |> start_se_from(standard_exit_tx, @utxo_pos1)
+
+    assert {{:error, :unchallenged_exit},
+            [%Event.UnchallengedExit{utxo_pos: ^exiting_position}, %Event.InvalidExit{utxo_pos: ^exiting_position}]} =
+             %ExitProcessor.Request{eth_height_now: 13, blknum_now: @late_blknum}
+             |> Core.determine_utxo_existence_to_get(processor)
+             |> mock_utxo_exists(state)
+             |> Core.check_validity(processor)
+  end
+
+  @tag fixtures: [:processor_empty, :state_empty, :alice]
+  test "invalid exits that have been witnessed already inactive don't excite events", %{
+    processor_empty: processor,
+    state_empty: state,
+    alice: alice
+  } do
+    standard_exit_tx = TestHelper.create_recovered([{1, 0, 0, alice}], @eth, [{alice, 10}])
+    processor = processor |> start_se_from(standard_exit_tx, @utxo_pos1, inactive: true)
+
+    assert {:ok, []} =
+             %ExitProcessor.Request{eth_height_now: 13, blknum_now: @late_blknum}
+             |> Core.determine_utxo_existence_to_get(processor)
+             |> mock_utxo_exists(state)
+             |> Core.check_validity(processor)
+  end
+
+  @tag fixtures: [:processor_empty, :state_empty, :alice]
+  test "exits of utxos that couldn't have been seen created yet never excite events", %{
+    processor_empty: processor,
+    state_empty: state,
+    alice: alice
+  } do
+    standard_exit_tx = TestHelper.create_recovered([{1, 0, 0, alice}], @eth, [{alice, 10}])
+    processor = processor |> start_se_from(standard_exit_tx, Utxo.position(@late_blknum, 0, 0))
+
+    assert {:ok, []} =
+             %ExitProcessor.Request{eth_height_now: 13, blknum_now: @early_blknum}
+             |> Core.determine_utxo_existence_to_get(processor)
+             |> mock_utxo_exists(state)
+             |> Core.check_validity(processor)
+  end
+
+  @tag fixtures: [:processor_empty, :alice, :state_empty]
+  test "handles invalid exit finalization - doesn't forget and causes a byzantine chain report", %{
+    processor_empty: processor,
+    state_empty: state,
+    alice: alice
+  } do
+    standard_exit_tx1 = TestHelper.create_recovered([{1, 0, 0, alice}], @eth, [{alice, 10}])
+    standard_exit_tx2 = TestHelper.create_recovered([{1000, 0, 0, alice}], @eth, [{alice, 10}, {alice, 10}])
+
+    processor =
+      processor
+      |> start_se_from(standard_exit_tx1, @utxo_pos1)
+      |> start_se_from(standard_exit_tx2, @utxo_pos2, eth_height: 4)
+
+    # exits invalidly finalize and continue/start emitting events and complain
+    {:ok, {_, two_spend}, state_after_spend} =
+      [@utxo_pos1, @utxo_pos2] |> prepare_exit_finalizations() |> State.Core.exit_utxos(state)
+
+    # finalizing here - note that without `finalize_exits`, we would just get a single invalid exit event
+    # with - we get 3, because we include the invalidly finalized on which will hurt forever
+    # (see persistence tests for the "forever" part)
+    assert {processor, [], _} = Core.finalize_exits(processor, two_spend)
+
+    assert {{:error, :unchallenged_exit}, [_event1, _event2, _event3]} =
+             %ExitProcessor.Request{eth_height_now: 12, blknum_now: @late_blknum}
+             |> Core.determine_utxo_existence_to_get(processor)
+             |> mock_utxo_exists(state_after_spend)
+             |> Core.check_validity(processor)
+  end
+
+  @tag fixtures: [:processor_empty, :state_empty, :alice]
+  test "can work with State to determine valid exits and finalize them", %{
+    processor_empty: processor,
+    state_empty: state_empty,
+    alice: alice
+  } do
+    state = state_empty |> TestHelper.do_deposit(alice, %{amount: 10, currency: @eth, blknum: 2})
+
+    standard_exit_tx = TestHelper.create_recovered([{1, 0, 0, alice}], @eth, [{alice, 10}])
+    processor = processor |> start_se_from(standard_exit_tx, @utxo_pos1)
+
+    assert {:ok, []} =
+             %ExitProcessor.Request{eth_height_now: 5, blknum_now: @late_blknum}
+             |> Core.determine_utxo_existence_to_get(processor)
+             |> mock_utxo_exists(state)
+             |> Core.check_validity(processor)
+
+    # go into the future - old exits work the same
+    assert {:ok, []} =
+             %ExitProcessor.Request{eth_height_now: 105, blknum_now: @late_blknum}
+             |> Core.determine_utxo_existence_to_get(processor)
+             |> mock_utxo_exists(state)
+             |> Core.check_validity(processor)
+
+    # exit validly finalizes and continues to not emit any events
+    {:ok, {_, spends}, _} = [@utxo_pos1] |> prepare_exit_finalizations() |> State.Core.exit_utxos(state)
+    assert {processor, _, [{:delete, :exit_info, {2, 0, 0}}]} = Core.finalize_exits(processor, spends)
+
+    assert %ExitProcessor.Request{utxos_to_check: []} =
+             Core.determine_utxo_existence_to_get(%ExitProcessor.Request{blknum_now: @late_blknum}, processor)
+  end
+
+  @tag fixtures: [:alice, :processor_empty, :state_empty]
+  test "only asking for spends concerning ifes",
+       %{
+         alice: alice,
+         processor_empty: processor,
+         state_empty: state_empty
+       } do
+    processor = processor |> start_ife_from(TestHelper.create_recovered([{1, 0, 0, alice}], []))
+
+    state = state_empty |> TestHelper.do_deposit(alice, %{amount: 10, currency: @eth, blknum: 1})
+    comp = TestHelper.create_recovered([{1, 0, 0, alice}], @eth, [{alice, 8}])
+
+    # first sanity-check as if the utxo was not spent yet
+    assert %{utxos_to_check: utxos_to_check, utxo_exists_result: utxo_exists_result, spends_to_get: spends_to_get} =
+             %ExitProcessor.Request{blknum_now: @late_blknum}
+             |> Core.determine_utxo_existence_to_get(processor)
+             |> mock_utxo_exists(state)
+             |> Core.determine_spends_to_get(processor)
+
+    assert {Utxo.position(1, 0, 0), false} not in Enum.zip(utxos_to_check, utxo_exists_result)
+    assert Utxo.position(1, 0, 0) not in spends_to_get
+
+    # spend and see that Core now requests the relevant utxo checks and spends to get
+    {:ok, _, state} = State.Core.exec(state, comp, %{@eth => 0})
+    {:ok, {block, _, _}, state} = State.Core.form_block(1000, state)
+
+    assert %{utxos_to_check: utxos_to_check, utxo_exists_result: utxo_exists_result, spends_to_get: spends_to_get} =
+             %ExitProcessor.Request{blknum_now: @late_blknum, blocks_result: [block]}
+             |> Core.determine_utxo_existence_to_get(processor)
+             |> mock_utxo_exists(state)
+             |> Core.determine_spends_to_get(processor)
+
+    assert {Utxo.position(1, 0, 0), false} in Enum.zip(utxos_to_check, utxo_exists_result)
+    assert Utxo.position(1, 0, 0) in spends_to_get
+  end
+
+  defp mock_utxo_exists(%ExitProcessor.Request{utxos_to_check: positions} = request, state) do
+    %{request | utxo_exists_result: positions |> Enum.map(&State.Core.utxo_exists?(&1, state))}
+  end
+
+  defp prepare_exit_finalizations(utxo_positions), do: Enum.map(utxo_positions, &%{utxo_pos: Utxo.Position.encode(&1)})
+
+  # FIXME: stop being a fixture
+  deffixture processor_empty() do
+    {:ok, empty} = Core.init([], [], [])
+    empty
+  end
+end

--- a/apps/omg_watcher/test/omg_watcher/exit_processor/persistence_test.exs
+++ b/apps/omg_watcher/test/omg_watcher/exit_processor/persistence_test.exs
@@ -41,45 +41,41 @@ defmodule OMG.Watcher.ExitProcessor.PersistenceTest do
 
   setup %{db_pid: db_pid} do
     :ok = OMG.DB.initiation_multiupdate(db_pid)
-  end
 
-  deffixture processor_empty() do
-    {:ok, empty} = Core.init([], [], [])
-    empty
-  end
+    alice = OMG.TestHelper.generate_entity()
+    carol = OMG.TestHelper.generate_entity()
+    {:ok, processor_empty} = Core.init([], [], [])
 
-  # TODO: DRY against `exit_processor/core_test.exs` or refactor to make unnecessary in any other way
-  deffixture transactions(alice, carol) do
-    [
+    transactions = [
       Transaction.new([{1, 0, 0}, {1, 2, 1}], [{alice.addr, @eth, 1}, {carol.addr, @eth, 2}]),
       Transaction.new([{2, 1, 0}, {2, 2, 1}], [{alice.addr, @eth, 1}, {carol.addr, @eth, 2}])
     ]
-  end
 
-  deffixture exits(alice, transactions) do
     [txbytes1, txbytes2] = transactions |> Enum.map(&Transaction.raw_txbytes/1)
 
-    {[
-       %{
-         owner: alice.addr,
-         eth_height: 2,
-         exit_id: 1,
-         call_data: %{utxo_pos: Utxo.Position.encode(@utxo_pos1), output_tx: txbytes1}
-       },
-       %{
-         owner: alice.addr,
-         eth_height: 4,
-         exit_id: 2,
-         call_data: %{utxo_pos: Utxo.Position.encode(@utxo_pos2), output_tx: txbytes2}
-       }
-     ],
-     [
-       {alice.addr, @eth, 10, Utxo.Position.encode(@utxo_pos1)},
-       {@zero_address, @eth, 10, Utxo.Position.encode(@utxo_pos2)}
-     ]}
+    exits =
+      {[
+         %{
+           owner: alice.addr,
+           eth_height: 2,
+           exit_id: 1,
+           call_data: %{utxo_pos: Utxo.Position.encode(@utxo_pos1), output_tx: txbytes1}
+         },
+         %{
+           owner: alice.addr,
+           eth_height: 4,
+           exit_id: 2,
+           call_data: %{utxo_pos: Utxo.Position.encode(@utxo_pos2), output_tx: txbytes2}
+         }
+       ],
+       [
+         {alice.addr, @eth, 10, Utxo.Position.encode(@utxo_pos1)},
+         {@zero_address, @eth, 10, Utxo.Position.encode(@utxo_pos2)}
+       ]}
+
+    {:ok, %{alice: alice, carol: carol, processor_empty: processor_empty, transactions: transactions, exits: exits}}
   end
 
-  @tag fixtures: [:processor_empty, :exits]
   test "persist finalizations with mixed validities",
        %{processor_empty: processor, db_pid: db_pid, exits: {exit_events, statuses}} do
     processor
@@ -87,7 +83,6 @@ defmodule OMG.Watcher.ExitProcessor.PersistenceTest do
     |> persist_finalize_exits({[@utxo_pos1], [@utxo_pos2]}, db_pid)
   end
 
-  @tag fixtures: [:processor_empty, :exits]
   test "persist finalizations with all valid",
        %{processor_empty: processor, db_pid: db_pid, exits: {exit_events, statuses}} do
     processor
@@ -95,7 +90,6 @@ defmodule OMG.Watcher.ExitProcessor.PersistenceTest do
     |> persist_finalize_exits({[@utxo_pos1, @utxo_pos2], []}, db_pid)
   end
 
-  @tag fixtures: [:processor_empty, :exits]
   test "persist finalizations with all invalid",
        %{processor_empty: processor, db_pid: db_pid, exits: {exit_events, statuses}} do
     processor
@@ -103,7 +97,6 @@ defmodule OMG.Watcher.ExitProcessor.PersistenceTest do
     |> persist_finalize_exits({[], [@utxo_pos1, @utxo_pos2]}, db_pid)
   end
 
-  @tag fixtures: [:processor_empty, :exits]
   test "persist challenges and challenge responses",
        %{processor_empty: processor, db_pid: db_pid, exits: {exit_events, statuses}} do
     processor
@@ -113,7 +106,6 @@ defmodule OMG.Watcher.ExitProcessor.PersistenceTest do
     |> persist_respond_to_in_flight_exits_challenges([@utxo_pos1], db_pid)
   end
 
-  @tag fixtures: [:processor_empty, :exits]
   test "persist multiple challenges and challenge responses",
        %{processor_empty: processor, db_pid: db_pid, exits: {exit_events, statuses}} do
     processor
@@ -123,7 +115,6 @@ defmodule OMG.Watcher.ExitProcessor.PersistenceTest do
     |> persist_respond_to_in_flight_exits_challenges([@utxo_pos2, @utxo_pos1], db_pid)
   end
 
-  @tag fixtures: [:processor_empty, :alice, :carol]
   test "persist started ifes regardless of status",
        %{processor_empty: processor, alice: alice, carol: carol, db_pid: db_pid} do
     txs = [
@@ -137,7 +128,6 @@ defmodule OMG.Watcher.ExitProcessor.PersistenceTest do
     |> persist_new_ifes(txs, [[alice.priv], [alice.priv, carol.priv]], contract_statuses, db_pid)
   end
 
-  @tag fixtures: [:processor_empty, :alice]
   test "persist new challenges, responses and piggybacks",
        %{processor_empty: processor, alice: alice, db_pid: db_pid} do
     tx = Transaction.new([{2, 1, 0}], [{alice.addr, @eth, 1}, {alice.addr, @eth, 2}])
@@ -166,7 +156,6 @@ defmodule OMG.Watcher.ExitProcessor.PersistenceTest do
     |> persist_challenge_piggybacks(piggybacks1, db_pid)
   end
 
-  @tag fixtures: [:processor_empty, :alice]
   test "persist ife finalizations",
        %{processor_empty: processor, alice: alice, db_pid: db_pid} do
     tx = Transaction.new([{2, 1, 0}], [{alice.addr, @eth, 1}, {alice.addr, @eth, 2}])

--- a/apps/omg_watcher/test/support/exit_processor/test_helper.ex
+++ b/apps/omg_watcher/test/support/exit_processor/test_helper.ex
@@ -28,6 +28,12 @@ defmodule OMG.Watcher.ExitProcessor.TestHelper do
   @exit_id 1
 
   def start_se_from(%Core{} = processor, tx, exiting_pos, opts \\ []) do
+    {event, status} = se_event_status(tx, exiting_pos, opts)
+    {processor, _} = Core.new_exits(processor, [event], [status])
+    processor
+  end
+
+  def se_event_status(tx, exiting_pos, opts \\ []) do
     Utxo.position(_, _, oindex) = exiting_pos
     txbytes = Transaction.raw_txbytes(tx)
     enc_pos = Utxo.Position.encode(exiting_pos)
@@ -41,8 +47,7 @@ defmodule OMG.Watcher.ExitProcessor.TestHelper do
       Keyword.get(opts, :status) ||
         if(Keyword.get(opts, :inactive), do: {@zero_address, @eth, 10, enc_pos}, else: {owner, @eth, 10, enc_pos})
 
-    {processor, _} = Core.new_exits(processor, [event], [status])
-    processor
+    {event, status}
   end
 
   def start_ife_from(%Core{} = processor, tx, opts \\ []) do
@@ -51,7 +56,8 @@ defmodule OMG.Watcher.ExitProcessor.TestHelper do
     processor
   end
 
-  def ife_event(%{signed_tx: %{sigs: sigs}} = tx, opts \\ []) do
+  def ife_event(tx, opts \\ []) do
+    sigs = Keyword.get(opts, :sigs) || get_sigs(tx)
     eth_height = Keyword.get(opts, :eth_height, 2)
 
     %{
@@ -59,4 +65,6 @@ defmodule OMG.Watcher.ExitProcessor.TestHelper do
       eth_height: eth_height
     }
   end
+
+  defp get_sigs(%{signed_tx: %{sigs: sigs}}), do: sigs
 end

--- a/apps/omg_watcher/test/support/exit_processor/test_helper.ex
+++ b/apps/omg_watcher/test/support/exit_processor/test_helper.ex
@@ -1,0 +1,62 @@
+# Copyright 2018 OmiseGO Pte Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defmodule OMG.Watcher.ExitProcessor.TestHelper do
+  @moduledoc """
+  Common utilities to manipulate the `ExitProcessor`
+  """
+
+  alias OMG.State.Transaction
+  alias OMG.Utxo
+  alias OMG.Watcher.ExitProcessor.Core
+
+  require Utxo
+
+  @eth OMG.Eth.RootChain.eth_pseudo_address()
+  @zero_address OMG.Eth.zero_address()
+  @exit_id 1
+
+  def start_se_from(%Core{} = processor, tx, exiting_pos, opts \\ []) do
+    Utxo.position(_, _, oindex) = exiting_pos
+    txbytes = Transaction.raw_txbytes(tx)
+    enc_pos = Utxo.Position.encode(exiting_pos)
+    owner = tx |> Transaction.get_outputs() |> Enum.at(oindex) |> Map.get(:owner)
+    eth_height = Keyword.get(opts, :eth_height, 2)
+
+    call_data = %{utxo_pos: enc_pos, output_tx: txbytes}
+    event = %{owner: owner, eth_height: eth_height, exit_id: @exit_id, call_data: call_data}
+
+    status =
+      Keyword.get(opts, :status) ||
+        if(Keyword.get(opts, :inactive), do: {@zero_address, @eth, 10, enc_pos}, else: {owner, @eth, 10, enc_pos})
+
+    {processor, _} = Core.new_exits(processor, [event], [status])
+    processor
+  end
+
+  def start_ife_from(%Core{} = processor, tx, opts \\ []) do
+    status = Keyword.get(opts, :status, {1, @exit_id})
+    {processor, _} = Core.new_in_flight_exits(processor, [ife_event(tx, opts)], [status])
+    processor
+  end
+
+  def ife_event(%{signed_tx: %{sigs: sigs}} = tx, opts \\ []) do
+    eth_height = Keyword.get(opts, :eth_height, 2)
+
+    %{
+      call_data: %{in_flight_tx: Transaction.raw_txbytes(tx), in_flight_tx_sigs: Enum.join(sigs)},
+      eth_height: eth_height
+    }
+  end
+end

--- a/mix.lock
+++ b/mix.lock
@@ -41,7 +41,7 @@
   "licensir": {:hex, :licensir, "0.2.7", "ad902c337560ccd70de843e5b208c1db08ba2f879ee01c9389023b779131f30a", [:mix], [], "hexpm"},
   "makeup": {:hex, :makeup, "0.8.0", "9cf32aea71c7fe0a4b2e9246c2c4978f9070257e5c9ce6d4a28ec450a839b55f", [:mix], [{:nimble_parsec, "~> 0.5.0", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm"},
   "makeup_elixir": {:hex, :makeup_elixir, "0.13.0", "be7a477997dcac2e48a9d695ec730b2d22418292675c75aa2d34ba0909dcdeda", [:mix], [{:makeup, "~> 0.8", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm"},
-  "merkle_tree": {:hex, :merkle_tree, "1.5.0", "5caa988eeae19c7f72fc204ca1050973f041453f3e35cce8cf6955109b2ad0b4", [:mix], [], "hexpm"},
+  "merkle_tree": {:hex, :merkle_tree, "1.6.0", "33caf6e597704e91fb1e521ccc81298727568344b1dfd88b5c03bcd774e50a6d", [:mix], [], "hexpm"},
   "metrics": {:hex, :metrics, "1.0.1", "25f094dea2cda98213cecc3aeff09e940299d950904393b2a29d191c346a8486", [:rebar3], [], "hexpm"},
   "mime": {:hex, :mime, "1.3.1", "30ce04ab3175b6ad0bdce0035cba77bba68b813d523d1aac73d9781b4d193cf8", [:mix], [], "hexpm"},
   "mimerl": {:hex, :mimerl, "1.2.0", "67e2d3f571088d5cfd3e550c383094b47159f3eee8ffa08e64106cdf5e981be3", [:rebar3], [], "hexpm"},


### PR DESCRIPTION
Continuing work towards #608 

This PR aims at DRYing, splitting up (a bit) and simplifying the tests of `ExitProcessor.Core`.

Use of `fixtures` has been greatly reduced. Firstly, there's a lot less reliance on shared fixtures between tests, so that modifying the fixture to add a more specific test isn't necessary - one can now much more easily setup the new tests using helper functions etc. The "rich" fixtures like `processor_filled` are intended to be used whenever we can take them "as they are" and rely only on the generic setup they contain.

This effort can be continued. Things left to do:
  - divide up the large remaining test into `describe` blocks or separate test files, to make the setup more focused and readable. The way this test is arranged should be thought through carefully
  - put all the tests in their respectful categories; right now their very garbled. There is some repetition, and probably some specific behaviors might still be untested.

No tests where removed or changed in terms of logic. Some tests were split out to `state_interaction_test.exs`. The order of tests hasn't been altered to make it more reviewable

The new approach to test setup required us to optimize the `merkle_tree` library, which this PR also includes