### PR TITLE
feature: parallel coveralls

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -123,7 +123,7 @@ jobs:
             if [[ -z "$COVERALLS_REPO_TOKEN" ]]; then
               mix coveralls.html --parallel --umbrella --include child_chain --exclude watcher --exclude common --exclude test --trace
             else
-              mix coveralls.circle --parallel --umbrella --include child_chain --exclude watcher --exclude common --trace ||
+              mix coveralls.circle --parallel --umbrella --include child_chain --exclude watcher --exclude common --exclude test --trace ||
                 # if mix failed, then coveralls_merge won't run, so signal done here and return original exit status
                 (retval=$? && curl -k https://coveralls.io/webhook?repo_token=$COVERALLS_REPO_TOKEN -d "payload[build_num]=$CIRCLE_WORKFLOW_WORKSPACE_ID&payload[status]=done" && exit $retval)
             fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -139,9 +139,6 @@ jobs:
           keys:
             - v1-mix-cache-test-compile-{{ checksum "mix.lock" }}
       - run:
-          name: Compile
-          command: mix compile
-      - run:
           name: Integration Tests & Coveralls Part Child Chain
           command: |
             # Don't submit coverage report for forks, but let the build succeed
@@ -178,9 +175,6 @@ jobs:
       - restore_cache:
           keys:
             - v1-mix-cache-test-compile-{{ checksum "mix.lock" }}
-      - run:
-          name: Compile
-          command: mix compile
       - run:
           name: Integration Tests & Coveralls Part Watcher
           command: |
@@ -219,9 +213,6 @@ jobs:
           keys:
             - v1-mix-cache-test-compile-{{ checksum "mix.lock" }}
       - run:
-          name: Compile
-          command: mix compile
-      - run:
           name: Integration Tests & Coveralls Part Common
           command: |
             # Don't submit coverage report for forks, but let the build succeed
@@ -239,32 +230,18 @@ jobs:
       - image: omisegoimages/elixir-omg-circleci:v1.8-20190129-02
         environment:
           DATABASE_URL: postgres://postgres:postgres@localhost:5432/omisego_dev
-      - image: circleci/postgres:9.6-alpine
-        environment:
-          POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: postgres
-          POSTGRES_DB: omisego_dev
-          MIX_ENV: test
-
     working_directory: ~/repo
 
     steps:
       - attach_workspace:
            at: .
-
       - run: mix local.hex --force
       - run: mix local.rebar --force
-
-      # - restore_cache:
-      #     keys:
-      #       - v1-mix-cache-{{ checksum "mix.lock" }}
-
       - restore_cache:
           keys:
             - v1-plt-cache-{{ ".tool-versions" }}-{{ checksum "mix.lock" }}
             - v1-plt-cache-{{ ".tool-versions" }}-{{ checksum "mix.exs" }}
             - v1-plt-cache-{{ ".tool-versions" }}
-
       - run:
           name: Unpack PLT cache
           command: |
@@ -272,26 +249,21 @@ jobs:
             cp plts/dialyxir*.plt _build/test/ || true
             mkdir -p ~/.mix
             cp plts/dialyxir*.plt ~/.mix/ || true
-
       - run: mix dialyzer --plt
-
       - run:
           name: Pack PLT cache
           command: |
             mkdir -p plts
             cp _build/test/dialyxir*.plt plts/
             cp ~/.mix/dialyxir*.plt plts/
-
       - save_cache:
           key: v1-plt-cache-{{ ".tool-versions" }}-{{ checksum "mix.lock" }}
           paths:
             - plts
-
       - save_cache:
           key: v1-plt-cache-{{ ".tool-versions" }}-{{ checksum "mix.exs" }}
           paths:
             - plts
-
       - save_cache:
           key: v1-plt-cache-{{ ".tool-versions" }}
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,9 +74,9 @@ jobs:
       - run: mix local.hex --force
       - run: mix local.rebar --force
 
-      # - restore_cache:
-      #     keys:
-      #       - v1-mix-cache-{{ checksum "mix.lock" }}
+      - restore_cache:
+          keys:
+            - v1-mix-cache-test-compile-{{ checksum "mix.lock" }}
 
       - run: mix test
 
@@ -98,11 +98,28 @@ jobs:
            at: .
       - run: MIX_ENV=test mix do local.hex --force, local.rebar --force, compile --warnings-as-errors --force, test --exclude test, credo, format --check-formatted --dry-run
 
+  coveralls_and_integration_tests_compile:
+    docker:
+      - image: omisegoimages/elixir-omg-circleci:v1.8-20190129-02
+        environment:
+          DATABASE_URL: postgres://postgres:postgres@localhost:5432/omisego_dev
+          MIX_ENV: test
+    working_directory: ~/repo
+
+    steps:
+      - attach_workspace:
+           at: .
+      - run: mix do local.hex --force, local.rebar --force, compile --warnings-as-errors --force
+      - save_cache:
+          key: v1-mix-cache-test-compile-{{ checksum "mix.lock" }}
+          paths: "_build"
+
   coveralls_and_integration_tests_child_chain:
     docker:
       - image: omisegoimages/elixir-omg-circleci:v1.8-20190129-02
         environment:
           DATABASE_URL: postgres://postgres:postgres@localhost:5432/omisego_dev
+          MIX_ENV: test
       - image: circleci/postgres:9.6-alpine
         environment:
           POSTGRES_USER: postgres
@@ -118,30 +135,31 @@ jobs:
       - run: mix local.hex --force
       - run: mix local.rebar --force
 
-      # - restore_cache:
-      #     keys:
-      #       - v1-mix-cache-{{ checksum "mix.lock" }}
-
+      - restore_cache:
+          keys:
+            - v1-mix-cache-test-compile-{{ checksum "mix.lock" }}
+      - run:
+          name: Compile
+          command: mix compile
       - run:
           name: Integration Tests & Coveralls Part Child Chain
           command: |
             # Don't submit coverage report for forks, but let the build succeed
             export SHELL=/bin/bash
             if [[ -z "$COVERALLS_REPO_TOKEN" ]]; then
-              MIX_ENV=test mix coveralls.html --parallel --umbrella --include child_chain --exclude watcher --exclude common --trace
+              mix coveralls.html --parallel --umbrella --include child_chain --exclude watcher --exclude common --trace
             else
-              MIX_ENV=test mix coveralls.circle --parallel --umbrella --include child_chain --exclude watcher --exclude common --trace ||
+              mix coveralls.circle --parallel --umbrella --include child_chain --exclude watcher --exclude common --trace ||
                 # if mix failed, then coveralls_merge won't run, so signal done here and return original exit status
                 (retval=$? && curl -k https://coveralls.io/webhook?repo_token=$COVERALLS_REPO_TOKEN -d "payload[build_num]=$CIRCLE_WORKFLOW_WORKSPACE_ID&payload[status]=done" && exit $retval)
             fi
-      - store_artifacts:
-          path: cover/excoveralls.html
 
   coveralls_and_integration_tests_watcher:
     docker:
       - image: omisegoimages/elixir-omg-circleci:v1.8-20190129-02
         environment:
           DATABASE_URL: postgres://postgres:postgres@localhost:5432/omisego_dev
+          MIX_ENV: test
       - image: circleci/postgres:9.6-alpine
         environment:
           POSTGRES_USER: postgres
@@ -157,30 +175,31 @@ jobs:
       - run: mix local.hex --force
       - run: mix local.rebar --force
 
-      # - restore_cache:
-      #     keys:
-      #       - v1-mix-cache-{{ checksum "mix.lock" }}
-
+      - restore_cache:
+          keys:
+            - v1-mix-cache-test-compile-{{ checksum "mix.lock" }}
+      - run:
+          name: Compile
+          command: mix compile
       - run:
           name: Integration Tests & Coveralls Part Watcher
           command: |
             # Don't submit coverage report for forks, but let the build succeed
             export SHELL=/bin/bash
             if [[ -z "$COVERALLS_REPO_TOKEN" ]]; then
-              MIX_ENV=test mix coveralls.html --parallel --umbrella --include watcher --exclude child_chain --exclude common --trace
+              mix coveralls.html --parallel --umbrella --include watcher --exclude child_chain --exclude common --trace
             else
-              MIX_ENV=test mix coveralls.circle --parallel --umbrella --include watcher --exclude child_chain --exclude common --trace ||
+              mix coveralls.circle --parallel --umbrella --include watcher --exclude child_chain --exclude common --trace ||
                 # if mix failed, then coveralls_merge won't run, so signal done here and return original exit status
                 (retval=$? && curl -k https://coveralls.io/webhook?repo_token=$COVERALLS_REPO_TOKEN -d "payload[build_num]=$CIRCLE_WORKFLOW_WORKSPACE_ID&payload[status]=done" && exit $retval)
             fi
-      - store_artifacts:
-          path: cover/excoveralls.html
 
   coveralls_and_integration_tests_common:
     docker:
       - image: omisegoimages/elixir-omg-circleci:v1.8-20190129-02
         environment:
           DATABASE_URL: postgres://postgres:postgres@localhost:5432/omisego_dev
+          MIX_ENV: test
       - image: circleci/postgres:9.6-alpine
         environment:
           POSTGRES_USER: postgres
@@ -196,24 +215,24 @@ jobs:
       - run: mix local.hex --force
       - run: mix local.rebar --force
 
-      # - restore_cache:
-      #     keys:
-      #       - v1-mix-cache-{{ checksum "mix.lock" }}
-
+      - restore_cache:
+          keys:
+            - v1-mix-cache-test-compile-{{ checksum "mix.lock" }}
+      - run:
+          name: Compile
+          command: mix compile
       - run:
           name: Integration Tests & Coveralls Part Common
           command: |
             # Don't submit coverage report for forks, but let the build succeed
             export SHELL=/bin/bash
             if [[ -z "$COVERALLS_REPO_TOKEN" ]]; then
-              MIX_ENV=test mix coveralls.html --parallel --umbrella --include common --exclude watcher --exclude child_chain --trace
+              mix coveralls.html --parallel --umbrella --include common --exclude watcher --exclude child_chain --trace
             else
-              MIX_ENV=test mix coveralls.circle --parallel --umbrella --include common --exclude watcher --exclude child_chain --trace ||
+              mix coveralls.circle --parallel --umbrella --include common --exclude watcher --exclude child_chain --trace ||
                 # if mix failed, then coveralls_merge won't run, so signal done here and return original exit status
                 (retval=$? && curl -k https://coveralls.io/webhook?repo_token=$COVERALLS_REPO_TOKEN -d "payload[build_num]=$CIRCLE_WORKFLOW_WORKSPACE_ID&payload[status]=done" && exit $retval)
             fi
-      - store_artifacts:
-          path: cover/excoveralls.html
 
   dialyzer:
     docker:
@@ -413,18 +432,28 @@ workflows:
             - coveralls_and_integration_tests_child_chain
             - coveralls_and_integration_tests_watcher
             - coveralls_and_integration_tests_common
+      - coveralls_and_integration_tests_compile:
+          requires: [build]
       - coveralls_and_integration_tests_child_chain:
-          requires: [build]
+          requires:
+            - build
+            - coveralls_and_integration_tests_compile
       - coveralls_and_integration_tests_watcher:
-          requires: [build]
+          requires:
+            - build
+            - coveralls_and_integration_tests_compile
       - coveralls_and_integration_tests_common:
-          requires: [build]
+          requires:
+            - build
+            - coveralls_and_integration_tests_compile
       - lint:
           requires: [build]
       - dialyzer:
           requires: [build]
       - test:
-          requires: [build]
+          requires:
+            - build
+            - coveralls_and_integration_tests_compile
       - release:
           requires: [build]
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,32 +54,6 @@ jobs:
             - docker-compose.yml
             - rel/
 
-  test:
-    docker:
-      - image: omisegoimages/elixir-omg-circleci:v1.8-20190129-02
-        environment:
-          DATABASE_URL: postgres://postgres:postgres@localhost:5432/omisego_dev
-      - image: circleci/postgres:9.6-alpine
-        environment:
-          POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: postgres
-          POSTGRES_DB: omisego_dev
-          MIX_ENV: test
-    working_directory: ~/repo
-
-    steps:
-      - attach_workspace:
-           at: .
-
-      - run: mix local.hex --force
-      - run: mix local.rebar --force
-
-      - restore_cache:
-          keys:
-            - v1-mix-cache-test-compile-{{ checksum "mix.lock" }}
-
-      - run: mix test
-
   lint:
     docker:
       - image: omisegoimages/elixir-omg-circleci:v1.8-20190129-02
@@ -114,7 +88,7 @@ jobs:
           key: v1-mix-cache-test-compile-{{ checksum "mix.lock" }}
           paths: "_build"
 
-  coveralls_and_integration_tests_child_chain:
+  child_chain_coveralls_and_integration_tests:
     docker:
       - image: omisegoimages/elixir-omg-circleci:v1.8-20190129-02
         environment:
@@ -138,20 +112,23 @@ jobs:
       - restore_cache:
           keys:
             - v1-mix-cache-test-compile-{{ checksum "mix.lock" }}
+      - run:
+          name: Compile
+          command: mix compile
       - run:
           name: Integration Tests & Coveralls Part Child Chain
           command: |
             # Don't submit coverage report for forks, but let the build succeed
             export SHELL=/bin/bash
             if [[ -z "$COVERALLS_REPO_TOKEN" ]]; then
-              mix coveralls.html --parallel --umbrella --include child_chain --exclude watcher --exclude common --trace
+              mix coveralls.html --parallel --umbrella --include child_chain --exclude watcher --exclude common --exclude test --trace
             else
               mix coveralls.circle --parallel --umbrella --include child_chain --exclude watcher --exclude common --trace ||
                 # if mix failed, then coveralls_merge won't run, so signal done here and return original exit status
                 (retval=$? && curl -k https://coveralls.io/webhook?repo_token=$COVERALLS_REPO_TOKEN -d "payload[build_num]=$CIRCLE_WORKFLOW_WORKSPACE_ID&payload[status]=done" && exit $retval)
             fi
 
-  coveralls_and_integration_tests_watcher:
+  watcher_coveralls_and_integration_tests:
     docker:
       - image: omisegoimages/elixir-omg-circleci:v1.8-20190129-02
         environment:
@@ -175,20 +152,23 @@ jobs:
       - restore_cache:
           keys:
             - v1-mix-cache-test-compile-{{ checksum "mix.lock" }}
+      - run:
+          name: Compile
+          command: mix compile
       - run:
           name: Integration Tests & Coveralls Part Watcher
           command: |
             # Don't submit coverage report for forks, but let the build succeed
             export SHELL=/bin/bash
             if [[ -z "$COVERALLS_REPO_TOKEN" ]]; then
-              mix coveralls.html --parallel --umbrella --include watcher --exclude child_chain --exclude common --trace
+              mix coveralls.html --parallel --umbrella --include watcher --exclude child_chain --exclude common --exclude test --trace
             else
-              mix coveralls.circle --parallel --umbrella --include watcher --exclude child_chain --exclude common --trace ||
+              mix coveralls.circle --parallel --umbrella --include watcher --exclude child_chain --exclude common --exclude test --trace ||
                 # if mix failed, then coveralls_merge won't run, so signal done here and return original exit status
                 (retval=$? && curl -k https://coveralls.io/webhook?repo_token=$COVERALLS_REPO_TOKEN -d "payload[build_num]=$CIRCLE_WORKFLOW_WORKSPACE_ID&payload[status]=done" && exit $retval)
             fi
 
-  coveralls_and_integration_tests_common:
+  common_coveralls_and_integration_tests:
     docker:
       - image: omisegoimages/elixir-omg-circleci:v1.8-20190129-02
         environment:
@@ -213,14 +193,57 @@ jobs:
           keys:
             - v1-mix-cache-test-compile-{{ checksum "mix.lock" }}
       - run:
+          name: Compile
+          command: mix compile
+      - run:
           name: Integration Tests & Coveralls Part Common
           command: |
             # Don't submit coverage report for forks, but let the build succeed
             export SHELL=/bin/bash
             if [[ -z "$COVERALLS_REPO_TOKEN" ]]; then
-              mix coveralls.html --parallel --umbrella --include common --exclude watcher --exclude child_chain --trace
+              mix coveralls.html --parallel --umbrella --include common --exclude watcher --exclude child_chain --exclude test --trace
             else
-              mix coveralls.circle --parallel --umbrella --include common --exclude watcher --exclude child_chain --trace ||
+              mix coveralls.circle --parallel --umbrella --include common --exclude watcher --exclude child_chain --exclude test --trace ||
+                # if mix failed, then coveralls_merge won't run, so signal done here and return original exit status
+                (retval=$? && curl -k https://coveralls.io/webhook?repo_token=$COVERALLS_REPO_TOKEN -d "payload[build_num]=$CIRCLE_WORKFLOW_WORKSPACE_ID&payload[status]=done" && exit $retval)
+            fi
+
+  test:
+    docker:
+      - image: omisegoimages/elixir-omg-circleci:v1.8-20190129-02
+        environment:
+          DATABASE_URL: postgres://postgres:postgres@localhost:5432/omisego_dev
+          MIX_ENV: test
+      - image: circleci/postgres:9.6-alpine
+        environment:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: omisego_dev
+          MIX_ENV: test
+    working_directory: ~/repo
+
+    steps:
+      - attach_workspace:
+           at: .
+
+      - run: mix local.hex --force
+      - run: mix local.rebar --force
+
+      - restore_cache:
+          keys:
+            - v1-mix-cache-test-compile-{{ checksum "mix.lock" }}
+      - run:
+          name: Compile
+          command: mix compile
+      - run:
+          name: Test
+          command: |
+            # Don't submit coverage report for forks, but let the build succeed
+            export SHELL=/bin/bash
+            if [[ -z "$COVERALLS_REPO_TOKEN" ]]; then
+              mix coveralls.html --parallel --umbrella --trace
+            else
+              mix coveralls.circle --parallel --umbrella --trace ||
                 # if mix failed, then coveralls_merge won't run, so signal done here and return original exit status
                 (retval=$? && curl -k https://coveralls.io/webhook?repo_token=$COVERALLS_REPO_TOKEN -d "payload[build_num]=$CIRCLE_WORKFLOW_WORKSPACE_ID&payload[status]=done" && exit $retval)
             fi
@@ -401,20 +424,21 @@ workflows:
       - build
       - coveralls_merge:
           requires:
-            - coveralls_and_integration_tests_child_chain
-            - coveralls_and_integration_tests_watcher
-            - coveralls_and_integration_tests_common
+            - child_chain_coveralls_and_integration_tests
+            - watcher_coveralls_and_integration_tests
+            - common_coveralls_and_integration_tests
+            - test
       - coveralls_and_integration_tests_compile:
           requires: [build]
-      - coveralls_and_integration_tests_child_chain:
+      - child_chain_coveralls_and_integration_tests:
           requires:
             - build
             - coveralls_and_integration_tests_compile
-      - coveralls_and_integration_tests_watcher:
+      - watcher_coveralls_and_integration_tests:
           requires:
             - build
             - coveralls_and_integration_tests_compile
-      - coveralls_and_integration_tests_common:
+      - common_coveralls_and_integration_tests:
           requires:
             - build
             - coveralls_and_integration_tests_compile
@@ -439,9 +463,9 @@ workflows:
             - dialyzer
             - test
             - release
-            - coveralls_and_integration_tests_child_chain
-            - coveralls_and_integration_tests_watcher
-            - coveralls_and_integration_tests_common
+            - child_chain_coveralls_and_integration_tests
+            - watcher_coveralls_and_integration_tests
+            - common_coveralls_and_integration_tests
           filters:
             branches:
               only:
@@ -452,9 +476,9 @@ workflows:
             - lint
             - dialyzer
             - test
-            - coveralls_and_integration_tests_child_chain
-            - coveralls_and_integration_tests_watcher
-            - coveralls_and_integration_tests_common
+            - child_chain_coveralls_and_integration_tests
+            - watcher_coveralls_and_integration_tests
+            - common_coveralls_and_integration_tests
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -122,19 +122,33 @@ jobs:
       #     keys:
       #       - v1-mix-cache-{{ checksum "mix.lock" }}
 
+      # - run:
+      #     name: Integration Tests & Coveralls
+      #     command: |
+      #       export GIT_COMMIT_DESCRIPTION=$(git log --format=%B -n 1 $CIRCLE_SHA1)
+      #       export SHELL=/bin/bash
+      #       mix coveralls.post \
+      #         --umbrella \
+      #         --trace \
+      #         --include integration \
+      #         --include wrappers \
+      #         --sha $CIRCLE_SHA \
+      #         --branch $CIRCLE_BRANCH \
+      #         --message "$GIT_COMMIT_DESCRIPTION"
       - run:
-          name: Integration Tests & Coveralls
+          name: Integration Tests & Coveralls Part 1
           command: |
-            export GIT_COMMIT_DESCRIPTION=$(git log --format=%B -n 1 $CIRCLE_SHA1)
+            # Don't submit coverage report for forks, but let the build succeed
             export SHELL=/bin/bash
-            mix coveralls.post \
-              --umbrella \
-              --trace \
-              --include integration \
-              --include wrappers \
-              --sha $CIRCLE_SHA \
-              --branch $CIRCLE_BRANCH \
-              --message "$GIT_COMMIT_DESCRIPTION"
+            if [[ -z "$COVERALLS_REPO_TOKEN" ]]; then
+              MIX_ENV=test mix coveralls.html --parallel --umbrella --include integration --include wrappers --trace
+            else
+              MIX_ENV=test mix coveralls.circle --parallel --umbrella --include integration --include wrappers --trace ||
+                # if mix failed, then coveralls_merge won't run, so signal done here and return original exit status
+                (retval=$? && curl -k https://coveralls.io/webhook?repo_token=$COVERALLS_REPO_TOKEN -d "payload[build_num]=$CIRCLE_WORKFLOW_WORKSPACE_ID&payload[status]=done" && exit $retval)
+            fi
+      - store_artifacts:
+          path: cover/excoveralls.html
 
   dialyzer:
     docker:
@@ -231,6 +245,18 @@ jobs:
           name: Uploading watcher CI artifacts
           path: ./ci_artifact
 
+  coveralls_merge:
+    docker:
+      # Ensure .tool-versions matches
+      - image: omisegoimages/elixir-omg-circleci:v1.8-20190129-02
+        environment:
+          MIX_ENV: test
+
+    steps:
+      - run:
+          name: Tell coveralls.io build is done
+          command: curl -k https://coveralls.io/webhook?repo_token=$COVERALLS_REPO_TOKEN -d "payload[build_num]=$CIRCLE_WORKFLOW_WORKSPACE_ID&payload[status]=done"
+
   build_and_deploy_development:
     docker:
       - image: ubuntu:16.04
@@ -317,6 +343,9 @@ workflows:
   build-deploy:
     jobs:
       - build
+      - coveralls_merge:
+          requires:
+            - coveralls_and_integration_tests
       - coveralls_and_integration_tests:
           requires: [build]
       - lint:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,7 +98,7 @@ jobs:
            at: .
       - run: MIX_ENV=test mix do local.hex --force, local.rebar --force, compile --warnings-as-errors --force, test --exclude test, credo, format --check-formatted --dry-run
 
-  coveralls_and_integration_tests:
+  coveralls_and_integration_tests_child_chain:
     docker:
       - image: omisegoimages/elixir-omg-circleci:v1.8-20190129-02
         environment:
@@ -122,28 +122,93 @@ jobs:
       #     keys:
       #       - v1-mix-cache-{{ checksum "mix.lock" }}
 
-      # - run:
-      #     name: Integration Tests & Coveralls
-      #     command: |
-      #       export GIT_COMMIT_DESCRIPTION=$(git log --format=%B -n 1 $CIRCLE_SHA1)
-      #       export SHELL=/bin/bash
-      #       mix coveralls.post \
-      #         --umbrella \
-      #         --trace \
-      #         --include integration \
-      #         --include wrappers \
-      #         --sha $CIRCLE_SHA \
-      #         --branch $CIRCLE_BRANCH \
-      #         --message "$GIT_COMMIT_DESCRIPTION"
       - run:
-          name: Integration Tests & Coveralls Part 1
+          name: Integration Tests & Coveralls Part Child Chain
           command: |
             # Don't submit coverage report for forks, but let the build succeed
             export SHELL=/bin/bash
             if [[ -z "$COVERALLS_REPO_TOKEN" ]]; then
-              MIX_ENV=test mix coveralls.html --parallel --umbrella --include integration --include wrappers --trace
+              MIX_ENV=test mix coveralls.html --parallel --umbrella --include child_chain --exclude watcher --exclude common --trace
             else
-              MIX_ENV=test mix coveralls.circle --parallel --umbrella --include integration --include wrappers --trace ||
+              MIX_ENV=test mix coveralls.circle --parallel --umbrella --include child_chain --exclude watcher --exclude common --trace ||
+                # if mix failed, then coveralls_merge won't run, so signal done here and return original exit status
+                (retval=$? && curl -k https://coveralls.io/webhook?repo_token=$COVERALLS_REPO_TOKEN -d "payload[build_num]=$CIRCLE_WORKFLOW_WORKSPACE_ID&payload[status]=done" && exit $retval)
+            fi
+      - store_artifacts:
+          path: cover/excoveralls.html
+
+  coveralls_and_integration_tests_watcher:
+    docker:
+      - image: omisegoimages/elixir-omg-circleci:v1.8-20190129-02
+        environment:
+          DATABASE_URL: postgres://postgres:postgres@localhost:5432/omisego_dev
+      - image: circleci/postgres:9.6-alpine
+        environment:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: omisego_dev
+          MIX_ENV: test
+    working_directory: ~/repo
+
+    steps:
+      - attach_workspace:
+           at: .
+
+      - run: mix local.hex --force
+      - run: mix local.rebar --force
+
+      # - restore_cache:
+      #     keys:
+      #       - v1-mix-cache-{{ checksum "mix.lock" }}
+
+      - run:
+          name: Integration Tests & Coveralls Part Watcher
+          command: |
+            # Don't submit coverage report for forks, but let the build succeed
+            export SHELL=/bin/bash
+            if [[ -z "$COVERALLS_REPO_TOKEN" ]]; then
+              MIX_ENV=test mix coveralls.html --parallel --umbrella --include watcher --exclude child_chain --exclude common --trace
+            else
+              MIX_ENV=test mix coveralls.circle --parallel --umbrella --include watcher --exclude child_chain --exclude common --trace ||
+                # if mix failed, then coveralls_merge won't run, so signal done here and return original exit status
+                (retval=$? && curl -k https://coveralls.io/webhook?repo_token=$COVERALLS_REPO_TOKEN -d "payload[build_num]=$CIRCLE_WORKFLOW_WORKSPACE_ID&payload[status]=done" && exit $retval)
+            fi
+      - store_artifacts:
+          path: cover/excoveralls.html
+
+  coveralls_and_integration_tests_common:
+    docker:
+      - image: omisegoimages/elixir-omg-circleci:v1.8-20190129-02
+        environment:
+          DATABASE_URL: postgres://postgres:postgres@localhost:5432/omisego_dev
+      - image: circleci/postgres:9.6-alpine
+        environment:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: omisego_dev
+          MIX_ENV: test
+    working_directory: ~/repo
+
+    steps:
+      - attach_workspace:
+           at: .
+
+      - run: mix local.hex --force
+      - run: mix local.rebar --force
+
+      # - restore_cache:
+      #     keys:
+      #       - v1-mix-cache-{{ checksum "mix.lock" }}
+
+      - run:
+          name: Integration Tests & Coveralls Part Common
+          command: |
+            # Don't submit coverage report for forks, but let the build succeed
+            export SHELL=/bin/bash
+            if [[ -z "$COVERALLS_REPO_TOKEN" ]]; then
+              MIX_ENV=test mix coveralls.html --parallel --umbrella --include common --exclude watcher --exclude child_chain --trace
+            else
+              MIX_ENV=test mix coveralls.circle --parallel --umbrella --include common --exclude watcher --exclude child_chain --trace ||
                 # if mix failed, then coveralls_merge won't run, so signal done here and return original exit status
                 (retval=$? && curl -k https://coveralls.io/webhook?repo_token=$COVERALLS_REPO_TOKEN -d "payload[build_num]=$CIRCLE_WORKFLOW_WORKSPACE_ID&payload[status]=done" && exit $retval)
             fi
@@ -345,8 +410,14 @@ workflows:
       - build
       - coveralls_merge:
           requires:
-            - coveralls_and_integration_tests
-      - coveralls_and_integration_tests:
+            - coveralls_and_integration_tests_child_chain
+            - coveralls_and_integration_tests_watcher
+            - coveralls_and_integration_tests_common
+      - coveralls_and_integration_tests_child_chain:
+          requires: [build]
+      - coveralls_and_integration_tests_watcher:
+          requires: [build]
+      - coveralls_and_integration_tests_common:
           requires: [build]
       - lint:
           requires: [build]
@@ -367,7 +438,9 @@ workflows:
             - dialyzer
             - test
             - release
-            - coveralls_and_integration_tests
+            - coveralls_and_integration_tests_child_chain
+            - coveralls_and_integration_tests_watcher
+            - coveralls_and_integration_tests_common
           filters:
             branches:
               only:
@@ -378,7 +451,9 @@ workflows:
             - lint
             - dialyzer
             - test
-            - coveralls_and_integration_tests
+            - coveralls_and_integration_tests_child_chain
+            - coveralls_and_integration_tests_watcher
+            - coveralls_and_integration_tests_common
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,7 +72,7 @@ jobs:
            at: .
       - run: MIX_ENV=test mix do local.hex --force, local.rebar --force, compile --warnings-as-errors --force, test --exclude test, credo, format --check-formatted --dry-run
 
-  coveralls_and_integration_tests_compile:
+  tests_compile_once:
     docker:
       - image: omisegoimages/elixir-omg-circleci:v1.8-20190129-02
         environment:
@@ -85,7 +85,7 @@ jobs:
            at: .
       - run: mix do local.hex --force, local.rebar --force, compile --warnings-as-errors --force
       - save_cache:
-          key: v1-mix-cache-test-compile-{{ checksum "mix.lock" }}
+          key: v1-mix-cache-test-compile-{{ checksum "mix.lock" }}-{{ .Branch }}-{{ .Revision }}
           paths: "_build"
 
   child_chain_coveralls_and_integration_tests:
@@ -111,7 +111,7 @@ jobs:
 
       - restore_cache:
           keys:
-            - v1-mix-cache-test-compile-{{ checksum "mix.lock" }}
+            - v1-mix-cache-test-compile-{{ checksum "mix.lock" }}-{{ .Branch }}-{{ .Revision }}
       - run:
           name: Compile
           command: mix compile
@@ -151,7 +151,7 @@ jobs:
 
       - restore_cache:
           keys:
-            - v1-mix-cache-test-compile-{{ checksum "mix.lock" }}
+            - v1-mix-cache-test-compile-{{ checksum "mix.lock" }}-{{ .Branch }}-{{ .Revision }}
       - run:
           name: Compile
           command: mix compile
@@ -191,7 +191,7 @@ jobs:
 
       - restore_cache:
           keys:
-            - v1-mix-cache-test-compile-{{ checksum "mix.lock" }}
+            - v1-mix-cache-test-compile-{{ checksum "mix.lock" }}-{{ .Branch }}-{{ .Revision }}
       - run:
           name: Compile
           command: mix compile
@@ -231,7 +231,7 @@ jobs:
 
       - restore_cache:
           keys:
-            - v1-mix-cache-test-compile-{{ checksum "mix.lock" }}
+            - v1-mix-cache-test-compile-{{ checksum "mix.lock" }}-{{ .Branch }}-{{ .Revision }}
       - run:
           name: Compile
           command: mix compile
@@ -428,20 +428,20 @@ workflows:
             - watcher_coveralls_and_integration_tests
             - common_coveralls_and_integration_tests
             - test
-      - coveralls_and_integration_tests_compile:
+      - tests_compile_once:
           requires: [build]
       - child_chain_coveralls_and_integration_tests:
           requires:
             - build
-            - coveralls_and_integration_tests_compile
+            - tests_compile_once
       - watcher_coveralls_and_integration_tests:
           requires:
             - build
-            - coveralls_and_integration_tests_compile
+            - tests_compile_once
       - common_coveralls_and_integration_tests:
           requires:
             - build
-            - coveralls_and_integration_tests_compile
+            - tests_compile_once
       - lint:
           requires: [build]
       - dialyzer:
@@ -449,7 +449,7 @@ workflows:
       - test:
           requires:
             - build
-            - coveralls_and_integration_tests_compile
+            - tests_compile_once
       - release:
           requires: [build]
           filters:

--- a/apps/omg/config/config.exs
+++ b/apps/omg/config/config.exs
@@ -5,7 +5,8 @@ use Mix.Config
 config :omg,
   deposit_finality_margin: 10,
   ethereum_events_check_interval_ms: 500,
-  coordinator_eth_height_check_interval_ms: 6_000
+  coordinator_eth_height_check_interval_ms: 6_000,
+  client_monitor_interval_ms: 500
 
 config :omg, :eip_712_domain,
   name: "OMG Network",

--- a/apps/omg/config/test.exs
+++ b/apps/omg/config/test.exs
@@ -3,4 +3,5 @@ use Mix.Config
 config :omg,
   deposit_finality_margin: 1,
   ethereum_events_check_interval_ms: 50,
-  coordinator_eth_height_check_interval_ms: 100
+  coordinator_eth_height_check_interval_ms: 100,
+  client_monitor_interval_ms: 50

--- a/apps/omg/lib/omg/ethereum_client_monitor.ex
+++ b/apps/omg/lib/omg/ethereum_client_monitor.ex
@@ -24,7 +24,7 @@ defmodule OMG.EthereumClientMonitor do
   require Logger
   alias OMG.Eth
 
-  @default_interval 500
+  @default_interval Application.get_env(:omg, :client_monitor_interval_ms)
   @type t :: %__MODULE__{
           interval: pos_integer(),
           tref: reference() | nil,

--- a/apps/omg/lib/omg/state/transaction/signed.ex
+++ b/apps/omg/lib/omg/state/transaction/signed.ex
@@ -21,6 +21,7 @@ defmodule OMG.State.Transaction.Signed do
 
   alias OMG.Crypto
   alias OMG.State.Transaction
+  alias OMG.TypedDataHash
 
   @signature_length 65
   @empty_signature <<0::size(520)>>
@@ -61,7 +62,7 @@ defmodule OMG.State.Transaction.Signed do
   """
   @spec get_spenders(t()) :: {:ok, list(Crypto.address_t())} | {:error, atom}
   def get_spenders(%Transaction.Signed{raw_tx: raw_tx, sigs: sigs}) do
-    hash_without_sigs = OMG.TypedDataHash.hash_struct(raw_tx)
+    hash_without_sigs = TypedDataHash.hash_struct(raw_tx)
 
     with {:ok, reversed_spenders} <- get_reversed_spenders(hash_without_sigs, sigs),
          do: {:ok, Enum.reverse(reversed_spenders)}

--- a/apps/omg/test/omg/crypto_test.exs
+++ b/apps/omg/test/omg/crypto_test.exs
@@ -21,6 +21,8 @@ defmodule OMG.CryptoTest do
 
   alias OMG.Crypto
   alias OMG.DevCrypto
+  alias OMG.State.Transaction
+  alias OMG.TypedDataHash
 
   test "sha3 library usage, address generation" do
     # test vectors below were generated using pyethereum's sha3 and privtoaddr
@@ -56,8 +58,6 @@ defmodule OMG.CryptoTest do
   end
 
   test "sign, verify" do
-    alias OMG.State.Transaction
-    alias OMG.TypedDataHash
     {:ok, priv} = DevCrypto.generate_private_key()
     {:ok, pub} = DevCrypto.generate_public_key(priv)
     {:ok, address} = Crypto.generate_address(pub)

--- a/apps/omg/test/omg/integration/root_chain_coordinator_test.exs
+++ b/apps/omg/test/omg/integration/root_chain_coordinator_test.exs
@@ -26,6 +26,7 @@ defmodule OMG.RootChainCoordinatorTest do
   alias OMG.Integration.DepositHelper
 
   @moduletag :integration
+  @moduletag :common
 
   @tag fixtures: [:alice, :db_initialized, :root_chain_contract_config]
   test "can do a simplest sync",

--- a/apps/omg_child_chain/test/omg_child_chain/integration/happy_path_test.exs
+++ b/apps/omg_child_chain/test/omg_child_chain/integration/happy_path_test.exs
@@ -38,7 +38,7 @@ defmodule OMG.ChildChain.Integration.HappyPathTest do
   @eth OMG.Eth.RootChain.eth_pseudo_address()
   @interval OMG.Eth.RootChain.get_child_block_interval() |> elem(1)
 
-  @tag fixtures: [:alice, :bob, :omg_child_chain, :token, :alice_deposits, :eth_node]
+  @tag fixtures: [:alice, :bob, :omg_child_chain, :token, :alice_deposits]
   test "deposit, spend, restart, exit etc works fine", %{
     alice: alice,
     bob: bob,

--- a/apps/omg_child_chain/test/omg_child_chain/integration/happy_path_test.exs
+++ b/apps/omg_child_chain/test/omg_child_chain/integration/happy_path_test.exs
@@ -38,7 +38,7 @@ defmodule OMG.ChildChain.Integration.HappyPathTest do
   @eth OMG.Eth.RootChain.eth_pseudo_address()
   @interval OMG.Eth.RootChain.get_child_block_interval() |> elem(1)
 
-  @tag fixtures: [:alice, :bob, :omg_child_chain, :token, :alice_deposits]
+  @tag fixtures: [:alice, :bob, :omg_child_chain, :token, :alice_deposits, :eth_node]
   test "deposit, spend, restart, exit etc works fine", %{
     alice: alice,
     bob: bob,

--- a/apps/omg_child_chain/test/omg_child_chain/integration/happy_path_test.exs
+++ b/apps/omg_child_chain/test/omg_child_chain/integration/happy_path_test.exs
@@ -31,6 +31,7 @@ defmodule OMG.ChildChain.Integration.HappyPathTest do
   require OMG.Utxo
 
   @moduletag :integration
+  @moduletag :child_chain
   # bumping the timeout to two minutes for the tests here, as they do a lot of transactions to Ethereum to test
   @moduletag timeout: 120_000
 

--- a/apps/omg_child_chain/test/omg_child_chain/integration/monitor_test.exs
+++ b/apps/omg_child_chain/test/omg_child_chain/integration/monitor_test.exs
@@ -18,7 +18,9 @@ defmodule OMG.ChildChain.MonitorTest do
   alias OMG.Alert.AlarmHandler
   alias OMG.ChildChain.Monitor
   use ExUnit.Case, async: true
+
   @moduletag :integration
+  @moduletag :child_chain
   @moduletag timeout: 120_000
 
   setup_all do

--- a/apps/omg_db/test/omg_db/application_test.exs
+++ b/apps/omg_db/test/omg_db/application_test.exs
@@ -20,6 +20,8 @@ defmodule OMG.DB.ApplicationTest do
   use ExUnit.Case, async: false
 
   @moduletag :wrappers
+  @moduletag :common
+
   @tag fixtures: [:db_initialized]
   test "starts and stops app, inits", %{db_initialized: db_result} do
     assert :ok = db_result

--- a/apps/omg_db/test/omg_db/db_test.exs
+++ b/apps/omg_db/test/omg_db/db_test.exs
@@ -26,6 +26,7 @@ defmodule OMG.DBTest do
   alias OMG.DB
 
   @moduletag :wrappers
+  @moduletag :common
 
   test "handles object storage", %{db_dir: dir, db_pid: pid} do
     :ok =

--- a/apps/omg_eth/test/omg_eth/eth_test.exs
+++ b/apps/omg_eth/test/omg_eth/eth_test.exs
@@ -30,6 +30,7 @@ defmodule OMG.EthTest do
   @eth OMG.Eth.RootChain.eth_pseudo_address()
 
   @moduletag :wrappers
+  @moduletag :common
 
   @tag fixtures: [:eth_node]
   test "get_ethereum_height returns integer" do

--- a/apps/omg_performance/test/omg_performance/integration/performance_test.exs
+++ b/apps/omg_performance/test/omg_performance/integration/performance_test.exs
@@ -24,6 +24,7 @@ defmodule OMG.PerformanceTest do
   alias OMG.Eth
 
   @moduletag :integration
+  @moduletag :common
 
   deffixture destdir do
     {:ok, _} = Application.ensure_all_started(:briefly)

--- a/apps/omg_status/test/omg_status/integration/alarms_test.exs
+++ b/apps/omg_status/test/omg_status/integration/alarms_test.exs
@@ -15,7 +15,9 @@
 defmodule OMG.Status.Alert.AlarmTest do
   use ExUnit.Case, async: false
   alias OMG.Status.Alert.Alarm
+
   @moduletag :integration
+  @moduletag :common
   @moduletag timeout: 240_000
 
   setup do

--- a/apps/omg_watcher/lib/omg_watcher/exit_processor/core.ex
+++ b/apps/omg_watcher/lib/omg_watcher/exit_processor/core.ex
@@ -33,15 +33,17 @@ defmodule OMG.Watcher.ExitProcessor.Core do
   alias OMG.Block
   alias OMG.Crypto
   alias OMG.State.Transaction
+  alias OMG.TypedDataHash
   alias OMG.Utxo
-  require Utxo
-  require Transaction
   alias OMG.Watcher.Event
   alias OMG.Watcher.ExitProcessor
   alias OMG.Watcher.ExitProcessor.CompetitorInfo
   alias OMG.Watcher.ExitProcessor.ExitInfo
   alias OMG.Watcher.ExitProcessor.InFlightExitInfo
   alias OMG.Watcher.ExitProcessor.TxAppendix
+
+  require Utxo
+  require Transaction
 
   @default_sla_margin 10
   @zero_address OMG.Eth.zero_address()
@@ -1210,7 +1212,7 @@ defmodule OMG.Watcher.ExitProcessor.Core do
   # Finds the exact signature which signed the particular transaction for the given owner address
   @spec find_sig(Transaction.Signed.t(), Crypto.address_t()) :: {:ok, Crypto.sig_t()} | nil
   defp find_sig(%Transaction.Signed{sigs: sigs, raw_tx: raw_tx}, owner) do
-    tx_hash = OMG.TypedDataHash.hash_struct(raw_tx)
+    tx_hash = TypedDataHash.hash_struct(raw_tx)
 
     Enum.find(sigs, fn sig ->
       {:ok, owner} == Crypto.recover_address(tx_hash, sig)

--- a/apps/omg_watcher/test/omg_watcher/integration/block_getter_test.exs
+++ b/apps/omg_watcher/test/omg_watcher/integration/block_getter_test.exs
@@ -40,6 +40,7 @@ defmodule OMG.Watcher.Integration.BlockGetterTest do
   import ExUnit.CaptureLog
 
   @moduletag :integration
+  @moduletag :watcher
 
   @timeout 40_000
   @eth OMG.Eth.RootChain.eth_pseudo_address()

--- a/apps/omg_watcher/test/omg_watcher/integration/in_flight_exit_test.exs
+++ b/apps/omg_watcher/test/omg_watcher/integration/in_flight_exit_test.exs
@@ -31,6 +31,7 @@ defmodule OMG.Watcher.Integration.InFlightExitTest do
   @eth OMG.Eth.RootChain.eth_pseudo_address()
 
   @moduletag :integration
+  @moduletag :watcher
   # bumping the timeout to two minutes for the tests here, as they do a lot of transactions to Ethereum to test
   @moduletag timeout: 180_000
 

--- a/apps/omg_watcher/test/omg_watcher/integration/invalid_exit_test.exs
+++ b/apps/omg_watcher/test/omg_watcher/integration/invalid_exit_test.exs
@@ -29,6 +29,7 @@ defmodule OMG.Watcher.Integration.InvalidExitTest do
   import ExUnit.CaptureLog
 
   @moduletag :integration
+  @moduletag :watcher
   @moduletag timeout: 120_000
 
   @timeout 40_000

--- a/apps/omg_watcher/test/omg_watcher/integration/standard_exit_test.exs
+++ b/apps/omg_watcher/test/omg_watcher/integration/standard_exit_test.exs
@@ -34,6 +34,7 @@ defmodule OMG.Watcher.Integration.StandardExitTest do
   @endpoint OMG.Watcher.Web.Endpoint
 
   @moduletag :integration
+  @moduletag :watcher
   @moduletag timeout: 180_000
 
   @timeout 40_000

--- a/apps/omg_watcher/test/omg_watcher/web/controllers/status_test.exs
+++ b/apps/omg_watcher/test/omg_watcher/web/controllers/status_test.exs
@@ -16,7 +16,9 @@ defmodule OMG.Watcher.Web.Controller.StatusTest do
   use ExUnitFixtures
   use ExUnit.Case, async: false
   alias OMG.Watcher.TestHelper
+
   @moduletag :integration
+  @moduletag :watcher
 
   @tag fixtures: [:watcher, :root_chain_contract_config]
   test "status endpoint returns expected response format" do


### PR DESCRIPTION
I've seen that integration tests can take around 20 minutes now so I thought it might be a good time to try and reduce the time.
I've split the integration + wrapper tags into child chain, watcher and common (everything else) and we run them in parallel, gather the results and send off to coveralls. It reduces the runs significantly. Also, we now compile the source only once, cache the _build folder just before the test run.  