### PR TITLE
Deploying with faucet addres instead of first

### DIFF
--- a/apps/omg_eth/test/support/dev_helpers.ex
+++ b/apps/omg_eth/test/support/dev_helpers.ex
@@ -47,8 +47,8 @@ defmodule OMG.Eth.DevHelpers do
 
     with {:ok, _} <- Application.ensure_all_started(:ethereumex),
          {:ok, authority} <- create_and_fund_authority_addr(opts),
-         {:ok, depoyer_addr} <- get_deployer_address(opts),
-         {:ok, txhash, contract_addr} <- Eth.Deployer.create_new(OMG.Eth.RootChain, root_path, depoyer_addr),
+         {:ok, deployer_addr} <- get_deployer_address(opts),
+         {:ok, txhash, contract_addr} <- Eth.Deployer.create_new(OMG.Eth.RootChain, root_path, deployer_addr),
          {:ok, _} <-
            Eth.RootChain.init(exit_period_seconds, authority, contract_addr) |> Eth.DevHelpers.transact_sync!() do
       %{contract_addr: contract_addr, txhash_contract: txhash, authority_addr: authority}
@@ -136,6 +136,7 @@ defmodule OMG.Eth.DevHelpers do
 
   # private
 
+  # returns well-funded faucet address for contract deployment or first address returned from node otherwise
   defp get_deployer_address(opts) do
     with {:ok, [addr | _]} <- Ethereumex.HttpClient.eth_accounts(),
          do: {:ok, from_hex(Keyword.get(opts, :faucet, addr))}

--- a/apps/omg_eth/test/support/dev_helpers.ex
+++ b/apps/omg_eth/test/support/dev_helpers.ex
@@ -47,8 +47,8 @@ defmodule OMG.Eth.DevHelpers do
 
     with {:ok, _} <- Application.ensure_all_started(:ethereumex),
          {:ok, authority} <- create_and_fund_authority_addr(opts),
-         {:ok, [addr | _]} <- Ethereumex.HttpClient.eth_accounts(),
-         {:ok, txhash, contract_addr} <- Eth.Deployer.create_new(OMG.Eth.RootChain, root_path, from_hex(addr)),
+         {:ok, depoyer_addr} <- get_deployer_address(opts),
+         {:ok, txhash, contract_addr} <- Eth.Deployer.create_new(OMG.Eth.RootChain, root_path, depoyer_addr),
          {:ok, _} <-
            Eth.RootChain.init(exit_period_seconds, authority, contract_addr) |> Eth.DevHelpers.transact_sync!() do
       %{contract_addr: contract_addr, txhash_contract: txhash, authority_addr: authority}
@@ -135,6 +135,11 @@ defmodule OMG.Eth.DevHelpers do
   end
 
   # private
+
+  defp get_deployer_address(opts) do
+    with {:ok, [addr | _]} <- Ethereumex.HttpClient.eth_accounts(),
+         do: {:ok, from_hex(Keyword.get(opts, :faucet, addr))}
+  end
 
   defp create_and_fund_authority_addr(opts) do
     with {:ok, authority} <- Ethereumex.HttpClient.request("personal_newAccount", [@passphrase], []),


### PR DESCRIPTION
Issue raised by @jbunce - cannot deploy contract because of insufficient funds.
After this changes it tries first to get faucet address as deployer and fallbacks to first address if not provided.