### PR TITLE
feat: watcher application metrics

### DIFF
--- a/apps/omg/config/config.exs
+++ b/apps/omg/config/config.exs
@@ -6,7 +6,7 @@ config :omg,
   deposit_finality_margin: 10,
   ethereum_events_check_interval_ms: 500,
   coordinator_eth_height_check_interval_ms: 6_000,
-  metrics_interval: 60_000,
+  metrics_collection_interval: 60_000,
   client_monitor_interval_ms: 500
 
 config :omg, :eip_712_domain,

--- a/apps/omg/config/config.exs
+++ b/apps/omg/config/config.exs
@@ -6,6 +6,7 @@ config :omg,
   deposit_finality_margin: 10,
   ethereum_events_check_interval_ms: 500,
   coordinator_eth_height_check_interval_ms: 6_000,
+  metrics_interval: 60_000,
   client_monitor_interval_ms: 500
 
 config :omg, :eip_712_domain,

--- a/apps/omg/lib/omg/state.ex
+++ b/apps/omg/lib/omg/state.ex
@@ -90,7 +90,7 @@ defmodule OMG.State do
     # Get utxos() is essential for the State and Blockgetter. And it takes a while. TODO - measure it!
     # Our approach is simply blocking the supervision boot tree
     # until we've processed history.
-    {:ok, _} = :timer.send_interval(Application.fetch_env!(:omg, :metrics_interval), self(), :send_metrics)
+    {:ok, _} = :timer.send_interval(Application.fetch_env!(:omg, :metrics_collection_interval), self(), :send_metrics)
     {:ok, DB.utxos(), {:continue, :setup}}
   end
 

--- a/apps/omg/lib/omg/state.ex
+++ b/apps/omg/lib/omg/state.ex
@@ -125,8 +125,9 @@ defmodule OMG.State do
   end
 
   def handle_info(:send_metrics, state) do
-    _ = Core.Metrics.calculate(state)
-    |> Enum.map(fn {key, value} -> Appsignal.set_gauge(key, value) end)
+    _ =
+      Core.Metrics.calculate(state)
+      |> Enum.map(fn {key, value} -> Appsignal.set_gauge(key, value) end)
 
     {:noreply, state}
   end

--- a/apps/omg/lib/omg/state/core/metrics.ex
+++ b/apps/omg/lib/omg/state/core/metrics.ex
@@ -1,0 +1,43 @@
+# Copyright 2019 OmiseGO Pte Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defmodule OMG.State.Core.Metrics do
+  @moduledoc """
+  Counting business metrics sent to appsignal
+  """
+
+  alias OMG.Eth.Encoding
+  alias OMG.State.Core
+
+  def calculate(%Core{utxos: utxos}) do
+    [
+      {"unique_users", unique_users(utxos)}
+      | balance(utxos)
+        |> Enum.map(fn {currency, amount} -> {"balance_" <> Encoding.to_hex(currency), amount} end)
+    ]
+  end
+
+  defp unique_users(utxos) do
+    utxos
+    |> Enum.map(fn {_, %OMG.Utxo{owner: owner}} -> owner end)
+    |> Enum.uniq()
+    |> Enum.count()
+  end
+
+  defp balance(utxos) do
+    Enum.reduce(utxos, %{}, fn {_, %{currency: currency, amount: amount}}, acc ->
+      Map.update(acc, currency, amount, &(&1 + amount))
+    end)
+  end
+end

--- a/apps/omg/lib/omg/state/core/metrics.ex
+++ b/apps/omg/lib/omg/state/core/metrics.ex
@@ -23,8 +23,7 @@ defmodule OMG.State.Core.Metrics do
   def calculate(%Core{utxos: utxos}) do
     [
       {"unique_users", unique_users(utxos)}
-      | balance(utxos)
-        |> Enum.map(fn {currency, amount} -> {"balance_" <> Encoding.to_hex(currency), amount} end)
+      | Enum.map(balance(utxos), fn {currency, amount} -> {"balance_" <> Encoding.to_hex(currency), amount} end)
     ]
   end
 

--- a/apps/omg/test/omg/state/core/metrics_test.exs
+++ b/apps/omg/test/omg/state/core/metrics_test.exs
@@ -1,0 +1,47 @@
+# Copyright 2019 OmiseGO Pte Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defmodule OMG.State.Core.MetricsTest do
+  @moduledoc """
+  Tests functional behaviors of `OMG.State.Core.Metrics`.
+  """
+  use ExUnitFixtures
+  use ExUnit.Case, async: true
+
+  alias OMG.Eth.Encoding
+  alias OMG.State.Core
+  alias OMG.Utxo
+
+  require Utxo
+
+  @eth OMG.Eth.RootChain.eth_pseudo_address()
+  @not_eth <<1::size(160)>>
+  @tag fixtures: [:alice, :bob, :carol]
+
+  test "calculate metrics from state", %{alice: alice, bob: bob, carol: carol} do
+    utxos = %{
+      Utxo.position(2_835, 4076, 3) => %OMG.Utxo{amount: 700_000_000, currency: @eth, owner: alice},
+      Utxo.position(1_075, 2559, 0) => %OMG.Utxo{amount: 111_111_111, currency: @not_eth, owner: alice},
+      Utxo.position(8_149, 4854, 2) => %OMG.Utxo{amount: 77_000_000, currency: @eth, owner: bob},
+      Utxo.position(7_202, 4057, 3) => %OMG.Utxo{amount: 222_222_222, currency: @not_eth, owner: carol}
+    }
+
+    assert MapSet.new(Core.Metrics.calculate(%Core{utxos: utxos})) ==
+             MapSet.new([
+               {"unique_users", 3},
+               {"balance_" <> Encoding.to_hex(@eth), 777_000_000},
+               {"balance_" <> Encoding.to_hex(@not_eth), 333_333_333}
+             ])
+  end
+end

--- a/apps/omg/test/omg/state/core/metrics_test.exs
+++ b/apps/omg/test/omg/state/core/metrics_test.exs
@@ -31,10 +31,10 @@ defmodule OMG.State.Core.MetricsTest do
 
   test "calculate metrics from state", %{alice: alice, bob: bob, carol: carol} do
     utxos = %{
-      Utxo.position(2_835, 4076, 3) => %OMG.Utxo{amount: 700_000_000, currency: @eth, owner: alice},
-      Utxo.position(1_075, 2559, 0) => %OMG.Utxo{amount: 111_111_111, currency: @not_eth, owner: alice},
-      Utxo.position(8_149, 4854, 2) => %OMG.Utxo{amount: 77_000_000, currency: @eth, owner: bob},
-      Utxo.position(7_202, 4057, 3) => %OMG.Utxo{amount: 222_222_222, currency: @not_eth, owner: carol}
+      Utxo.position(2_000, 4076, 3) => %OMG.Utxo{amount: 700_000_000, currency: @eth, owner: alice},
+      Utxo.position(1_000, 2559, 0) => %OMG.Utxo{amount: 111_111_111, currency: @not_eth, owner: alice},
+      Utxo.position(8_000, 4854, 2) => %OMG.Utxo{amount: 77_000_000, currency: @eth, owner: bob},
+      Utxo.position(7_000, 4057, 3) => %OMG.Utxo{amount: 222_222_222, currency: @not_eth, owner: carol}
     }
 
     assert MapSet.new(Core.Metrics.calculate(%Core{utxos: utxos})) ==

--- a/apps/omg_rpc/lib/omg_rpc/web/controllers/transaction.ex
+++ b/apps/omg_rpc/lib/omg_rpc/web/controllers/transaction.ex
@@ -30,5 +30,21 @@ defmodule OMG.RPC.Web.Controller.Transaction do
       |> put_view(View.Transaction)
       |> render(:submit, result: details)
     end
+    |> increment_metrics_counter()
+  end
+
+  defp increment_metrics_counter(response) do
+    case response do
+      {:error, {:validation_error, _, _}} ->
+        Appsignal.increment_counter("transaction.failed.validation", 1)
+
+      %Plug.Conn{} ->
+        Appsignal.increment_counter("transaction.succeed", 1)
+
+      _ ->
+        Appsignal.increment_counter("transaction.fail.unidentified", 1)
+    end
+
+    response
   end
 end

--- a/apps/omg_watcher/lib/omg_watcher/exit_processor.ex
+++ b/apps/omg_watcher/lib/omg_watcher/exit_processor.ex
@@ -48,7 +48,6 @@ defmodule OMG.Watcher.ExitProcessor do
   """
   @decorate measure_event()
   def new_exits(exits) do
-    Appsignal.increment_counter("exit.started", length(exits))
     GenServer.call(__MODULE__, {:new_exits, exits})
   end
 
@@ -58,7 +57,6 @@ defmodule OMG.Watcher.ExitProcessor do
   """
   @decorate measure_event()
   def new_in_flight_exits(in_flight_exit_started_events) do
-    Appsignal.increment_counter("in_flight_exit.started", length(in_flight_exit_started_events))
     GenServer.call(__MODULE__, {:new_in_flight_exits, in_flight_exit_started_events})
   end
 
@@ -68,7 +66,6 @@ defmodule OMG.Watcher.ExitProcessor do
   """
   @decorate measure_event()
   def finalize_exits(finalizations) do
-    Appsignal.increment_counter("exit.finalize", length(finalizations))
     GenServer.call(__MODULE__, {:finalize_exits, finalizations})
   end
 
@@ -78,7 +75,6 @@ defmodule OMG.Watcher.ExitProcessor do
   """
   @decorate measure_event()
   def piggyback_exits(piggybacks) do
-    Appsignal.increment_counter("in_flight_exit.piggyback", length(piggybacks))
     GenServer.call(__MODULE__, {:piggyback_exits, piggybacks})
   end
 
@@ -88,7 +84,6 @@ defmodule OMG.Watcher.ExitProcessor do
   """
   @decorate measure_event()
   def challenge_exits(challenges) do
-    Appsignal.increment_counter("exit.challenge", length(challenges))
     GenServer.call(__MODULE__, {:challenge_exits, challenges})
   end
 
@@ -99,7 +94,6 @@ defmodule OMG.Watcher.ExitProcessor do
   """
   @decorate measure_event()
   def new_ife_challenges(challenges) do
-    Appsignal.increment_counter("in_flight_exit.piggyback", length(challenges))
     GenServer.call(__MODULE__, {:new_ife_challenges, challenges})
   end
 
@@ -109,7 +103,6 @@ defmodule OMG.Watcher.ExitProcessor do
   """
   @decorate measure_event()
   def respond_to_in_flight_exits_challenges(responds) do
-    Appsignal.increment_counter("in_flight_exit.respond_to_challeges", length(responds))
     GenServer.call(__MODULE__, {:respond_to_in_flight_exits_challenges, responds})
   end
 
@@ -120,7 +113,6 @@ defmodule OMG.Watcher.ExitProcessor do
   """
   @decorate measure_event()
   def challenge_piggybacks(challenges) do
-    Appsignal.increment_counter("in_flight_exit.challenge_piggyback", length(challenges))
     GenServer.call(__MODULE__, {:challenge_piggybacks, challenges})
   end
 
@@ -130,7 +122,6 @@ defmodule OMG.Watcher.ExitProcessor do
   """
   @decorate measure_event()
   def finalize_in_flight_exits(finalizations) do
-    Appsignal.increment_counter("in_flight_exit.finalize", length(finalizations))
     GenServer.call(__MODULE__, {:finalize_in_flight_exits, finalizations})
   end
 

--- a/apps/omg_watcher/lib/omg_watcher/exit_processor.ex
+++ b/apps/omg_watcher/lib/omg_watcher/exit_processor.ex
@@ -48,7 +48,7 @@ defmodule OMG.Watcher.ExitProcessor do
   """
   @decorate measure_event()
   def new_exits(exits) do
-    Appsignal.increment_counter("exit.started", length exits)
+    Appsignal.increment_counter("exit.started", length(exits))
     GenServer.call(__MODULE__, {:new_exits, exits})
   end
 
@@ -58,7 +58,7 @@ defmodule OMG.Watcher.ExitProcessor do
   """
   @decorate measure_event()
   def new_in_flight_exits(in_flight_exit_started_events) do
-    Appsignal.increment_counter("in_flight_exit.started", length in_flight_exit_started_events)
+    Appsignal.increment_counter("in_flight_exit.started", length(in_flight_exit_started_events))
     GenServer.call(__MODULE__, {:new_in_flight_exits, in_flight_exit_started_events})
   end
 
@@ -68,7 +68,7 @@ defmodule OMG.Watcher.ExitProcessor do
   """
   @decorate measure_event()
   def finalize_exits(finalizations) do
-    Appsignal.increment_counter("exit.finalize", length finalizations)
+    Appsignal.increment_counter("exit.finalize", length(finalizations))
     GenServer.call(__MODULE__, {:finalize_exits, finalizations})
   end
 
@@ -78,7 +78,7 @@ defmodule OMG.Watcher.ExitProcessor do
   """
   @decorate measure_event()
   def piggyback_exits(piggybacks) do
-    Appsignal.increment_counter("in_flight_exit.piggyback", length piggybacks)
+    Appsignal.increment_counter("in_flight_exit.piggyback", length(piggybacks))
     GenServer.call(__MODULE__, {:piggyback_exits, piggybacks})
   end
 
@@ -88,7 +88,7 @@ defmodule OMG.Watcher.ExitProcessor do
   """
   @decorate measure_event()
   def challenge_exits(challenges) do
-    Appsignal.increment_counter("exit.challenge", length challenges)
+    Appsignal.increment_counter("exit.challenge", length(challenges))
     GenServer.call(__MODULE__, {:challenge_exits, challenges})
   end
 
@@ -99,7 +99,7 @@ defmodule OMG.Watcher.ExitProcessor do
   """
   @decorate measure_event()
   def new_ife_challenges(challenges) do
-    Appsignal.increment_counter("in_flight_exit.piggyback", length challenges)
+    Appsignal.increment_counter("in_flight_exit.piggyback", length(challenges))
     GenServer.call(__MODULE__, {:new_ife_challenges, challenges})
   end
 
@@ -109,7 +109,7 @@ defmodule OMG.Watcher.ExitProcessor do
   """
   @decorate measure_event()
   def respond_to_in_flight_exits_challenges(responds) do
-    Appsignal.increment_counter("in_flight_exit.respond_to_challeges", length responds)
+    Appsignal.increment_counter("in_flight_exit.respond_to_challeges", length(responds))
     GenServer.call(__MODULE__, {:respond_to_in_flight_exits_challenges, responds})
   end
 
@@ -120,7 +120,7 @@ defmodule OMG.Watcher.ExitProcessor do
   """
   @decorate measure_event()
   def challenge_piggybacks(challenges) do
-    Appsignal.increment_counter("in_flight_exit.challenge_piggyback", length challenges)
+    Appsignal.increment_counter("in_flight_exit.challenge_piggyback", length(challenges))
     GenServer.call(__MODULE__, {:challenge_piggybacks, challenges})
   end
 
@@ -130,7 +130,7 @@ defmodule OMG.Watcher.ExitProcessor do
   """
   @decorate measure_event()
   def finalize_in_flight_exits(finalizations) do
-    Appsignal.increment_counter("in_flight_exit.finalize", length finalizations)
+    Appsignal.increment_counter("in_flight_exit.finalize", length(finalizations))
     GenServer.call(__MODULE__, {:finalize_in_flight_exits, finalizations})
   end
 

--- a/apps/omg_watcher/lib/omg_watcher/exit_processor.ex
+++ b/apps/omg_watcher/lib/omg_watcher/exit_processor.ex
@@ -48,6 +48,7 @@ defmodule OMG.Watcher.ExitProcessor do
   """
   @decorate measure_event()
   def new_exits(exits) do
+    Appsignal.increment_counter("exit.started", length exits)
     GenServer.call(__MODULE__, {:new_exits, exits})
   end
 
@@ -57,6 +58,7 @@ defmodule OMG.Watcher.ExitProcessor do
   """
   @decorate measure_event()
   def new_in_flight_exits(in_flight_exit_started_events) do
+    Appsignal.increment_counter("in_flight_exit.started", length in_flight_exit_started_events)
     GenServer.call(__MODULE__, {:new_in_flight_exits, in_flight_exit_started_events})
   end
 
@@ -66,6 +68,7 @@ defmodule OMG.Watcher.ExitProcessor do
   """
   @decorate measure_event()
   def finalize_exits(finalizations) do
+    Appsignal.increment_counter("exit.finalize", length finalizations)
     GenServer.call(__MODULE__, {:finalize_exits, finalizations})
   end
 
@@ -75,6 +78,7 @@ defmodule OMG.Watcher.ExitProcessor do
   """
   @decorate measure_event()
   def piggyback_exits(piggybacks) do
+    Appsignal.increment_counter("in_flight_exit.piggyback", length piggybacks)
     GenServer.call(__MODULE__, {:piggyback_exits, piggybacks})
   end
 
@@ -84,6 +88,7 @@ defmodule OMG.Watcher.ExitProcessor do
   """
   @decorate measure_event()
   def challenge_exits(challenges) do
+    Appsignal.increment_counter("exit.challenge", length challenges)
     GenServer.call(__MODULE__, {:challenge_exits, challenges})
   end
 
@@ -94,6 +99,7 @@ defmodule OMG.Watcher.ExitProcessor do
   """
   @decorate measure_event()
   def new_ife_challenges(challenges) do
+    Appsignal.increment_counter("in_flight_exit.piggyback", length challenges)
     GenServer.call(__MODULE__, {:new_ife_challenges, challenges})
   end
 
@@ -103,6 +109,7 @@ defmodule OMG.Watcher.ExitProcessor do
   """
   @decorate measure_event()
   def respond_to_in_flight_exits_challenges(responds) do
+    Appsignal.increment_counter("in_flight_exit.respond_to_challeges", length responds)
     GenServer.call(__MODULE__, {:respond_to_in_flight_exits_challenges, responds})
   end
 
@@ -113,6 +120,7 @@ defmodule OMG.Watcher.ExitProcessor do
   """
   @decorate measure_event()
   def challenge_piggybacks(challenges) do
+    Appsignal.increment_counter("in_flight_exit.challenge_piggyback", length challenges)
     GenServer.call(__MODULE__, {:challenge_piggybacks, challenges})
   end
 
@@ -122,6 +130,7 @@ defmodule OMG.Watcher.ExitProcessor do
   """
   @decorate measure_event()
   def finalize_in_flight_exits(finalizations) do
+    Appsignal.increment_counter("in_flight_exit.finalize", length finalizations)
     GenServer.call(__MODULE__, {:finalize_in_flight_exits, finalizations})
   end
 

--- a/apps/omg_watcher/lib/omg_watcher/web/controllers/transaction.ex
+++ b/apps/omg_watcher/lib/omg_watcher/web/controllers/transaction.ex
@@ -48,8 +48,14 @@ defmodule OMG.Watcher.Web.Controller.Transaction do
   """
   def submit(conn, params) do
     with {:ok, tx} <- expect(params, "transaction", :hex) do
+      Appsignal.increment_counter("transaction.succeed", 1)
+
       API.Transaction.submit(tx)
       |> api_response(conn, :submission)
+    else
+      err ->
+        Appsignal.increment_counter("transaction.failed", 1)
+        err
     end
   end
 


### PR DESCRIPTION
regarding the balance for the fee and the total number of tokens in our contract.
Possible solutions:

1. adding them to the structure in state/core.ex.
Additional fields:
  -- balances: %{Crypto.address_t() => non_neg_integer()}
  -- fee_balances: %{Crypto.address_t() => non_neg_integer()}
balances and fee_balances are closely related to state/core .ex and state.ex
if we put it elsewhere, there is a greater risk disperse control over the balance.
Minus the state size increases. The balance / fee_balances alone can be calculated from historical data.

2. a separate GenServer that focuses only on fee and balance, isolation from state balance and fee_balance.
watcher could only count balance
Minus connecting to everything under what state is connected

after a short consultation,
We decided at first, to add new module State.Core.Metrics, 
and in it calculate metric balance without fee_balances in intervals of time.
(Calculation from whole utxo map)


~1m utxos average time of completion
real_utxos: 999_998
unique user:  1024, time: 0.150868 s
balance time: 0.36 s
median: 122,  time: 0.83776 s