### PR TITLE
fix: make ExitProcessor tolerate spending blocks not being found

### DIFF
--- a/apps/omg_watcher/test/exit_processor/core_test.exs
+++ b/apps/omg_watcher/test/exit_processor/core_test.exs
@@ -1119,16 +1119,24 @@ defmodule OMG.Watcher.ExitProcessor.CoreTest do
       assert Utxo.position(1, 0, 0) in spends_to_get
     end
 
-    test "by asking for the right blocks",
-         %{} do
-      # NOTE: for now test trivial, because we don't require any filtering yet
+    test "by asking for the right blocks when all are spent correctly" do
       assert %{blknums_to_get: [1000]} =
-               %ExitProcessor.Request{spent_blknum_result: [1000]} |> Core.determine_blocks_to_get()
+               %ExitProcessor.Request{spends_to_get: [@utxo_pos1], spent_blknum_result: [1000]}
+               |> Core.determine_blocks_to_get()
 
-      assert %{blknums_to_get: []} = %ExitProcessor.Request{spent_blknum_result: []} |> Core.determine_blocks_to_get()
+      assert %{blknums_to_get: []} =
+               %ExitProcessor.Request{spends_to_get: [], spent_blknum_result: []} |> Core.determine_blocks_to_get()
 
       assert %{blknums_to_get: [2000, 1000]} =
-               %ExitProcessor.Request{spent_blknum_result: [2000, 1000]} |> Core.determine_blocks_to_get()
+               %ExitProcessor.Request{spends_to_get: [@utxo_pos1, @utxo_pos2], spent_blknum_result: [2000, 1000]}
+               |> Core.determine_blocks_to_get()
+    end
+
+    @tag :capture_log
+    test "by asking for the right blocks if some spends are missing" do
+      assert %{blknums_to_get: [1000]} =
+               %ExitProcessor.Request{spends_to_get: [@utxo_pos1, @utxo_pos2], spent_blknum_result: [:not_found, 1000]}
+               |> Core.determine_blocks_to_get()
     end
 
     @tag fixtures: [:processor_filled]


### PR DESCRIPTION
Fixes the situation which looks like the following:

```
2019-04-25 11:45:53.709 [error] module=gen_server function=error_info/7 ⋅GenServer OMG.Watcher.ExitProcessor terminating
** (FunctionClauseError) no function clause matching in OMG.Watcher.ExitProcessor.Core.get_known_txs/1
    (omg_watcher) lib/exit_processor/core.ex:738: OMG.Watcher.ExitProcessor.Core.get_known_txs([:not_found])
    (omg_watcher) lib/exit_processor/core.ex:523: OMG.Watcher.ExitProcessor.Core.get_ifes_with_competitors/2
    (omg_watcher) lib/exit_processor/core.ex:487: OMG.Watcher.ExitProcessor.Core.invalid_exits/2
    (omg_watcher) lib/exit_processor.ex:257: OMG.Watcher.ExitProcessor.handle_call/3
    (stdlib) gen_server.erl:661: :gen_server.try_handle_call/4
    (stdlib) gen_server.erl:690: :gen_server.handle_msg/6
    (stdlib) proc_lib.erl:249: :proc_lib.init_p_do_apply/3
Last message (from OMG.Watcher.BlockGetter): :check_validity⋅
```

or like this:

```
April 24th 2019, 15:09:05.2482019-04-24 13:09:05.248 [error] module=gen_server function=error_info/7 ⋅GenServer OMG.Watcher.ExitProcessor terminating
April 24th 2019, 15:09:05.248    :not_found.number()
April 24th 2019, 15:09:05.248    (elixir) lib/enum.ex:1327: Enum."-map/2-lists^map/1-0-"/2
April 24th 2019, 15:09:05.248    (elixir) lib/enum.ex:2337: Enum.sort_by/3
April 24th 2019, 15:09:05.248    (elixir) lib/enum.ex:2337: anonymous fn/2 in Enum.sort_by/3
April 24th 2019, 15:09:05.248    (omg_watcher) lib/exit_processor/core.ex:745: OMG.Watcher.ExitProcessor.Core.get_known_txs/1
April 24th 2019, 15:09:05.248    (omg_watcher) lib/exit_processor/core.ex:511: OMG.Watcher.ExitProcessor.Core.get_ifes_with_competitors/2
April 24th 2019, 15:09:05.248    (omg_watcher) lib/exit_processor/core.ex:475: OMG.Watcher.ExitProcessor.Core.invalid_exits/2
April 24th 2019, 15:09:05.248Last message (from OMG.Watcher.BlockGetter): :check_validity⋅
April 24th 2019, 15:09:05.248** (UndefinedFunctionError) function :not_found.number/0 is undefined (module :not_found is not available)
April 24th 2019, 15:09:05.248    (elixir) lib/enum.ex:1327: Enum."-map/2-lists^map/1-0-"/2
April 24th 2019, 15:09:05.2202019-04-24 13:09:05.220 [info] module=OMG.Watcher.BlockGetter.Core function=apply_block/2 ⋅Applied block: #413000, from eth height: 4265461, eth height done?: true⋅
```

This occurs when there is an IFE spending a UTXO already exited via a finalized SE.

Since the SE finalized, the UTXO is missing -> ExitProcessor starts looking for a block that spends it -> it is `:not_found` and this `:not_found` isn't handled properly.

The reason why a resync won't have this, is that the IFE is finalized and as such not active and doesn't excite the looking for above. The Watcher on `staging` is stuck in this state - the invalidity prevents it from "seeing" the finalization and deactivation. It looks like a bug that affects both `v0.1` and `master`.
