### PR TITLE
refactor: move configuration to env

### DIFF
--- a/apps/omg/config/config.exs
+++ b/apps/omg/config/config.exs
@@ -4,8 +4,9 @@ use Mix.Config
 
 config :omg,
   deposit_finality_margin: 10,
-  ethereum_events_check_interval_ms: 500,
-  coordinator_eth_height_check_interval_ms: 6_000,
+  ethereum_events_check_interval_ms: {:system, "ETHEREUM_EVENTS_CHECK_INTERVAL_MS", 500, {String, :to_integer}},
+  coordinator_eth_height_check_interval_ms:
+    {:system, "COORDINATOR_ETH_HEIGHT_CHECK_INTERVAL_MS", 1_000, {String, :to_integer}},
   client_monitor_interval_ms: 500
 
 config :omg, :eip_712_domain,

--- a/apps/omg/config/dev.exs
+++ b/apps/omg/config/dev.exs
@@ -1,7 +1,2 @@
-# dev config necessary to load project in iex
+# Intentionally blank!
 use Mix.Config
-
-config :omg,
-  ethereum_events_check_interval_ms: 500,
-  coordinator_eth_height_check_interval_ms: 1_000,
-  loggers: [Appsignal.Ecto, Ecto.LogEntry]

--- a/apps/omg/config/prod.exs
+++ b/apps/omg/config/prod.exs
@@ -1,1 +1,2 @@
+# Intentionally blank!
 use Mix.Config

--- a/apps/omg_child_chain/config/config.exs
+++ b/apps/omg_child_chain/config/config.exs
@@ -4,7 +4,8 @@ use Mix.Config
 
 config :omg_child_chain,
   submission_finality_margin: 20,
-  block_queue_eth_height_check_interval_ms: 6_000,
+  block_queue_eth_height_check_interval_ms:
+    {:system, "BLOCK_QUEUE_ETH_HEIGHT_CHECK_INTERVAL_MS", 1_000, {String, :to_integer}},
   child_block_minimal_enqueue_gap: 1,
   fee_specs_file_name: "fee_specs.json",
   ignore_fees: false

--- a/apps/omg_child_chain/config/dev.exs
+++ b/apps/omg_child_chain/config/dev.exs
@@ -1,8 +1,2 @@
-# dev config necessary to load project in iex
+# Intentionally blank!
 use Mix.Config
-
-config :omg_child_chain,
-  ethereum_events_check_interval_ms: 500,
-  block_queue_eth_height_check_interval_ms: 1_000,
-  coordinator_eth_height_check_interval_ms: 1_000,
-  loggers: [Appsignal.Ecto, Ecto.LogEntry]

--- a/apps/omg_eth/config/config.exs
+++ b/apps/omg_eth/config/config.exs
@@ -16,7 +16,7 @@ config :omg_eth,
   eth_node: {:system, "ETH_NODE", "geth"},
   node_logging_in_debug: true,
   child_block_interval: 1000,
-  exit_period_seconds: {:system, "EXIT_PERIOD_SECONDS", 7 * 24 * 60 * 60, {String, :to_integer}},
+  exit_period_seconds: {:system, "EXIT_PERIOD_SECONDS", 4 * 60, {String, :to_integer}},
   ethereum_client_warning_time_ms: ethereum_client_timeout_ms / 4
 
 import_config "#{Mix.env()}.exs"

--- a/apps/omg_eth/config/dev.exs
+++ b/apps/omg_eth/config/dev.exs
@@ -1,8 +1,2 @@
+# Intentionally blank!
 use Mix.Config
-
-# bumping because otherwise import/unlock of accounts will fail in some of use cases (perf tests)
-config :ethereumex,
-  http_options: [recv_timeout: 60_000]
-
-config :omg_eth,
-  exit_period_seconds: {:system, "EXIT_PERIOD_SECONDS", 4 * 60, {String, :to_integer}}

--- a/apps/omg_eth/config/prod.exs
+++ b/apps/omg_eth/config/prod.exs
@@ -1,1 +1,2 @@
+# Intentionally blank!
 use Mix.Config

--- a/apps/omg_watcher/config/dev.exs
+++ b/apps/omg_watcher/config/dev.exs
@@ -47,5 +47,4 @@ config :omg_watcher, OMG.Watcher.DB.Repo,
   adapter: Ecto.Adapters.Postgres,
   pool_size: 10,
   # DATABASE_URL format is following `postgres://{user_name}:{password}@{host:port}/{database_name}`
-  url: {:system, "DATABASE_URL", "postgres://omisego_dev:omisego_dev@localhost/omisego_dev"},
-  loggers: [Appsignal.Ecto, Ecto.LogEntry]
+  url: {:system, "DATABASE_URL", "postgres://omisego_dev:omisego_dev@localhost/omisego_dev"}

--- a/apps/omg_watcher/config/prod.exs
+++ b/apps/omg_watcher/config/prod.exs
@@ -24,8 +24,7 @@ config :omg_watcher, OMG.Watcher.Web.Endpoint,
 config :omg_watcher, OMG.Watcher.DB.Repo,
   adapter: Ecto.Adapters.Postgres,
   # DATABASE_URL format is following `postgres://{user_name}:{password}@{host:port}/{database_name}`
-  url: {:system, "DATABASE_URL", ""},
-  loggers: [Appsignal.Ecto, Ecto.LogEntry]
+  url: {:system, "DATABASE_URL", ""}
 
 config :omg_watcher, environment: :prod
 

--- a/docker-compose-non-mac.yml
+++ b/docker-compose-non-mac.yml
@@ -37,6 +37,9 @@ services:
       - ETHEREUM_RPC_URL=http://localhost:8545
       - CHILD_CHAIN_URL=http://localhost:9656
       - ETHEREUM_NETWORK=LOCALCHAIN
+      - ETHEREUM_EVENTS_CHECK_INTERVAL_MS: 500
+      - COORDINATOR_ETH_HEIGHT_CHECK_INTERVAL_MS: 1000
+      - BLOCK_QUEUE_ETH_HEIGHT_CHECK_INTERVAL_MS: 1000
     restart: always
     ports:
       - "9656:9656"
@@ -63,6 +66,8 @@ services:
       - CHILD_CHAIN_URL=http://localhost:9656
       - ETHEREUM_NETWORK=LOCALCHAIN
       - DATABASE_URL=postgres://omisego_dev:omisego_dev@localhost:5433/omisego_dev
+      - ETHEREUM_EVENTS_CHECK_INTERVAL_MS: 500
+      - COORDINATOR_ETH_HEIGHT_CHECK_INTERVAL_MS: 1000
     restart: always
     ports:
       - "7434:7434"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,6 +54,10 @@ services:
       - ETHEREUM_RPC_URL=http://docker.for.mac.localhost:8545
       - CHILD_CHAIN_URL=http://docker.for.mac.localhost:9656
       - ETHEREUM_NETWORK=LOCALCHAIN
+      - ETHEREUM_EVENTS_CHECK_INTERVAL_MS: 500
+      - COORDINATOR_ETH_HEIGHT_CHECK_INTERVAL_MS: 1000
+      - BLOCK_QUEUE_ETH_HEIGHT_CHECK_INTERVAL_MS: 1000
+      - ERL_CC_COOKIE: PLASMA
     restart: always
     ports:
       - "9656:9656"
@@ -79,6 +83,9 @@ services:
       - CHILD_CHAIN_URL=http://docker.for.mac.localhost:9656
       - ETHEREUM_NETWORK=LOCALCHAIN
       - DATABASE_URL=postgres://omisego_dev:omisego_dev@docker.for.mac.localhost:5433/omisego_dev
+      - ETHEREUM_EVENTS_CHECK_INTERVAL_MS: 500
+      - COORDINATOR_ETH_HEIGHT_CHECK_INTERVAL_MS: 1000
+      - ERL_W_COOKIE: PLASMA
     restart: always
     ports:
       - "7434:7434"


### PR DESCRIPTION
This would simplify the release process because we would create only one MIX_ENV=prod release and control that release with environment specific variables.

The fallback values are from *dev*.
