### PR TITLE
fix: finalize in-flight exits in Watcher

### DIFF
--- a/apps/omg/test/omg/state/core_test.exs
+++ b/apps/omg/test/omg/state/core_test.exs
@@ -518,9 +518,11 @@ defmodule OMG.State.CoreTest do
   test "exits utxos given in various forms", %{alice: alice, state_alice_deposit: state} do
     # this test checks whether all ways of calling `exit_utxos/1` work on par
     # this is _very important_ to support all clients of that functions, whose inputs come in different flavors
+    %Transaction.Recovered{tx_hash: tx_hash} = tx = create_recovered([{1, 0, 0, alice}], @eth, [{alice, 7}, {alice, 3}])
+
     state =
       state
-      |> Core.exec(create_recovered([{1, 0, 0, alice}], @eth, [{alice, 7}, {alice, 3}]), :ignore)
+      |> Core.exec(tx, :ignore)
       |> success?
 
     utxo_pos_exits = [Utxo.position(@blknum1, 0, 0), Utxo.position(@blknum1, 0, 1)]
@@ -541,6 +543,9 @@ defmodule OMG.State.CoreTest do
              utxo_pos_exits
              |> Enum.map(&Utxo.Position.encode/1)
              |> Core.exit_utxos(state)
+
+    piggybacks = [%{tx_hash: tx_hash, output_index: 4}, %{tx_hash: tx_hash, output_index: 5}]
+    assert exit_utxos_response_reference == Core.exit_utxos(piggybacks, state)
   end
 
   @tag fixtures: [:alice, :state_alice_deposit]
@@ -622,6 +627,13 @@ defmodule OMG.State.CoreTest do
     utxo_pos_exit_1 = Utxo.position(@blknum1, 0, 0)
 
     assert {:ok, {[], {[], [^utxo_pos_exit_1]}}, ^state} = Core.exit_utxos([utxo_pos_exit_1], state)
+  end
+
+  @tag fixtures: [:state_empty]
+  test "notifies about invalid in-flight exit", %{state_empty: state} do
+    piggyback = %{tx_hash: 1, output_index: 5}
+
+    assert {:ok, {[], {[], [^piggyback]}}, ^state} = Core.exit_utxos([piggyback], state)
   end
 
   @tag fixtures: [:alice, :state_empty]

--- a/apps/omg_eth/lib/omg_eth/root_chain.ex
+++ b/apps/omg_eth/lib/omg_eth/root_chain.ex
@@ -456,7 +456,7 @@ defmodule OMG.Eth.RootChain do
            Eth.get_call_data(
              from_hex(log["transactionHash"]),
              "startInFlightExit",
-             [:in_flight_tx, :inputs_txs, :input_includion_proofs, :in_flight_tx_sigs],
+             [:in_flight_tx, :inputs_txs, :input_inclusion_proofs, :in_flight_tx_sigs],
              [:bytes, :bytes, :bytes, :bytes]
            )
          )
@@ -624,7 +624,7 @@ defmodule OMG.Eth.RootChain do
 
   def decode_in_flight_exit_output_finalized(log) do
     non_indexed_keys = [:in_flight_exit_id, :output_index]
-    non_indexed_key_types = [{:uint, 192}, {:uint, 256}]
+    non_indexed_key_types = [{:uint, 192}, {:uint, 8}]
     indexed_keys = indexed_keys_types = []
 
     Eth.parse_events_with_indexed_fields(

--- a/apps/omg_eth/mix.exs
+++ b/apps/omg_eth/mix.exs
@@ -37,9 +37,6 @@ defmodule OMG.Eth.MixProject do
       {:deferred_config, "~> 0.1.1"},
       {
         :plasma_contracts,
-        # NOTE: this is a long-running patch-branch applied to `master` which hard-codes shorter exit periods.
-        #       Rebase on `master`, if new changes are pushed there.
-        #       Switch back to `master`, after the exit periods are properly parametrized on deployment
         git: "https://github.com/omisego/plasma-contracts",
         branch: "master",
         sparse: "contracts/",

--- a/apps/omg_watcher/lib/omg_watcher/exit_processor/in_flight_exit_info.ex
+++ b/apps/omg_watcher/lib/omg_watcher/exit_processor/in_flight_exit_info.ex
@@ -336,6 +336,10 @@ defmodule OMG.Watcher.ExitProcessor.InFlightExitInfo do
     is_piggybacked?(ife, index) and !is_finalized?(ife, index)
   end
 
+  def activate(%__MODULE__{} = ife) do
+    %{ife | is_active: true}
+  end
+
   def is_canonical?(%__MODULE__{is_canonical: value}), do: value
 
   defp is_older?(Utxo.position(tx1_blknum, tx1_index, _), Utxo.position(tx2_blknum, tx2_index, _)),

--- a/apps/omg_watcher/test/omg_watcher/exit_processor/persistence_test.exs
+++ b/apps/omg_watcher/test/omg_watcher/exit_processor/persistence_test.exs
@@ -253,7 +253,7 @@ defmodule OMG.Watcher.ExitProcessor.PersistenceTest do
   end
 
   defp persist_finalize_ifes(processor, finalizations, db_pid) do
-    {:ok, processor, db_updates} = Core.finalize_in_flight_exits(processor, finalizations)
+    {:ok, processor, db_updates} = Core.finalize_in_flight_exits(processor, finalizations, %{})
     persist_common(processor, db_updates, db_pid)
   end
 end

--- a/apps/omg_watcher/test/omg_watcher/integration/in_flight_exit_test.exs
+++ b/apps/omg_watcher/test/omg_watcher/integration/in_flight_exit_test.exs
@@ -315,10 +315,35 @@ defmodule OMG.Watcher.Integration.InFlightExitTest do
        %{alice: alice, bob: bob, alice_deposits: {deposit_blknum, _}} do
     Eth.DevHelpers.import_unlock_fund(bob)
 
-    exit_finality_margin = Application.fetch_env!(:omg_watcher, :exit_finality_margin)
+    tx = OMG.TestHelper.create_signed([{deposit_blknum, 0, 0, alice}], @eth, [{alice, 5}, {bob, 5}])
 
-    %Transaction.Signed{raw_tx: raw_tx} =
-      tx = OMG.TestHelper.create_signed([{deposit_blknum, 0, 0, alice}], @eth, [{alice, 5}, {bob, 5}])
+    %{"blknum" => blknum} = TestHelper.submit(tx |> Transaction.Signed.encode())
+    IntegrationTest.wait_for_block_fetch(blknum, @timeout)
+
+    _ = exit_in_flight_and_wait_for_ife(tx, alice)
+
+    assert %{"in_flight_exits" => [%{}]} = TestHelper.success?("/status.get")
+
+    _ = piggyback_and_process_exits(tx, 4 + 1, bob)
+
+    assert %{"in_flight_exits" => [], "byzantine_events" => []} = TestHelper.success?("/status.get")
+  end
+
+  @tag fixtures: [:watcher, :alice, :bob, :child_chain, :token, :alice_deposits]
+  test "finalization of utxo not recognized in state leaves in-flight exit active",
+       %{alice: alice, bob: bob, alice_deposits: {deposit_blknum, _}} do
+    Eth.DevHelpers.import_unlock_fund(bob)
+
+    tx = OMG.TestHelper.create_signed([{deposit_blknum, 0, 0, alice}], @eth, [{alice, 5}, {bob, 5}])
+
+    _ = exit_in_flight_and_wait_for_ife(tx, alice)
+    _ = piggyback_and_process_exits(tx, 4 + 1, bob)
+
+    assert %{"in_flight_exits" => [_], "byzantine_events" => [_]} = TestHelper.success?("/status.get")
+  end
+
+  defp exit_in_flight_and_wait_for_ife(tx, exiting_user) do
+    exit_finality_margin = Application.fetch_env!(:omg_watcher, :exit_finality_margin)
 
     get_in_flight_exit_response = tx |> Transaction.Signed.encode() |> TestHelper.get_in_flight_exit()
 
@@ -328,28 +353,28 @@ defmodule OMG.Watcher.Integration.InFlightExitTest do
         get_in_flight_exit_response["input_txs"],
         get_in_flight_exit_response["input_txs_inclusion_proofs"],
         get_in_flight_exit_response["in_flight_tx_sigs"],
-        alice.addr
+        exiting_user.addr
       )
       |> Eth.DevHelpers.transact_sync!()
 
     Eth.DevHelpers.wait_for_root_chain_block(eth_height + exit_finality_margin + 1)
+  end
 
-    assert %{"in_flight_exits" => [%{}]} = TestHelper.success?("/status.get")
-
+  defp piggyback_and_process_exits(%Transaction.Signed{raw_tx: raw_tx}, output, output_owner) do
     raw_tx_bytes = raw_tx |> Transaction.raw_txbytes()
 
-    {:ok, %{"status" => "0x1"}} =
-      OMG.Eth.RootChain.piggyback_in_flight_exit(raw_tx_bytes, 4 + 1, bob.addr)
+    {:ok, _} =
+      OMG.Eth.RootChain.piggyback_in_flight_exit(raw_tx_bytes, output, output_owner.addr)
       |> Eth.DevHelpers.transact_sync!()
 
     exit_period = Application.fetch_env!(:omg_eth, :exit_period_seconds) * 1_000
     Process.sleep(2 * exit_period + 5_000)
 
+    exit_finality_margin = Application.fetch_env!(:omg_watcher, :exit_finality_margin)
+
     {:ok, %{"status" => "0x1", "blockNumber" => eth_height}} =
-      OMG.Eth.RootChain.process_exits(@eth, 0, 1, alice.addr) |> Eth.DevHelpers.transact_sync!()
+      OMG.Eth.RootChain.process_exits(@eth, 0, 1, output_owner.addr) |> Eth.DevHelpers.transact_sync!()
 
     Eth.DevHelpers.wait_for_root_chain_block(eth_height + exit_finality_margin + 10)
-
-    assert %{"in_flight_exits" => [], "byzantine_events" => []} = TestHelper.success?("/status.get")
   end
 end

--- a/apps/omg_watcher/test/support/exit_processor/test_helper.ex
+++ b/apps/omg_watcher/test/support/exit_processor/test_helper.ex
@@ -56,6 +56,11 @@ defmodule OMG.Watcher.ExitProcessor.TestHelper do
     processor
   end
 
+  def piggyback_ife_from(%Core{} = processor, tx_hash, output_index) do
+    {processor, _} = Core.new_piggybacks(processor, [%{tx_hash: tx_hash, output_index: output_index}])
+    processor
+  end
+
   def ife_event(tx, opts \\ []) do
     sigs = Keyword.get(opts, :sigs) || get_sigs(tx)
     eth_height = Keyword.get(opts, :eth_height, 2)


### PR DESCRIPTION
Partly solves #630. Exited utxo can no longer be spent, but IFEs are not reflected in convenience API. That will be solved in a separate PR.

Closes #630.