### PR TITLE
setup containers with releases

### DIFF
--- a/.circleci/ci_publish.sh
+++ b/.circleci/ci_publish.sh
@@ -1,0 +1,86 @@
+#!/bin/sh
+
+set -e
+
+echo_info() {
+    printf "\\033[0;34m%s\\033[0;0m\\n" "$1"
+}
+
+echo_warn() {
+    printf "\\033[0;33m%s\\033[0;0m\\n" "$1"
+}
+
+
+## Sanity check
+##
+
+if [ -z "$DOCKER_PASS" ] || [ -z "$DOCKER_USER" ]; then
+    echo_warn "Docker credentials is not present, skipping publish."
+    exit 0
+fi
+
+if [ -z "$IMAGE_NAME" ]; then
+    echo_warn "IMAGE_NAME not present, failing."
+    exit 1
+fi
+
+
+## Generate tags
+##
+
+if [ -n "$CIRCLE_SHA1" ]; then
+    _image_tag="$(printf "%s" "$CIRCLE_SHA1" | head -c 8)"
+fi
+
+if [ -n "$CIRCLE_TAG" ]; then
+    _ver="${CIRCLE_TAG#*v}"
+
+    # Given a v1.0.0-pre.1 tag, this will generate:
+    # - 1.0
+    # - 1.0.0-pre
+    # - 1.0.0-pre.1
+    while true; do
+        case "$_ver" in
+            *.* )
+                _image_tag="$_ver $_image_tag"
+                _ver="${_ver%.*}"
+                ;;
+            * )
+                break;;
+        esac
+    done
+
+    # In case the commit is HEAD of latest version branch, also tag stable.
+    if [ -n "$CIRCLE_REPOSITORY_URL" ] && [ -n "$CIRCLE_SHA1" ]; then
+        _stable_head="$(
+            git ls-remote --heads "$CIRCLE_REPOSITORY_URL" "v*" |
+            awk '/refs\/heads\/v[0-9]+\.[0-9]+$/ { LH=$1 } END { print LH }'
+        )"
+
+        if [ "$CIRCLE_SHA1" = "$_stable_head" ]; then
+            _image_tag="$_image_tag stable"
+        fi
+    fi
+else
+    case "$CIRCLE_BRANCH" in
+        master ) _image_tag="$_image_tag latest";;
+        v*     ) _image_tag="$_image_tag ${CIRCLE_BRANCH#*v}-dev";;
+        *      ) ;;
+    esac
+fi
+
+
+## Publishing
+##
+
+if [ -f "$HOME/caches/docker-layers.tar" ]; then
+    docker load -i "$HOME/caches/docker-layers.tar"
+fi
+
+printf "%s\\n" "$DOCKER_PASS" | docker login -u "$DOCKER_USER" --password-stdin
+
+for tag in $_image_tag; do
+    echo_info "Publishing Docker image as $IMAGE_NAME:$tag"
+    docker tag "$IMAGE_NAME" "$IMAGE_NAME:$tag"
+    docker push "$IMAGE_NAME:$tag"
+done

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -332,31 +332,24 @@ jobs:
     steps:
       - checkout
       - run: make docker-child_chain CHILD_CHAIN_IMAGE_NAME=$CHILD_CHAIN_IMAGE_NAME
-      #- notify_slack_failure
-      #- notify_slack
 
   publish_watcher:
     executor: metal_watcher
     steps:
       - checkout
       - run: make docker-watcher WATCHER_PROD_IMAGE_NAME=$WATCHER_PROD_IMAGE_NAME
-      #- notify_slack_failure
-      #- notify_slack
 
   deploy_watcher:
     executor: deploy
     steps:
       - checkout
       #- run: sh .circleci/ci_deploy.sh
-      #- notify_slack_failure
-      #- notify_slack_deploy
+
   deploy_child_chain:
     executor: deploy
     steps:
       - checkout
       #- run: sh .circleci/ci_deploy.sh
-      #- notify_slack_failure
-      #- notify_slack_deploy
 
   coveralls_merge:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,12 +34,12 @@ executors:
   metal_child_chain:
     machine: true
     environment:
-      CHILD_CHAIN_PROD_IMAGE_NAME: "omisego/child_chain"
+      IMAGE_NAME: "omisego/child_chain"
 
   metal_watcher:
     machine: true
     environment:
-      WATCHER_PROD_IMAGE_NAME: "omisego/watcher"
+      IMAGE_NAME: "omisego/watcher"
 
 commands:
   setup_elixir-omg_workspace:
@@ -247,12 +247,14 @@ jobs:
     steps:
       - checkout
       - run: make docker-child_chain CHILD_CHAIN_IMAGE_NAME=$CHILD_CHAIN_IMAGE_NAME
+      - run: sh .circleci/ci_publish.sh
 
   publish_watcher:
     executor: metal_watcher
     steps:
       - checkout
       - run: make docker-watcher WATCHER_PROD_IMAGE_NAME=$WATCHER_PROD_IMAGE_NAME
+      - run: sh .circleci/ci_publish.sh
 
   deploy_watcher:
     executor: deploy

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -502,14 +502,14 @@ workflows:
                 - v0.1
       # Publish in case of master branch.
       - publish_child_chain:
-          requires: [child_chain_coveralls_and_integration_tests, watcher_coveralls_and_integration_tests, common_coveralls_and_integration_tests, test, dialyzer, lint]
+          #requires: [child_chain_coveralls_and_integration_tests, watcher_coveralls_and_integration_tests, common_coveralls_and_integration_tests, test, dialyzer, lint]
           filters:
             branches:
               only:
                 - master
                 - 579-publish_release_docker
       - publish_watcher:
-          requires: [child_chain_coveralls_and_integration_tests, watcher_coveralls_and_integration_tests, common_coveralls_and_integration_tests, test, dialyzer, lint]
+          #requires: [child_chain_coveralls_and_integration_tests, watcher_coveralls_and_integration_tests, common_coveralls_and_integration_tests, test, dialyzer, lint]
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,36 @@
-version: 2
+version: 2.1
+
+executors:
+  child_chain-builder:
+    docker:
+      - image: omisegoimages/elixir-omg-builder:v1.2
+    working_directory: ~/src
+  watcher-builder:
+    docker:
+      - image: omisegoimages/elixir-omg-builder:v1.2
+    working_directory: ~/src
+
+  builder_pg:
+    docker:
+      - image: omisegoimages/elixir-omg-builder:v1.2
+      - image: postgres:9.6-alpine
+    working_directory: ~/src
+
+  deploy:
+    docker:
+      - image: omisegoimages/elixir-omg-deploy:stable
+    working_directory: ~/src
+
+  child_chain-metal:
+    machine: true
+    environment:
+      IMAGE_NAME: "omisego/child_chain"
+
+  watcher-metal:
+    machine: true
+    environment:
+      IMAGE_NAME: "omisego/watcher"
+
 jobs:
   build:
     docker:
@@ -325,6 +357,23 @@ jobs:
           name: Uploading watcher CI artifacts
           path: ./ci_artifact
 
+  publish:
+    executor: metal
+    steps:
+      - checkout
+      - run: make docker IMAGE_NAME=$IMAGE_NAME
+      - run: make docker CHILD_CHAIN_IMAGE_NAME=$CHILD_CHAIN_IMAGE_NAME
+      - notify_slack_failure
+      - notify_slack
+
+  deploy:
+    executor: deploy
+    steps:
+      - checkout
+      #- run: sh .circleci/ci_deploy.sh
+      #- notify_slack_failure
+      #- notify_slack_deploy
+
   coveralls_merge:
     docker:
       # Ensure .tool-versions matches
@@ -481,3 +530,19 @@ workflows:
             branches:
               only:
                 - v0.1
+      # Publish in case of master branch.
+      - publish:
+          requires: [child_chain_coveralls_and_integration_tests, watcher_coveralls_and_integration_tests, common_coveralls_and_integration_tests, test, dialyzer, lint]
+          filters:
+            branches:
+              only:
+                - master
+                - 579-publish_release_docker
+      # Release deploy to development in case of master branch.
+      - deploy:
+          requires: [publish]
+          filters:
+            branches:
+              only:
+                - master
+                - 579-publish_release_docker

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,6 +48,9 @@ jobs:
       - run: make deps-elixir-omg
       - run: ERLANG_ROCKSDB_BUILDOPTS='-j 2' make build-test
       - save_cache:
+          key: v1-mix-cache-test-compile-{{ checksum "mix.lock" }}-{{ .Branch }}-{{ .Revision }}
+          paths: "_build"
+      - save_cache:
           key: v1-rocksdb-cache-{{ checksum "mix.lock" }}
           paths:
             - "deps/rocksdb"
@@ -83,22 +86,6 @@ jobs:
     steps:
       - setup_elixir-omg_workspace
       - run: MIX_ENV=test mix do local.hex --force, local.rebar --force, compile --warnings-as-errors --force, ecto.create, ecto.migrate, test --exclude test, credo, format --check-formatted --dry-run
-
-  tests_compile_once:
-    docker:
-      - image: omisegoimages/elixir-omg-circleci:v1.8-20190129-02
-        environment:
-          DATABASE_URL: postgres://postgres:postgres@localhost:5432/omisego_dev
-          MIX_ENV: test
-    working_directory: ~/repo
-
-    steps:
-      - attach_workspace:
-           at: .
-      - run: mix do local.hex --force, local.rebar --force, compile --warnings-as-errors --force
-      - save_cache:
-          key: v1-mix-cache-test-compile-{{ checksum "mix.lock" }}-{{ .Branch }}-{{ .Revision }}
-          paths: "_build"
 
   child_chain_coveralls_and_integration_tests:
     docker:
@@ -261,22 +248,16 @@ jobs:
             fi
 
   dialyzer:
-    docker:
-      - image: omisegoimages/elixir-omg-circleci:v1.8-20190129-02
-        environment:
-          DATABASE_URL: postgres://postgres:postgres@localhost:5432/omisego_dev
-    working_directory: ~/repo
-
+    executor: builder_pg
+    environment:
+      DATABASE_URL: postgres://postgres:postgres@localhost:5432/omisego_dev
     steps:
-      - attach_workspace:
-           at: .
-      - run: mix local.hex --force
-      - run: mix local.rebar --force
+      - setup_elixir-omg_workspace
       - restore_cache:
           keys:
-            - v1-plt-cache-{{ ".tool-versions" }}-{{ checksum "mix.lock" }}
-            - v1-plt-cache-{{ ".tool-versions" }}-{{ checksum "mix.exs" }}
-            - v1-plt-cache-{{ ".tool-versions" }}
+            - v2-plt-cache-{{ ".tool-versions" }}-{{ checksum "mix.lock" }}
+            - v2-plt-cache-{{ ".tool-versions" }}-{{ checksum "mix.exs" }}
+            - v2-plt-cache-{{ ".tool-versions" }}
       - run:
           name: Unpack PLT cache
           command: |
@@ -292,15 +273,15 @@ jobs:
             cp _build/test/dialyxir*.plt plts/
             cp ~/.mix/dialyxir*.plt plts/
       - save_cache:
-          key: v1-plt-cache-{{ ".tool-versions" }}-{{ checksum "mix.lock" }}
+          key: v2-plt-cache-{{ ".tool-versions" }}-{{ checksum "mix.lock" }}
           paths:
             - plts
       - save_cache:
-          key: v1-plt-cache-{{ ".tool-versions" }}-{{ checksum "mix.exs" }}
+          key: v2-plt-cache-{{ ".tool-versions" }}-{{ checksum "mix.exs" }}
           paths:
             - plts
       - save_cache:
-          key: v1-plt-cache-{{ ".tool-versions" }}
+          key: v2-plt-cache-{{ ".tool-versions" }}
           paths:
             - plts
 
@@ -431,20 +412,15 @@ workflows:
             - watcher_coveralls_and_integration_tests
             - common_coveralls_and_integration_tests
             - test
-      - tests_compile_once:
-          requires: [build]
       - child_chain_coveralls_and_integration_tests:
           requires:
             - build
-            - tests_compile_once
       - watcher_coveralls_and_integration_tests:
           requires:
             - build
-            - tests_compile_once
       - common_coveralls_and_integration_tests:
           requires:
             - build
-            - tests_compile_once
       - lint:
           requires: [build]
       - dialyzer:
@@ -452,7 +428,7 @@ workflows:
       - test:
           requires:
             - build
-            - tests_compile_once
+
       - build_and_deploy_development:
           requires:
             - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -247,14 +247,14 @@ jobs:
     steps:
       - checkout
       - run: make docker-child_chain CHILD_CHAIN_IMAGE_NAME=$CHILD_CHAIN_IMAGE_NAME
-      - run: sh .circleci/ci_publish.sh
+      #- run: sh .circleci/ci_publish.sh
 
   publish_watcher:
     executor: metal_watcher
     steps:
       - checkout
       - run: make docker-watcher WATCHER_PROD_IMAGE_NAME=$WATCHER_PROD_IMAGE_NAME
-      - run: sh .circleci/ci_publish.sh
+      #- run: sh .circleci/ci_publish.sh
 
   deploy_watcher:
     executor: deploy

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ executors:
   builder_pg:
     docker:
       - image: omisegoimages/elixir-omg-builder:v1.3
-      - image: postgres:9.6-alpine
+      - image: circleci/postgres:9.6-alpine
         environment:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres
@@ -43,8 +43,16 @@ jobs:
     executor: builder
     steps:
       - checkout
+      - restore_cache:
+          key: v1-rocksdb-cache-{{ checksum "mix.lock" }}
       - run: make deps-elixir-omg
       - run: ERLANG_ROCKSDB_BUILDOPTS='-j 2' make build-test
+      - save_cache:
+          key: v1-rocksdb-cache-{{ checksum "mix.lock" }}
+          paths:
+            - "deps/rocksdb"
+            - "_build/test/lib/rocksdb/"
+            - "_build/test/dev/rocksdb/"
       - persist_to_workspace:
           root: .
           paths:
@@ -70,6 +78,8 @@ jobs:
 
   lint:
     executor: builder_pg
+    environment:
+      DATABASE_URL: postgres://postgres:postgres@localhost:5432/omisego_dev
     steps:
       - setup_elixir-omg_workspace
       - run: MIX_ENV=test mix do local.hex --force, local.rebar --force, compile --warnings-as-errors --force, ecto.create, ecto.migrate, test --exclude test, credo, format --check-formatted --dry-run

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,10 @@ executors:
     docker:
       - image: omisegoimages/elixir-omg-builder:v1.3
       - image: postgres:9.6-alpine
+        environment:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: omisego_dev
     working_directory: ~/src
 
   deploy:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,7 @@ jobs:
     steps:
       - checkout
       - run: make deps-elixir-omg
-      - run: make build-test
+      - run: ERLANG_ROCKSDB_BUILDOPTS='-j 2' make build-test
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,7 +72,7 @@ jobs:
     executor: builder_pg
     steps:
       - setup_elixir-omg_workspace
-      - run: MIX_ENV=test mix do local.hex --force, local.rebar --force, compile --warnings-as-errors --force, test --exclude test, credo, format --check-formatted --dry-run
+      - run: MIX_ENV=test mix do local.hex --force, local.rebar --force, compile --warnings-as-errors --force, ecto.create, ecto.migrate, test --exclude test, credo, format --check-formatted --dry-run
 
   tests_compile_once:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,6 +41,8 @@ commands:
 jobs:
   build:
     executor: builder
+    environment:
+      MIX_ENV: "test"
     steps:
       - checkout
       - restore_cache:
@@ -48,7 +50,7 @@ jobs:
       - run: make deps-elixir-omg
       - run: ERLANG_ROCKSDB_BUILDOPTS='-j 2' make build-test
       - save_cache:
-          key: v1-mix-cache-test-compile-{{ checksum "mix.lock" }}-{{ .Branch }}-{{ .Revision }}
+          key: v2-mix-cache-test-compile-{{ checksum "mix.lock" }}-{{ .Branch }}-{{ .Revision }}
           paths: "_build"
       - save_cache:
           key: v1-rocksdb-cache-{{ checksum "mix.lock" }}
@@ -57,19 +59,17 @@ jobs:
             - "_build/test/lib/rocksdb/"
             - "_build/test/dev/rocksdb/"
       - persist_to_workspace:
-          root: .
+          name: Persist workspace
+          root: ~/src
           paths:
             - .circleci
             - dialyzer.ignore-warnings
             - .formatter.exs
-            - .git
-            - .gitignore
             - _build
             - .credo.exs
             - apps
             - bin
             - config
-            - db/.gitkeep
             - deps
             - doc
             - mix.exs
@@ -83,34 +83,21 @@ jobs:
     executor: builder_pg
     environment:
       DATABASE_URL: postgres://postgres:postgres@localhost:5432/omisego_dev
+      MIX_ENV: test
     steps:
       - setup_elixir-omg_workspace
-      - run: MIX_ENV=test mix do local.hex --force, local.rebar --force, compile --warnings-as-errors --force, ecto.create, ecto.migrate, test --exclude test, credo, format --check-formatted --dry-run
+      - run: mix do local.hex --force, local.rebar --force, compile --warnings-as-errors --force, ecto.create, ecto.migrate, test --exclude test, credo, format --check-formatted --dry-run
 
   child_chain_coveralls_and_integration_tests:
-    docker:
-      - image: omisegoimages/elixir-omg-circleci:v1.8-20190129-02
-        environment:
-          DATABASE_URL: postgres://postgres:postgres@localhost:5432/omisego_dev
-          MIX_ENV: test
-      - image: circleci/postgres:9.6-alpine
-        environment:
-          POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: postgres
-          POSTGRES_DB: omisego_dev
-          MIX_ENV: test
-    working_directory: ~/repo
-
+    executor: builder_pg
+    environment:
+      DATABASE_URL: postgres://postgres:postgres@localhost:5432/omisego_dev
+      MIX_ENV: test
     steps:
-      - attach_workspace:
-           at: .
-
-      - run: mix local.hex --force
-      - run: mix local.rebar --force
-
+      - setup_elixir-omg_workspace
       - restore_cache:
           keys:
-            - v1-mix-cache-test-compile-{{ checksum "mix.lock" }}-{{ .Branch }}-{{ .Revision }}
+            - v2-mix-cache-test-compile-{{ checksum "mix.lock" }}-{{ .Branch }}-{{ .Revision }}
       - run:
           name: Compile
           command: mix compile
@@ -128,29 +115,15 @@ jobs:
             fi
 
   watcher_coveralls_and_integration_tests:
-    docker:
-      - image: omisegoimages/elixir-omg-circleci:v1.8-20190129-02
-        environment:
-          DATABASE_URL: postgres://postgres:postgres@localhost:5432/omisego_dev
-          MIX_ENV: test
-      - image: circleci/postgres:9.6-alpine
-        environment:
-          POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: postgres
-          POSTGRES_DB: omisego_dev
-          MIX_ENV: test
-    working_directory: ~/repo
-
+    executor: builder_pg
+    environment:
+      DATABASE_URL: postgres://postgres:postgres@localhost:5432/omisego_dev
+      MIX_ENV: test
     steps:
-      - attach_workspace:
-           at: .
-
-      - run: mix local.hex --force
-      - run: mix local.rebar --force
-
+      - setup_elixir-omg_workspace
       - restore_cache:
           keys:
-            - v1-mix-cache-test-compile-{{ checksum "mix.lock" }}-{{ .Branch }}-{{ .Revision }}
+            - v2-mix-cache-test-compile-{{ checksum "mix.lock" }}-{{ .Branch }}-{{ .Revision }}
       - run:
           name: Compile
           command: mix compile
@@ -168,29 +141,15 @@ jobs:
             fi
 
   common_coveralls_and_integration_tests:
-    docker:
-      - image: omisegoimages/elixir-omg-circleci:v1.8-20190129-02
-        environment:
-          DATABASE_URL: postgres://postgres:postgres@localhost:5432/omisego_dev
-          MIX_ENV: test
-      - image: circleci/postgres:9.6-alpine
-        environment:
-          POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: postgres
-          POSTGRES_DB: omisego_dev
-          MIX_ENV: test
-    working_directory: ~/repo
-
+    executor: builder_pg
+    environment:
+      DATABASE_URL: postgres://postgres:postgres@localhost:5432/omisego_dev
+      MIX_ENV: test
     steps:
-      - attach_workspace:
-           at: .
-
-      - run: mix local.hex --force
-      - run: mix local.rebar --force
-
+      - setup_elixir-omg_workspace
       - restore_cache:
           keys:
-            - v1-mix-cache-test-compile-{{ checksum "mix.lock" }}-{{ .Branch }}-{{ .Revision }}
+            - v2-mix-cache-test-compile-{{ checksum "mix.lock" }}-{{ .Branch }}-{{ .Revision }}
       - run:
           name: Compile
           command: mix compile
@@ -208,29 +167,15 @@ jobs:
             fi
 
   test:
-    docker:
-      - image: omisegoimages/elixir-omg-circleci:v1.8-20190129-02
-        environment:
-          DATABASE_URL: postgres://postgres:postgres@localhost:5432/omisego_dev
-          MIX_ENV: test
-      - image: circleci/postgres:9.6-alpine
-        environment:
-          POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: postgres
-          POSTGRES_DB: omisego_dev
-          MIX_ENV: test
-    working_directory: ~/repo
-
+    executor: builder_pg
+    environment:
+      DATABASE_URL: postgres://postgres:postgres@localhost:5432/omisego_dev
+      MIX_ENV: test
     steps:
-      - attach_workspace:
-           at: .
-
-      - run: mix local.hex --force
-      - run: mix local.rebar --force
-
+      - setup_elixir-omg_workspace
       - restore_cache:
           keys:
-            - v1-mix-cache-test-compile-{{ checksum "mix.lock" }}-{{ .Branch }}-{{ .Revision }}
+            - v2-mix-cache-test-compile-{{ checksum "mix.lock" }}-{{ .Branch }}-{{ .Revision }}
       - run:
           name: Compile
           command: mix compile

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -412,14 +412,14 @@ workflows:
                 - v0.1
       # Publish in case of master branch.
       - publish_child_chain:
-          #requires: [child_chain_coveralls_and_integration_tests, watcher_coveralls_and_integration_tests, common_coveralls_and_integration_tests, test, dialyzer, lint]
+          requires: [child_chain_coveralls_and_integration_tests, watcher_coveralls_and_integration_tests, common_coveralls_and_integration_tests, test, dialyzer, lint]
           filters:
             branches:
               only:
                 - master
                 - 579-publish_release_docker
       - publish_watcher:
-          #requires: [child_chain_coveralls_and_integration_tests, watcher_coveralls_and_integration_tests, common_coveralls_and_integration_tests, test, dialyzer, lint]
+          requires: [child_chain_coveralls_and_integration_tests, watcher_coveralls_and_integration_tests, common_coveralls_and_integration_tests, test, dialyzer, lint]
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -247,14 +247,14 @@ jobs:
     steps:
       - checkout
       - run: make docker-child_chain CHILD_CHAIN_IMAGE_NAME=$CHILD_CHAIN_IMAGE_NAME
-      #- run: sh .circleci/ci_publish.sh
+      #TODO - run: sh .circleci/ci_publish.sh
 
   publish_watcher:
     executor: metal_watcher
     steps:
       - checkout
       - run: make docker-watcher WATCHER_PROD_IMAGE_NAME=$WATCHER_PROD_IMAGE_NAME
-      #- run: sh .circleci/ci_publish.sh
+      #TODO - run: sh .circleci/ci_publish.sh
 
   deploy_watcher:
     executor: deploy

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,11 +1,11 @@
 version: 2.1
 
 executors:
-  child_chain-builder:
+  child_chain_builder:
     docker:
       - image: omisegoimages/elixir-omg-builder:v1.2
     working_directory: ~/src
-  watcher-builder:
+  builder_watcher:
     docker:
       - image: omisegoimages/elixir-omg-builder:v1.2
     working_directory: ~/src
@@ -21,15 +21,15 @@ executors:
       - image: omisegoimages/elixir-omg-deploy:stable
     working_directory: ~/src
 
-  child_chain-metal:
+  metal_child_chain:
     machine: true
     environment:
-      IMAGE_NAME: "omisego/child_chain"
+      CHILD_CHAIN_PROD_IMAGE_NAME: "omisego/child_chain"
 
-  watcher-metal:
+  metal_watcher:
     machine: true
     environment:
-      IMAGE_NAME: "omisego/watcher"
+      WATCHER_PROD_IMAGE_NAME: "omisego/watcher"
 
 jobs:
   build:
@@ -327,46 +327,30 @@ jobs:
 
       - run: mix dialyzer --format short --halt-exit-status
 
-  release:
-    docker:
-      # Ensure .tool-versions matches
-      - image: omisegoimages/elixir-omg-circleci:v1.8-20190129-02
-        environment:
-          MIX_ENV: dev
-    working_directory: ~/repo
-
-    steps:
-      - attach_workspace:
-           at: .
-      - run: mix local.hex --force
-      - run: mix local.rebar --force
-      - run: MIX_ENV=prod mix release --name watcher --warnings-as-errors --env prod
-      - run: MIX_ENV=prod mix release --name child_chain --warnings-as-errors --env prod
-      - run: MIX_ENV=dev mix release --name watcher --warnings-as-errors --env dev
-      - run: MIX_ENV=dev mix release --name child_chain --warnings-as-errors --env dev
-      - run:
-          name: Collecting Watcher artifacts
-          command: |
-            mkdir -p ci_artifact
-            mv ./_build/prod/rel/watcher/releases/*/watcher.tar.gz ./ci_artifact/prod_watcher.tar.gz
-            mv ./_build/dev/rel/watcher/releases/*/watcher.tar.gz ./ci_artifact/dev_watcher.tar.gz
-            mv ./_build/prod/rel/child_chain/releases/*/child_chain.tar.gz ./ci_artifact/prod_child_chain.tar.gz
-            mv ./_build/dev/rel/child_chain/releases/*/child_chain.tar.gz ./ci_artifact/dev_child_chain.tar.gz
-          when: always
-      - store_artifacts:
-          name: Uploading watcher CI artifacts
-          path: ./ci_artifact
-
-  publish:
-    executor: metal
+  publish_child_chain:
+    executor: metal_child_chain
     steps:
       - checkout
-      - run: make docker IMAGE_NAME=$IMAGE_NAME
-      - run: make docker CHILD_CHAIN_IMAGE_NAME=$CHILD_CHAIN_IMAGE_NAME
-      - notify_slack_failure
-      - notify_slack
+      - run: make docker-child_chain CHILD_CHAIN_IMAGE_NAME=$CHILD_CHAIN_IMAGE_NAME
+      #- notify_slack_failure
+      #- notify_slack
 
-  deploy:
+  publish_watcher:
+    executor: metal_watcher
+    steps:
+      - checkout
+      - run: make docker-watcher WATCHER_PROD_IMAGE_NAME=$WATCHER_PROD_IMAGE_NAME
+      #- notify_slack_failure
+      #- notify_slack
+
+  deploy_watcher:
+    executor: deploy
+    steps:
+      - checkout
+      #- run: sh .circleci/ci_deploy.sh
+      #- notify_slack_failure
+      #- notify_slack_deploy
+  deploy_child_chain:
     executor: deploy
     steps:
       - checkout
@@ -497,19 +481,12 @@ workflows:
           requires:
             - build
             - tests_compile_once
-      - release:
-          requires: [build]
-          filters:
-            branches:
-              only:
-                - master
       - build_and_deploy_development:
           requires:
             - build
             - lint
             - dialyzer
             - test
-            - release
             - child_chain_coveralls_and_integration_tests
             - watcher_coveralls_and_integration_tests
             - common_coveralls_and_integration_tests
@@ -531,7 +508,14 @@ workflows:
               only:
                 - v0.1
       # Publish in case of master branch.
-      - publish:
+      - publish_child_chain:
+          requires: [child_chain_coveralls_and_integration_tests, watcher_coveralls_and_integration_tests, common_coveralls_and_integration_tests, test, dialyzer, lint]
+          filters:
+            branches:
+              only:
+                - master
+                - 579-publish_release_docker
+      - publish_watcher:
           requires: [child_chain_coveralls_and_integration_tests, watcher_coveralls_and_integration_tests, common_coveralls_and_integration_tests, test, dialyzer, lint]
           filters:
             branches:
@@ -539,8 +523,15 @@ workflows:
                 - master
                 - 579-publish_release_docker
       # Release deploy to development in case of master branch.
-      - deploy:
-          requires: [publish]
+      - deploy_child_chain:
+          requires: [publish_child_chain, publish_watcher]
+          filters:
+            branches:
+              only:
+                - master
+                - 579-publish_release_docker
+      - deploy_watcher:
+          requires: [publish_child_chain, publish_watcher]
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,6 +16,16 @@ executors:
           POSTGRES_DB: omisego_dev
     working_directory: ~/src
 
+  builder_pg_geth:
+    docker:
+      - image: omisegoimages/elixir-omg-tester:stable
+      - image: circleci/postgres:9.6-alpine
+        environment:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: omisego_dev
+    working_directory: ~/src
+
   deploy:
     docker:
       - image: omisegoimages/elixir-omg-deploy:stable
@@ -89,7 +99,7 @@ jobs:
       - run: mix do local.hex --force, local.rebar --force, compile --warnings-as-errors --force, ecto.create, ecto.migrate, test --exclude test, credo, format --check-formatted --dry-run
 
   child_chain_coveralls_and_integration_tests:
-    executor: builder_pg
+    executor: builder_pg_geth
     environment:
       DATABASE_URL: postgres://postgres:postgres@localhost:5432/omisego_dev
       MIX_ENV: test
@@ -115,7 +125,7 @@ jobs:
             fi
 
   watcher_coveralls_and_integration_tests:
-    executor: builder_pg
+    executor: builder_pg_geth
     environment:
       DATABASE_URL: postgres://postgres:postgres@localhost:5432/omisego_dev
       MIX_ENV: test
@@ -141,7 +151,7 @@ jobs:
             fi
 
   common_coveralls_and_integration_tests:
-    executor: builder_pg
+    executor: builder_pg_geth
     environment:
       DATABASE_URL: postgres://postgres:postgres@localhost:5432/omisego_dev
       MIX_ENV: test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,11 +1,7 @@
 version: 2.1
 
 executors:
-  child_chain_builder:
-    docker:
-      - image: omisegoimages/elixir-omg-builder:v1.2
-    working_directory: ~/src
-  builder_watcher:
+  builder:
     docker:
       - image: omisegoimages/elixir-omg-builder:v1.2
     working_directory: ~/src
@@ -31,39 +27,20 @@ executors:
     environment:
       WATCHER_PROD_IMAGE_NAME: "omisego/watcher"
 
+commands:
+  setup_elixir-omg_workspace:
+    description: "Setup workspace"
+    steps:
+      - attach_workspace:
+          name: Attach workspace
+          at: .
 jobs:
   build:
-    docker:
-      - image: omisegoimages/elixir-omg-circleci:v1.8-20190129-02
-        environment:
-          DATABASE_URL: postgres://postgres:postgres@localhost:5432/omisego_dev
-      - image: circleci/postgres:9.6-alpine
-        environment:
-          POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: postgres
-          POSTGRES_DB: omisego_dev
-    working_directory: ~/repo
+    executor: builder
     steps:
       - checkout
-      - setup_remote_docker
-      # - restore_cache:
-      #     keys:
-      #       - v1-mix-cache-{{ checksum "mix.lock" }}
-      - run:
-          name: Install Hex
-          command: |
-            mix do local.hex --force, local.rebar --force
-      - run:
-          name: Get Dependencies
-          command: |
-            export ERLANG_ROCKSDB_BUILDOPTS='-j 2'
-            mix do deps.get, deps.compile
-      # - save_cache:
-      #     key: v1-mix-cache-{{ checksum "mix.lock" }}
-      #     paths: "deps"
-      - run:
-          name: Compile
-          command: mix compile
+      - run: make deps-elixir-omg
+      - run: make build-test
       - persist_to_workspace:
           root: .
           paths:
@@ -88,21 +65,9 @@ jobs:
             - rel/
 
   lint:
-    docker:
-      - image: omisegoimages/elixir-omg-circleci:v1.8-20190129-02
-        environment:
-          DATABASE_URL: postgres://postgres:postgres@localhost:5432/omisego_dev
-      - image: circleci/postgres:9.6-alpine
-        environment:
-          POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: postgres
-          POSTGRES_DB: omisego_dev
-          MIX_ENV: test
-    working_directory: ~/repo
-
+    executor: builder_pg
     steps:
-      - attach_workspace:
-           at: .
+      - setup_elixir-omg_workspace
       - run: MIX_ENV=test mix do local.hex --force, local.rebar --force, compile --warnings-as-errors --force, test --exclude test, credo, format --check-formatted --dry-run
 
   tests_compile_once:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,12 +3,12 @@ version: 2.1
 executors:
   builder:
     docker:
-      - image: omisegoimages/elixir-omg-builder:v1.2
+      - image: omisegoimages/elixir-omg-builder:v1.3
     working_directory: ~/src
 
   builder_pg:
     docker:
-      - image: omisegoimages/elixir-omg-builder:v1.2
+      - image: omisegoimages/elixir-omg-builder:v1.3
       - image: postgres:9.6-alpine
     working_directory: ~/src
 

--- a/.gitignore
+++ b/.gitignore
@@ -25,8 +25,6 @@ erl_crash.dump
 # Dev sqllite db
 *ecto_simple.sqlite3*
 
-Makefile
-
 # Developers config file
 your_config_file.exs
 

--- a/Dockerfile.child_chain
+++ b/Dockerfile.child_chain
@@ -24,14 +24,6 @@ RUN set -xe \
 
 ## Application
 ##
-ARG solc
-
-RUN if [ ${solc} = "yes" ] ; then \
-       wget https://github.com/ethereum/solidity/releases/download/v0.4.25/solc-static-linux &&\
-       chmod +x solc-static-linux &&\
-       mv solc-static-linux /bin/solc &&\
-       chmod 755 /bin/solc ; else echo "Not installing solc." \
-; fi
 
 RUN apk add --update --no-cache --virtual .child_chain-runtime \
         bash \
@@ -56,7 +48,7 @@ RUN set -xe \
 
 ARG release_version
 
-ADD _build/prod/rel/child_chain/releases/${release_version}/child_chain.tar.gz /app
+ADD $(_build/prod/rel/child_chain/releases/${release_version}/child_chain.tar.gz | sed 's/"//g') /app
 RUN chown -R "${uid}:${gid}" /app
 WORKDIR /app
 

--- a/Dockerfile.child_chain
+++ b/Dockerfile.child_chain
@@ -48,7 +48,7 @@ RUN set -xe \
 
 ARG release_version
 
-ADD $(_build/prod/rel/child_chain/releases/${release_version}/child_chain.tar.gz | sed 's/"//g') /app
+ADD _build/prod/rel/child_chain/releases/${release_version}/child_chain.tar.gz /app
 RUN chown -R "${uid}:${gid}" /app
 WORKDIR /app
 

--- a/Dockerfile.child_chain
+++ b/Dockerfile.child_chain
@@ -1,0 +1,67 @@
+FROM alpine:3.8
+
+LABEL maintainer="OmiseGO Team <omg@omise.co>"
+LABEL description="Official image for OmiseGO (Watcher) Plasma Network"
+
+ENV LANG=C.UTF-8
+
+## S6
+##
+
+ENV S6_VERSION="1.21.4.0"
+
+RUN set -xe \
+ && apk add --update --no-cache --virtual .fetch-deps \
+        curl \
+        ca-certificates \
+ && S6_DOWNLOAD_URL="https://github.com/just-containers/s6-overlay/releases/download/v${S6_VERSION}/s6-overlay-amd64.tar.gz" \
+ && S6_DOWNLOAD_SHA256="e903f138dea67e75afc0f61e79eba529212b311dc83accc1e18a449d58a2b10c" \
+ && curl -fsL -o s6-overlay.tar.gz "${S6_DOWNLOAD_URL}" \
+ && echo "${S6_DOWNLOAD_SHA256}  s6-overlay.tar.gz" |sha256sum -c - \
+ && tar -xzC / -f s6-overlay.tar.gz \
+ && rm s6-overlay.tar.gz \
+ && apk del .fetch-deps
+
+## Application
+##
+
+RUN apk add --update --no-cache --virtual .child_chain-runtime \
+        bash \
+        libressl \
+        libressl-dev \
+        lksctp-tools
+
+COPY rootfs /
+
+# USER directive is not being used here since privileges are dropped via
+# s6-setuigid in /entrypoint. s6-overlay is required to be run as root.
+ARG user=child_chain
+ARG group=child_chain
+ARG uid=10000
+ARG gid=10000
+
+RUN set -xe \
+ && addgroup -g ${gid} ${group} \
+ && adduser -D -h /app -u ${uid} -G ${group} ${user} \
+ && chown "${uid}:${gid}" "/app" \
+ && chmod +x /child_chain_entrypoint
+
+ARG release_version
+
+ADD _build/prod/rel/watcher/releases/${release_version}/watcher.tar.gz /app
+RUN chown -R "${uid}:${gid}" /app
+WORKDIR /app
+
+# Child Chain app is using PORT environment variable to determine which port to run
+# the application server.
+ENV PORT 9656
+
+EXPOSE $PORT
+
+# These are ports required for clustering. The range is defined in vm.args
+# in inet_dist_listen_min and inet_dist_listen_max.
+#EXPOSE 4369 6900 6901 6902 6903 6904 6905 6906 6907 6908 6909
+
+ENTRYPOINT ["/init", "/entrypoint"]
+
+CMD ["foreground"]

--- a/Dockerfile.child_chain
+++ b/Dockerfile.child_chain
@@ -24,6 +24,14 @@ RUN set -xe \
 
 ## Application
 ##
+ARG solc
+
+RUN if [ ${solc} = "yes" ] ; then \
+       wget https://github.com/ethereum/solidity/releases/download/v0.4.25/solc-static-linux &&\
+       chmod +x solc-static-linux &&\
+       mv solc-static-linux /bin/solc &&\
+       chmod 755 /bin/solc ; else echo "Not installing solc." \
+; fi
 
 RUN apk add --update --no-cache --virtual .child_chain-runtime \
         bash \
@@ -48,7 +56,7 @@ RUN set -xe \
 
 ARG release_version
 
-ADD _build/prod/rel/watcher/releases/${release_version}/watcher.tar.gz /app
+ADD _build/prod/rel/child_chain/releases/${release_version}/child_chain.tar.gz /app
 RUN chown -R "${uid}:${gid}" /app
 WORKDIR /app
 

--- a/Dockerfile.watcher
+++ b/Dockerfile.watcher
@@ -25,6 +25,15 @@ RUN set -xe \
 ## Application
 ##
 
+ARG solc
+
+RUN if [ ${solc} = "yes" ] ; then \
+       wget https://github.com/ethereum/solidity/releases/download/v0.4.25/solc-static-linux &&\
+       chmod +x solc-static-linux &&\
+       mv solc-static-linux /bin/solc &&\
+       chmod 755 /bin/solc ; else echo "Not installing solc." \
+; fi
+
 RUN apk add --update --no-cache --virtual .watcher-runtime \
         bash \
         libressl \

--- a/Dockerfile.watcher
+++ b/Dockerfile.watcher
@@ -1,0 +1,67 @@
+FROM alpine:3.8
+
+LABEL maintainer="OmiseGO Team <omg@omise.co>"
+LABEL description="Official image for OmiseGO (Watcher) Plasma Network"
+
+ENV LANG=C.UTF-8
+
+## S6
+##
+
+ENV S6_VERSION="1.21.4.0"
+
+RUN set -xe \
+ && apk add --update --no-cache --virtual .fetch-deps \
+        curl \
+        ca-certificates \
+ && S6_DOWNLOAD_URL="https://github.com/just-containers/s6-overlay/releases/download/v${S6_VERSION}/s6-overlay-amd64.tar.gz" \
+ && S6_DOWNLOAD_SHA256="e903f138dea67e75afc0f61e79eba529212b311dc83accc1e18a449d58a2b10c" \
+ && curl -fsL -o s6-overlay.tar.gz "${S6_DOWNLOAD_URL}" \
+ && echo "${S6_DOWNLOAD_SHA256}  s6-overlay.tar.gz" |sha256sum -c - \
+ && tar -xzC / -f s6-overlay.tar.gz \
+ && rm s6-overlay.tar.gz \
+ && apk del .fetch-deps
+
+## Application
+##
+
+RUN apk add --update --no-cache --virtual .watcher-runtime \
+        bash \
+        libressl \
+        libressl-dev \
+        lksctp-tools
+
+COPY rootfs /
+
+# USER directive is not being used here since privileges are dropped via
+# s6-setuigid in /entrypoint. s6-overlay is required to be run as root.
+ARG user=watcher
+ARG group=watcher
+ARG uid=10000
+ARG gid=10000
+
+RUN set -xe \
+ && addgroup -g ${gid} ${group} \
+ && adduser -D -h /app -u ${uid} -G ${group} ${user} \
+ && chown "${uid}:${gid}" "/app" \
+ && chmod +x /watcher_entrypoint
+
+ARG release_version
+
+ADD _build/prod/rel/watcher/releases/${release_version}/watcher.tar.gz /app
+RUN chown -R "${uid}:${gid}" /app
+WORKDIR /app
+
+# Watcher app is using PORT environment variable to determine which port to run
+# the application server.
+ENV PORT 7434
+
+EXPOSE $PORT
+
+# These are ports required for clustering. The range is defined in vm.args
+# in inet_dist_listen_min and inet_dist_listen_max.
+#EXPOSE 4369 6900 6901 6902 6903 6904 6905 6906 6907 6908 6909
+
+ENTRYPOINT ["/init", "/entrypoint"]
+
+CMD ["foreground"]

--- a/Dockerfile.watcher
+++ b/Dockerfile.watcher
@@ -25,15 +25,6 @@ RUN set -xe \
 ## Application
 ##
 
-ARG solc
-
-RUN if [ ${solc} = "yes" ] ; then \
-       wget https://github.com/ethereum/solidity/releases/download/v0.4.25/solc-static-linux &&\
-       chmod +x solc-static-linux &&\
-       mv solc-static-linux /bin/solc &&\
-       chmod 755 /bin/solc ; else echo "Not installing solc." \
-; fi
-
 RUN apk add --update --no-cache --virtual .watcher-runtime \
         bash \
         libressl \
@@ -57,7 +48,7 @@ RUN set -xe \
 
 ARG release_version
 
-ADD _build/prod/rel/watcher/releases/${release_version}/watcher.tar.gz /app
+ADD $(_build/prod/rel/watcher/releases/"${release_version//\"}"/watcher.tar.gz | sed 's/"//g') /app
 RUN chown -R "${uid}:${gid}" /app
 WORKDIR /app
 

--- a/Dockerfile.watcher
+++ b/Dockerfile.watcher
@@ -48,7 +48,7 @@ RUN set -xe \
 
 ARG release_version
 
-ADD $(_build/prod/rel/watcher/releases/"${release_version//\"}"/watcher.tar.gz | sed 's/"//g') /app
+ADD _build/prod/rel/watcher/releases/0.2.0/watcher.tar.gz /app
 RUN chown -R "${uid}:${gid}" /app
 WORKDIR /app
 

--- a/Makefile
+++ b/Makefile
@@ -108,14 +108,14 @@ docker-watcher-prod:
 
 docker-child_chain-build-prod:
 	docker build -f Dockerfile.child_chain \
-		--build-arg release_version=$$(awk '/umbrella_version, do:/ { gsub(/[^0-9a-z\.\-]+/, "", $$2); print $$4 }' $(PWD)/mix.exs) \
+		--build-arg release_version=$$(awk '/umbrella_version, do: "/ { gsub(/"/, ""); print $$4 }' $(PWD)/mix.exs) \
 		--cache-from $(CHILD_CHAIN_PROD_IMAGE_NAME) \
 		-t $(CHILD_CHAIN_PROD_IMAGE_NAME) \
 		.
 
 docker-watcher-build-prod:
 	docker build -f Dockerfile.watcher \
-		--build-arg release_version=$$(awk '/umbrella_version, do:/ { gsub(/[^0-9a-z\.\-]+/, "", $$2); print $$4 }' $(PWD)/mix.exs) \
+		--build-arg release_version=$$(awk '/umbrella_version, do: "/ { gsub(/"/, ""); print $$4 }' $(PWD)/mix.exs) \
 		--cache-from $(WATCHER_PROD_IMAGE_NAME) \
 		-t $(WATCHER_PROD_IMAGE_NAME) \
 		.

--- a/Makefile
+++ b/Makefile
@@ -57,16 +57,16 @@ check-dialyzer:
 
 
 build-child_chain-prod: deps-elixir-omg
-	$(ENV_PROD) mix do compile, release --name child_chain
+	$(ENV_PROD) mix do compile, release --name child_chain --verbose
 
 build-child_chain-dev: deps-elixir-omg
-	$(ENV_DEV) mix do compile, release dev --name child_chain
+	$(ENV_DEV) mix do compile, release dev --name child_chain --verbose
 
 build-watcher-prod: deps-elixir-omg
-	$(ENV_PROD) mix do compile, release --name watcher
+	$(ENV_PROD) mix do compile, release --name watcher --verbose
 
 build-watcher-dev: deps-elixir-omg
-	$(ENV_DEV) mix do compile, release dev --name watcher
+	$(ENV_DEV) mix do compile, release dev --name watcher --verbose
 
 build-test: deps-elixir-omg
 	$(ENV_TEST) mix compile

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,128 @@
+all: clean build-child_chain-prod build-watcher-prod
+
+WATCHER_IMAGE_NAME      ?= "omisego/watcher:latest"
+CHILD_CHAIN_IMAGE_NAME      ?= "omisego/child_chain:latest"
+IMAGE_BUILDER   ?= "omisegoimages/elixir-omg-builder:v1.2"
+IMAGE_BUILD_DIR ?= $(PWD)
+
+ENV_DEV         ?= env MIX_ENV=dev
+ENV_TEST        ?= env MIX_ENV=test
+ENV_PROD        ?= env MIX_ENV=prod
+
+#
+# Setting-up
+#
+
+deps: deps-elixir-omg
+
+deps-elixir-omg:
+	mix deps.get
+
+.PHONY: deps deps-elixir-omg
+
+#
+# Cleaning
+#
+
+clean: clean-elixir-omg
+
+clean-elixir-omg:
+	rm -rf _build/
+	rm -rf deps/
+
+
+.PHONY: clean clean-elixir-omg
+
+#
+# Linting
+#
+
+format:
+	mix format
+
+check-format:
+	mix format --check-formatted 2>&1
+
+check-credo:
+	$(ENV_TEST) mix credo 2>&1
+
+check-dialyzer:
+	$(ENV_TEST) mix dialyzer --halt-exit-status 2>&1
+
+.PHONY: format check-format check-credo
+
+#
+# Building
+#
+
+
+build-child_chain-prod: deps-elixir-omg
+	$(ENV_PROD) mix do compile, release --name child_chain
+
+build-child_chain-dev: deps-elixir-omg
+	$(ENV_DEV) mix do compile, release dev --name child_chain
+
+build-watcher-prod: deps-elixir-omg
+	$(ENV_PROD) mix do compile, release --name watcher
+
+build-watcher-dev: deps-elixir-omg
+	$(ENV_DEV) mix do compile, release dev --name watcher
+
+build-test: deps-elixir-omg
+	$(ENV_TEST) mix compile
+
+.PHONY: build-prod build-dev build-test
+
+#
+# Testing
+#
+
+test: test-elixir-omg
+
+test-elixir-omg-watcher: build-test
+	$(ENV_TEST) mix test
+
+.PHONY: test test-elixir-omg
+
+#
+# Docker
+#
+
+docker-child_chain-prod:
+	docker run --rm -it \
+		-v $(PWD):/app \
+		-v $(IMAGE_BUILD_DIR)/deps:/app/deps \
+		-u root \
+		--entrypoint /bin/sh \
+		$(CHILD_CHAIN_IMAGE_NAME) \
+		-c "cd /app && make build-child_chain-prod"
+
+docker-watcher-prod:
+	docker run --rm -it \
+		-v $(PWD):/app \
+		-v $(IMAGE_BUILD_DIR)/deps:/app/deps \
+		-u root \
+		--entrypoint /bin/sh \
+		$(WATCHER_IMAGE_NAME) \
+		-c "cd /app && make build-watcher-prod"
+
+docker-child_chain-build:
+	docker build -f Dockerfile.child_chain \
+		--build-arg release_version=$$(awk '/umbrella_version:/ { gsub(/[^0-9a-z\.\-]+/, "", $$2); print $$2 }' $(PWD)/mix.exs) \
+		--cache-from $(CHILD_CHAIN_IMAGE_NAME) \
+		-t $(CHILD_CHAIN_IMAGE_NAME) \
+		.
+docker-watcher-build:
+	docker build -f Dockerfile.watcher \
+		--build-arg release_version=$$(awk '/umbrella_version:/ { gsub(/[^0-9a-z\.\-]+/, "", $$2); print $$2 }' $(PWD)/mix.exs) \
+		--cache-from $(WATCHER_IMAGE_NAME) \
+		-t $(WATCHER_IMAGE_NAME) \
+		.
+
+docker: docker-child_chain-prod docker-child_chain-build docker-wacher-prod docker-watcher-build
+
+docker-push: docker
+	docker push $(CHILD_CHAIN_IMAGE_NAME)
+	docker push $(WATCHER_IMAGE_NAME)
+
+.PHONY: docker docker-child_chain-prod docker-child_chain-build docker-watcher-prod docker-watcher-build docker-push

--- a/Makefile
+++ b/Makefile
@@ -79,9 +79,6 @@ build-test: deps-elixir-omg
 
 test: test-elixir-omg
 
-test-elixir-omg-watcher: build-test
-	$(ENV_TEST) mix test
-
 .PHONY: test test-elixir-omg
 
 #

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ all: clean build-child_chain-prod build-watcher-prod
 
 WATCHER_PROD_IMAGE_NAME      ?= "omisego/watcher:latest"
 CHILD_CHAIN_PROD_IMAGE_NAME      ?= "omisego/child_chain:latest"
-IMAGE_BUILDER   ?= "omisegoimages/elixir-omg-builder:v1.2"
+IMAGE_BUILDER   ?= "omisegoimages/elixir-omg-builder:v1.3"
 IMAGE_BUILD_DIR ?= $(PWD)
 
 ENV_DEV         ?= env MIX_ENV=dev

--- a/apps/omg_child_chain/config/dev.exs
+++ b/apps/omg_child_chain/config/dev.exs
@@ -3,5 +3,4 @@ use Mix.Config
 
 config :omg_child_chain,
   ethereum_events_check_interval_ms: 500,
-  block_queue_eth_height_check_interval_ms: 1_000,
-  coordinator_eth_height_check_interval_ms: 1_000
+  block_queue_eth_height_check_interval_ms: 1_000

--- a/mix.exs
+++ b/mix.exs
@@ -10,6 +10,8 @@ defmodule OMG.Umbrella.MixProject do
       deps: deps(),
       preferred_cli_env: [
         coveralls: :test,
+        "coveralls.detail": :test,
+        "coveralls.html": :test,
         "coveralls.circle": :test,
         dialyzer: :test
       ],

--- a/mix.exs
+++ b/mix.exs
@@ -10,9 +10,7 @@ defmodule OMG.Umbrella.MixProject do
       deps: deps(),
       preferred_cli_env: [
         coveralls: :test,
-        "coveralls.detail": :test,
-        "coveralls.post": :test,
-        "coveralls.html": :test,
+        "coveralls.circle": :test,
         dialyzer: :test
       ],
       dialyzer: dialyzer(),

--- a/rootfs/child_chain_entrypoint
+++ b/rootfs/child_chain_entrypoint
@@ -1,0 +1,67 @@
+#!/bin/execlineb -S0
+
+with-contenv
+cd /app
+s6-setuidgid child_chain
+
+## NODE_HOST
+##
+## Used in clustering; combine with an app name, this is used for identifying
+## and connecting each nodes. By default use the container hostname.
+##
+backtick -n default_host { s6-hostname }
+importas -iu default_host default_host
+importas -D $default_host NODE_HOST NODE_HOST
+s6-env NODE_HOST=$NODE_HOST
+
+## ERLANG_COOKIE
+##
+## Used in clustering; all nodes in the cluster is required to have the same
+## Erlang Cookie set. Randomly generated default cookie is only useful for
+## the single instance scenario.
+##
+backtick -n default_cookie {
+    pipeline {
+        s6-head -c 6 /dev/urandom
+    } foreground { base64 }
+}
+
+importas -iu default_cookie default_cookie
+importas -D $default_cookie ERLANG_COOKIE ERLANG_COOKIE
+s6-env ERLANG_COOKIE=$ERLANG_COOKIE
+
+## HOME
+##
+## Home is required to be set since some tools use it to create e.g. cache.
+## By default Child Chain will run with a limited privileges so HOME need to be
+## somewhere writable.
+##
+s6-env HOME=/app
+
+## REPLACE_OS_VARS
+##
+## Used by Distillery to replace environment variables in settings to the
+## value of environment variable.
+##
+s6-env REPLACE_OS_VARS=yes
+
+## Known commands
+##
+ifelse { test $1 == "init_key_value_db" } { /app/bin/child_chain $@ }
+
+ifelse { test $1 == "foreground" } {
+  importas -D true SERVE_ENDPOINTS SERVE_ENDPOINTS
+  s6-env SERVE_ENDPOINTS=$SERVE_ENDPOINTS
+  /app/bin/child_chain $@
+}
+
+ifelse { test $1 == "console" } {
+  importas -D false SERVE_ENDPOINTS SERVE_ENDPOINTS
+  s6-env SERVE_ENDPOINTS=$SERVE_ENDPOINTS
+  /app/bin/child_chain $@
+}
+
+## Fallback; if we're not running the known command, just run it as is.
+## This is to allow e.g. administrator attaching a shell into the container.
+##
+exec $@

--- a/rootfs/watcher_entrypoint
+++ b/rootfs/watcher_entrypoint
@@ -1,0 +1,68 @@
+#!/bin/execlineb -S0
+
+with-contenv
+cd /app
+s6-setuidgid watcher
+
+## NODE_HOST
+##
+## Used in clustering; combine with an app name, this is used for identifying
+## and connecting each nodes. By default use the container hostname.
+##
+backtick -n default_host { s6-hostname }
+importas -iu default_host default_host
+importas -D $default_host NODE_HOST NODE_HOST
+s6-env NODE_HOST=$NODE_HOST
+
+## ERLANG_COOKIE
+##
+## Used in clustering; all nodes in the cluster is required to have the same
+## Erlang Cookie set. Randomly generated default cookie is only useful for
+## the single instance scenario.
+##
+backtick -n default_cookie {
+    pipeline {
+        s6-head -c 6 /dev/urandom
+    } foreground { base64 }
+}
+
+importas -iu default_cookie default_cookie
+importas -D $default_cookie ERLANG_COOKIE ERLANG_COOKIE
+s6-env ERLANG_COOKIE=$ERLANG_COOKIE
+
+## HOME
+##
+## Home is required to be set since some tools use it to create e.g. cache.
+## By default Watcher will run with a limited privileges so HOME need to be
+## somewhere writable.
+##
+s6-env HOME=/app
+
+## REPLACE_OS_VARS
+##
+## Used by Distillery to replace environment variables in settings to the
+## value of environment variable.
+##
+s6-env REPLACE_OS_VARS=yes
+
+## Known commands
+##
+ifelse { test $1 == "init_key_value_db" } { /app/bin/watcher $@ }
+ifelse { test $1 == "init_postgresql_db" } { /app/bin/watcher $@ }
+
+ifelse { test $1 == "foreground" } {
+  importas -D true SERVE_ENDPOINTS SERVE_ENDPOINTS
+  s6-env SERVE_ENDPOINTS=$SERVE_ENDPOINTS
+  /app/bin/watcher $@
+}
+
+ifelse { test $1 == "console" } {
+  importas -D false SERVE_ENDPOINTS SERVE_ENDPOINTS
+  s6-env SERVE_ENDPOINTS=$SERVE_ENDPOINTS
+  /app/bin/watcher $@
+}
+
+## Fallback; if we're not running the known command, just run it as is.
+## This is to allow e.g. administrator attaching a shell into the container.
+##
+exec $@


### PR DESCRIPTION
This is part 1 of work that needs to be done to move our deployment towards OTP releases.
All images are based on Alpine 3.8 - https://github.com/omisego-images/docker-elixir-omg
Integration tests run towards custom alpine with geth and solc. It would be good to move away from this model though.

Processes and flows have been adjusted in a way similar to eWallet... thanks @sirn !!! But with separate repositories so that we're not coupled with their work.

