### PR TITLE
docs: clarify the confusing bit about socket route for watcher channels

### DIFF
--- a/apps/omg_watcher/lib/omg_watcher/web/endpoint.ex
+++ b/apps/omg_watcher/lib/omg_watcher/web/endpoint.ex
@@ -16,7 +16,8 @@ defmodule OMG.Watcher.Web.Endpoint do
   use Phoenix.Endpoint, otp_app: :omg_watcher
   use Appsignal.Phoenix
 
-  socket("/socket", OMG.Watcher.Web.Socket, websocket: [])
+  # NOTE: one connects to `ws://host:port/socket/websocket` here (the transport is appended)
+  socket("/socket", OMG.Watcher.Web.Socket, websocket: true)
 
   # Serve at "/" the static files from "priv/static" directory.
   #

--- a/docs/api_specs/watcher_websocket_specs.md
+++ b/docs/api_specs/watcher_websocket_specs.md
@@ -3,7 +3,8 @@
 
 <aside class="warning">TODO Explanation of the WebSocket/ Phoenix Channels mechanism used to receive events</aside>
 
-Exposed via websockets using [Phoenix channels](https://hexdocs.pm/phoenix/channels.html).
+Exposed via websockets using [Phoenix channels](https://hexdocs.pm/phoenix/channels.html) on `ws://host:port/socket/websocket`.
+
 Different events are emitted for each topic.
 
 There are the following topics:


### PR DESCRIPTION
I wasted some time on this, the docs on this are a bit concealed in `Phoenix.Channels` or just my bad luck. Deciding to leave some docs on our side as well