### PR TITLE
Refactor ExitProcessor.Core (tidy exit processor pt4)

### DIFF
--- a/apps/omg_watcher/lib/omg_watcher/exit_processor.ex
+++ b/apps/omg_watcher/lib/omg_watcher/exit_processor.ex
@@ -404,17 +404,19 @@ defmodule OMG.Watcher.ExitProcessor do
   # based on in-flight exiting transactions, updates the state with witnesses of those transactions' inclusions in block
   @spec update_with_ife_txs_from_blocks(Core.t()) :: Core.t()
   defp update_with_ife_txs_from_blocks(state) do
-    %ExitProcessor.Request{}
-    |> run_status_gets()
-    # To find if IFE was included, see first if its inputs were spent.
-    |> Core.determine_ife_input_utxos_existence_to_get(state)
-    |> get_ife_input_utxo_existence()
-    # Next, check by what transactions they were spent.
-    |> Core.determine_ife_spends_to_get(state)
-    |> get_ife_input_spending_blocks()
+    prepared_request =
+      %ExitProcessor.Request{}
+      |> run_status_gets()
+      # To find if IFE was included, see first if its inputs were spent.
+      |> Core.determine_ife_input_utxos_existence_to_get(state)
+      |> get_ife_input_utxo_existence()
+      # Next, check by what transactions they were spent.
+      |> Core.determine_ife_spends_to_get(state)
+      |> get_ife_input_spending_blocks()
+
     # Compare found txes with ife.tx.
     # If equal, persist information about position.
-    |> Core.find_ifes_in_blocks(state)
+    Core.find_ifes_in_blocks(state, prepared_request)
   end
 
   defp run_status_gets(%ExitProcessor.Request{} = request) do

--- a/apps/omg_watcher/lib/omg_watcher/exit_processor/competitor_info.ex
+++ b/apps/omg_watcher/lib/omg_watcher/exit_processor/competitor_info.ex
@@ -72,7 +72,10 @@ defmodule OMG.Watcher.ExitProcessor.CompetitorInfo do
     {tx_hash, struct!(__MODULE__, competitor_map)}
   end
 
-  def new(tx_bytes, competing_input_index, competing_input_signature) do
+  def new(%{call_data: %{competing_tx: tx_bytes, competing_tx_input_index: index, competing_tx_sig: sig}}),
+    do: do_new(tx_bytes, index, sig)
+
+  defp do_new(tx_bytes, competing_input_index, competing_input_signature) do
     with {:ok, %Transaction{} = raw_tx} <- Transaction.decode(tx_bytes) do
       {Transaction.raw_txhash(raw_tx),
        %__MODULE__{

--- a/apps/omg_watcher/lib/omg_watcher/exit_processor/core.ex
+++ b/apps/omg_watcher/lib/omg_watcher/exit_processor/core.ex
@@ -941,8 +941,8 @@ defmodule OMG.Watcher.ExitProcessor.Core do
   Note: this change is not persisted later!
   """
   def find_ifes_in_blocks(
-        %ExitProcessor.Request{ife_input_spending_blocks_result: blocks},
-        %__MODULE__{in_flight_exits: ifes} = state
+        %__MODULE__{in_flight_exits: ifes} = state,
+        %ExitProcessor.Request{ife_input_spending_blocks_result: blocks}
       ) do
     updated_ifes =
       ifes

--- a/apps/omg_watcher/lib/omg_watcher/exit_processor/core.ex
+++ b/apps/omg_watcher/lib/omg_watcher/exit_processor/core.ex
@@ -158,83 +158,13 @@ defmodule OMG.Watcher.ExitProcessor.Core do
       new_exits
       |> Enum.zip(exit_contract_statuses)
       |> Enum.map(fn {event, contract_status} ->
-        %{eth_height: eth_height, call_data: %{utxo_pos: utxo_pos, output_tx: txbytes}} = event
-        Utxo.position(_, _, oindex) = utxo_pos_decoded = Utxo.Position.decode!(utxo_pos)
-        {:ok, raw_tx} = Transaction.decode(txbytes)
-        %{amount: amount, currency: currency, owner: owner} = raw_tx |> Transaction.get_outputs() |> Enum.at(oindex)
-
-        {utxo_pos_decoded,
-         %ExitInfo{
-           amount: amount,
-           currency: currency,
-           owner: owner,
-           is_active: parse_contract_exit_status(contract_status),
-           eth_height: eth_height
-         }}
+        {ExitInfo.new_key(contract_status, event), ExitInfo.new(contract_status, event)}
       end)
 
-    db_updates =
-      new_exits_kv_pairs
-      |> Enum.map(&ExitInfo.make_db_update/1)
-
+    db_updates = new_exits_kv_pairs |> Enum.map(&ExitInfo.make_db_update/1)
     new_exits_map = Map.new(new_exits_kv_pairs)
 
     {%{state | exits: Map.merge(exits, new_exits_map)}, db_updates}
-  end
-
-  defp parse_contract_exit_status({@zero_address, _contract_token, _contract_amount, _contract_position}), do: false
-  defp parse_contract_exit_status({_contract_owner, _contract_token, _contract_amount, _contract_position}), do: true
-
-  # TODO: syncing problem (look new exits)
-  @doc """
-   Add new in flight exits from Ethereum events into tracked state.
-  """
-  @spec new_in_flight_exits(t(), list(map()), list(map())) :: {t(), list()} | {:error, :unexpected_events}
-  def new_in_flight_exits(state, new_ifes_events, contract_statuses)
-
-  def new_in_flight_exits(_state, new_ifes_events, contract_statuses)
-      when length(new_ifes_events) != length(contract_statuses),
-      do: {:error, :unexpected_events}
-
-  def new_in_flight_exits(%__MODULE__{in_flight_exits: ifes} = state, new_ifes_events, contract_statuses) do
-    new_ifes_kv_pairs =
-      new_ifes_events
-      |> Enum.zip(contract_statuses)
-      |> Enum.map(fn {%{eth_height: eth_height, call_data: %{in_flight_tx: tx_bytes, in_flight_tx_sigs: signatures}},
-                      {timestamp, contract_ife_id} = contract_status} ->
-        is_active = parse_contract_in_flight_exit_status(contract_status)
-        InFlightExitInfo.new(tx_bytes, signatures, <<contract_ife_id::192>>, timestamp, is_active, eth_height)
-      end)
-
-    db_updates =
-      new_ifes_kv_pairs
-      |> Enum.map(&InFlightExitInfo.make_db_update/1)
-
-    new_ifes = new_ifes_kv_pairs |> Map.new()
-
-    {%{state | in_flight_exits: Map.merge(ifes, new_ifes)}, db_updates}
-  end
-
-  defp parse_contract_in_flight_exit_status({timestamp, _contract_id}), do: timestamp != 0
-
-  @doc """
-    Add piggybacks from Ethereum events into tracked state.
-  """
-  @spec new_piggybacks(t(), [%{tx_hash: Transaction.tx_hash(), output_index: output_offset()}]) :: {t(), list()}
-  def new_piggybacks(%__MODULE__{} = state, piggybacks) when is_list(piggybacks) do
-    {updated_state, updated_pairs} = Enum.reduce(piggybacks, {state, %{}}, &process_piggyback/2)
-    {updated_state, Enum.map(updated_pairs, &InFlightExitInfo.make_db_update/1)}
-  end
-
-  defp process_piggyback(
-         %{tx_hash: tx_hash, output_index: output_index},
-         {%__MODULE__{in_flight_exits: ifes} = state, db_updates}
-       ) do
-    {:ok, ife} = Map.fetch(ifes, tx_hash)
-    {:ok, updated_ife} = InFlightExitInfo.piggyback(ife, output_index)
-
-    updated_state = %{state | in_flight_exits: Map.put(ifes, tx_hash, updated_ife)}
-    {updated_state, Map.put(db_updates, tx_hash, updated_ife)}
   end
 
   @doc """
@@ -294,41 +224,60 @@ defmodule OMG.Watcher.ExitProcessor.Core do
   defp delete_positions(utxo_positions),
     do: utxo_positions |> Enum.map(&{:delete, :exit_info, Utxo.Position.to_db_key(&1)})
 
-  # TODO: simplify flow
-  # https://github.com/omisego/elixir-omg/pull/361#discussion_r247481397
+  # TODO: syncing problem (look new exits)
+  @doc """
+   Add new in flight exits from Ethereum events into tracked state.
+  """
+  @spec new_in_flight_exits(t(), list(map()), list(map())) :: {t(), list()} | {:error, :unexpected_events}
+  def new_in_flight_exits(state, new_ifes_events, contract_statuses)
+
+  def new_in_flight_exits(_state, new_ifes_events, contract_statuses)
+      when length(new_ifes_events) != length(contract_statuses),
+      do: {:error, :unexpected_events}
+
+  def new_in_flight_exits(%__MODULE__{in_flight_exits: ifes} = state, new_ifes_events, contract_statuses) do
+    new_ifes =
+      new_ifes_events
+      |> Enum.zip(contract_statuses)
+      |> Enum.map(fn {event, contract_status} -> InFlightExitInfo.new_kv(event, contract_status) end)
+      |> Map.new()
+
+    updated_state = %{state | in_flight_exits: Map.merge(ifes, new_ifes)}
+    updated_ife_keys = new_ifes |> Enum.unzip() |> elem(0)
+
+    db_updates = ife_db_updates(updated_state, updated_ife_keys)
+
+    {updated_state, db_updates}
+  end
+
+  defp ife_db_updates(%__MODULE__{in_flight_exits: ifes}, updated_ife_keys) do
+    ifes
+    |> Map.take(updated_ife_keys)
+    |> Enum.map(&InFlightExitInfo.make_db_update/1)
+  end
+
+  @doc """
+    Add piggybacks from Ethereum events into tracked state.
+  """
+  @spec new_piggybacks(t(), [%{tx_hash: Transaction.tx_hash(), output_index: output_offset()}]) :: {t(), list()}
+  def new_piggybacks(%__MODULE__{} = state, piggyback_events) when is_list(piggyback_events) do
+    consume_events(state, piggyback_events, :output_index, &InFlightExitInfo.piggyback/2)
+  end
+
   @spec new_ife_challenges(t(), [map()]) :: {t(), list()}
-  def new_ife_challenges(%__MODULE__{in_flight_exits: ifes, competitors: competitors} = state, challenges_events) do
-    challenges =
-      challenges_events
-      |> Enum.map(fn %{
-                       call_data: %{
-                         competing_tx: competing_tx_bytes,
-                         competing_tx_input_index: competing_input_index,
-                         competing_tx_sig: signature
-                       }
-                     } ->
-        CompetitorInfo.new(competing_tx_bytes, competing_input_index, signature)
-      end)
+  def new_ife_challenges(%__MODULE__{} = state, challenges_events) do
+    {updated_state, ife_db_updates} =
+      consume_events(state, challenges_events, :competitor_position, &InFlightExitInfo.challenge/2)
 
-    new_competitors = challenges |> Map.new()
-    competitors_db_updates = challenges |> Enum.map(&CompetitorInfo.make_db_update/1)
+    {updated_state2, competitors_db_updates} = append_new_competitors(updated_state, challenges_events)
+    {updated_state2, competitors_db_updates ++ ife_db_updates}
+  end
 
-    updated_ifes =
-      challenges_events
-      |> Enum.map(fn %{tx_hash: tx_hash, competitor_position: position} ->
-        updated_ife = ifes |> Map.fetch!(tx_hash) |> InFlightExitInfo.challenge(position)
-        {tx_hash, updated_ife}
-      end)
+  defp append_new_competitors(%__MODULE__{competitors: competitors} = state, challenges_events) do
+    new_competitors = challenges_events |> Enum.map(&CompetitorInfo.new/1)
+    db_updates = new_competitors |> Enum.map(&CompetitorInfo.make_db_update/1)
 
-    ife_db_updates = updated_ifes |> Enum.map(&InFlightExitInfo.make_db_update/1)
-
-    state = %{
-      state
-      | competitors: Map.merge(competitors, new_competitors),
-        in_flight_exits: Map.merge(ifes, Map.new(updated_ifes))
-    }
-
-    {state, competitors_db_updates ++ ife_db_updates}
+    {%{state | competitors: Map.merge(competitors, Map.new(new_competitors))}, db_updates}
   end
 
   @spec respond_to_in_flight_exits_challenges(t(), [map()]) :: {t(), list()}
@@ -337,38 +286,36 @@ defmodule OMG.Watcher.ExitProcessor.Core do
     {state, []}
   end
 
-  # TODO: simplify flow
-  # https://github.com/omisego/elixir-omg/pull/361#discussion_r247483185
   @spec challenge_piggybacks(t(), [map()]) :: {t(), list()}
-  def challenge_piggybacks(%__MODULE__{in_flight_exits: ifes} = state, challenges) do
-    ifes_to_update =
-      challenges
-      |> Enum.map(fn %{tx_hash: tx_hash} -> tx_hash end)
-      |> (&Map.take(ifes, &1)).()
-      # initializes all ifes as not updated
-      |> Enum.map(fn {key, value} -> {key, {value, false}} end)
-      |> Map.new()
+  def challenge_piggybacks(%__MODULE__{} = state, challenges) do
+    consume_events(state, challenges, :output_index, &InFlightExitInfo.challenge_piggyback/2)
+  end
 
-    updated_ifes =
-      challenges
-      |> Enum.reduce(ifes_to_update, fn %{tx_hash: tx_hash, output_index: output_index}, acc ->
-        with {ife, _} = Map.fetch!(acc, tx_hash),
-             updated_ife = InFlightExitInfo.challenge_piggyback(ife, output_index) do
-          # mark as updated
-          %{acc | tx_hash => {updated_ife, true}}
-        else
-          _ -> acc
-        end
-      end)
-      |> Enum.reduce([], fn
-        {tx_hash, {ife, true}}, acc -> [{tx_hash, ife} | acc]
-        _, acc -> acc
-      end)
-      |> Map.new()
+  # produces new state and some db_updates based on
+  #   - an enumerable of Ethereum events with tx_hash and some field
+  #   - name of that other field
+  #   - a function operating on a single IFE structure and that fields value
+  # Leverages the fact, that operating on various IFE-related events follows the same pattern
+  defp consume_events(%__MODULE__{} = state, events, event_field, ife_f) do
+    processing_f = process_reducing_events_f(event_field, ife_f)
+    {updated_state, updated_ife_keys} = Enum.reduce(events, {state, MapSet.new()}, processing_f)
+    db_updates = ife_db_updates(updated_state, updated_ife_keys)
+    {updated_state, db_updates}
+  end
 
-    db_updates = updated_ifes |> Enum.map(&InFlightExitInfo.make_db_update/1)
+  # produces an `Enum.reduce`-able function that: grabs an IFE by tx_hash from the event, invokes a function on that
+  # using the value of a different field from the event, returning updated state and mapset of modified keys.
+  # Pseudocode:
+  # `event |> get IFE by tx_hash |> ife_f.(event[event_field])`
+  defp process_reducing_events_f(event_field, ife_f) do
+    fn event, {%__MODULE__{in_flight_exits: ifes} = state, updated_ife_keys} ->
+      tx_hash = event.tx_hash
+      event_field_value = event[event_field]
+      updated_ife = ifes |> Map.fetch!(tx_hash) |> ife_f.(event_field_value)
 
-    {%{state | in_flight_exits: Map.merge(ifes, updated_ifes)}, db_updates}
+      updated_state = %{state | in_flight_exits: Map.put(ifes, tx_hash, updated_ife)}
+      {updated_state, MapSet.put(updated_ife_keys, tx_hash)}
+    end
   end
 
   @doc """
@@ -384,10 +331,7 @@ defmodule OMG.Watcher.ExitProcessor.Core do
           | {:unknown_piggybacks, list()}
           | {:unknown_in_flight_exit, MapSet.t(non_neg_integer())}
   def prepare_utxo_exits_for_in_flight_exit_finalizations(%__MODULE__{in_flight_exits: ifes}, finalizations) do
-    # convert ife_id from int (given by contract) to a binary
-    finalizations =
-      finalizations
-      |> Enum.map(fn %{in_flight_exit_id: id} = map -> Map.replace!(map, :in_flight_exit_id, <<id::192>>) end)
+    finalizations = finalizations |> Enum.map(&ife_id_to_binary/1)
 
     with {:ok, ifes_by_id} <- get_all_finalized_ifes_by_ife_contract_id(finalizations, ifes),
          {:ok, []} <- known_piggybacks?(finalizations, ifes_by_id) do
@@ -398,6 +342,10 @@ defmodule OMG.Watcher.ExitProcessor.Core do
       {:ok, exits_by_ife_id}
     end
   end
+
+  # converts from int, which is how the contract serves it
+  defp ife_id_to_binary(finalization),
+    do: Map.update!(finalization, :in_flight_exit_id, fn id -> <<id::192>> end)
 
   defp get_all_finalized_ifes_by_ife_contract_id(finalizations, ifes) do
     finalizations_ids =

--- a/apps/omg_watcher/lib/omg_watcher/exit_processor/core.ex
+++ b/apps/omg_watcher/lib/omg_watcher/exit_processor/core.ex
@@ -50,10 +50,7 @@ defmodule OMG.Watcher.ExitProcessor.Core do
   @default_sla_margin 10
   @zero_address OMG.Eth.zero_address()
 
-  # TODO: divide into inputs and outputs: prevent contract's implementation from leaking into watcher
-  # https://github.com/omisego/elixir-omg/pull/361#discussion_r247926222
-  # <- TODO: contract implementation detail leaking here
-  @type output_offset() :: 0..7
+  @type contract_piggyback_offset_t() :: 0..7
 
   defstruct [:sla_margin, exits: %{}, in_flight_exits: %{}, competitors: %{}]
 
@@ -98,13 +95,15 @@ defmodule OMG.Watcher.ExitProcessor.Core do
           spending_input_index: 0..3,
           spending_sig: <<_::520>>
         }
+
   @type piggyback_challenge_data_error() ::
-          :unknown_ife
+          :ife_not_known_for_tx
           | Transaction.decode_error()
-          | :no_double_spend_on_particular_piggyback
           | :no_double_spend_on_particular_piggyback
 
   @type spent_blknum_result_t() :: pos_integer | :not_found
+
+  @type pb_type_t() :: :input | :output
 
   defmodule KnownTx do
     @moduledoc """
@@ -117,6 +116,21 @@ defmodule OMG.Watcher.ExitProcessor.Core do
     @type t() :: %__MODULE__{
             signed_tx: Transaction.Signed.t(),
             utxo_pos: Utxo.Position.t()
+          }
+  end
+
+  defmodule DoubleSpend do
+    @moduledoc """
+    Wraps information about a single double spend occuring between a verified transaction and a known transaction
+    """
+
+    defstruct [:index, :utxo_pos, :known_spent_index, :known_tx]
+
+    @type t() :: %__MODULE__{
+            index: non_neg_integer(),
+            utxo_pos: Utxo.Position.t(),
+            known_spent_index: non_neg_integer,
+            known_tx: KnownTx.t()
           }
   end
 
@@ -259,7 +273,8 @@ defmodule OMG.Watcher.ExitProcessor.Core do
   @doc """
     Add piggybacks from Ethereum events into tracked state.
   """
-  @spec new_piggybacks(t(), [%{tx_hash: Transaction.tx_hash(), output_index: output_offset()}]) :: {t(), list()}
+  @spec new_piggybacks(t(), [%{tx_hash: Transaction.tx_hash(), output_index: contract_piggyback_offset_t()}]) ::
+          {t(), list()}
   def new_piggybacks(%__MODULE__{} = state, piggyback_events) when is_list(piggyback_events) do
     consume_events(state, piggyback_events, :output_index, &InFlightExitInfo.piggyback/2)
   end
@@ -663,11 +678,7 @@ defmodule OMG.Watcher.ExitProcessor.Core do
       get_ifes_with_competitors(request, state)
       |> Enum.map(fn txbytes -> %Event.NonCanonicalIFE{txbytes: txbytes} end)
 
-    invalid_piggybacks =
-      get_invalid_piggybacks(request, state)
-      |> Enum.map(fn {txbytes, inputs, outputs} ->
-        %Event.InvalidPiggyback{txbytes: txbytes, inputs: inputs, outputs: outputs}
-      end)
+    invalid_piggybacks = get_invalid_piggybacks_events(request, state)
 
     # TODO: late piggybacks are critical, to be implemented in OMG-408
     late_invalid_piggybacks = []
@@ -712,14 +723,14 @@ defmodule OMG.Watcher.ExitProcessor.Core do
 
   def get_input_challenge_data(request, state, txbytes, input_index) do
     case input_index in 0..(Transaction.max_inputs() - 1) do
-      true -> get_piggyback_challenge_data(request, state, txbytes, input_index)
+      true -> get_piggyback_challenge_data(request, state, txbytes, input_index, :input)
       false -> {:error, :piggybacked_index_out_of_range}
     end
   end
 
   def get_output_challenge_data(request, state, txbytes, output_index) do
     case output_index in 0..(Transaction.max_outputs() - 1) do
-      true -> get_piggyback_challenge_data(request, state, txbytes, output_index + 4)
+      true -> get_piggyback_challenge_data(request, state, txbytes, output_index, :output)
       false -> {:error, :piggybacked_index_out_of_range}
     end
   end
@@ -728,175 +739,151 @@ defmodule OMG.Watcher.ExitProcessor.Core do
   defdelegate determine_exit_txbytes(request, state), to: ExitProcessor.StandardExitChallenge
   defdelegate create_challenge(request, state), to: ExitProcessor.StandardExitChallenge
 
-  defp produce_invalid_piggyback_proof(%ExitProcessor.Request{blocks_result: blocks}, state, tx, pb_index) do
-    known_txs = get_known_txs(blocks) ++ get_known_txs(state)
-
-    with {:ok, {ife, _encoded_tx, bad_inputs, bad_outputs, proofs}} <-
-           get_proofs_for_particular_ife(tx, pb_index, known_txs, state),
-         true <-
-           is_piggyback_in_the_list_of_known_doublespends?(pb_index, bad_inputs, bad_outputs) ||
-             {:error, :no_double_spend_on_particular_piggyback} do
-      challenge_data = prepare_piggyback_challenge_proofs(ife, tx, pb_index, proofs)
-      {:ok, hd(challenge_data)}
+  @spec produce_invalid_piggyback_proof(InFlightExitInfo.t(), list(KnownTx.t()), non_neg_integer(), pb_type_t()) ::
+          {:ok, input_challenge_data() | output_challenge_data()} | {:error, :no_double_spend_on_particular_piggyback}
+  defp produce_invalid_piggyback_proof(ife, known_txs, pb_index, pb_type) do
+    with {:ok, proof_materials} <- get_proofs_for_particular_ife(ife, pb_type, known_txs),
+         {:ok, proof} <- get_proof_for_particular_piggyback(pb_index, proof_materials) do
+      {:ok, prepare_piggyback_challenge_response(ife, pb_type, pb_index, proof)}
     end
   end
 
-  defp get_proofs_for_particular_ife(tx, pb_index, known_txs, state) do
-    encoded_tx = Transaction.raw_txbytes(tx)
-
-    case pb_index < Transaction.max_inputs() do
-      true -> get_invalid_piggybacks_on_inputs(known_txs, state)
-      false -> get_invalid_piggybacks_on_outputs(known_txs, state)
-    end
-    |> Enum.filter(fn {_, ife_tx, _, _, _} ->
-      encoded_tx == ife_tx
-    end)
+  # gets all proof materials for all possibly invalid piggybacks for a single ife, for a determined type (input/output)
+  defp get_proofs_for_particular_ife(ife, pb_type, known_txs) do
+    invalid_piggybacks_by_ife(known_txs, pb_type, [ife])
     |> case do
       [] -> {:error, :no_double_spend_on_particular_piggyback}
-      [proof] -> {:ok, proof}
+      # ife and pb_type are pinned here for a runtime sanity check - we got what we explicitly asked for
+      [{^ife, ^pb_type, proof_materials}] -> {:ok, proof_materials}
     end
   end
 
-  defp is_piggyback_in_the_list_of_known_doublespends?(pb_index, bad_inputs, bad_outputs),
-    do: pb_index in bad_inputs or (pb_index - 4) in bad_outputs
-
-  defp prepare_piggyback_challenge_proofs(_ife, tx, input_index, proofs)
-       when input_index in 0..(Transaction.max_inputs() - 1) do
-    for {competing_ktx, _utxo_of_doublespend, his_doublespend_input_index} <- Map.get(proofs, input_index),
-        do: %{
-          in_flight_txbytes: Transaction.raw_txbytes(tx),
-          in_flight_input_index: input_index,
-          spending_txbytes: Transaction.raw_txbytes(competing_ktx.signed_tx),
-          spending_input_index: his_doublespend_input_index,
-          spending_sig: Enum.at(competing_ktx.signed_tx.sigs, his_doublespend_input_index)
-        }
-  end
-
-  defp prepare_piggyback_challenge_proofs(ife, tx, output_index, proofs) when output_index in 4..7 do
-    for {competing_ktx, utxo_of_doublespend, his_doublespend_input_index} <- Map.get(proofs, output_index - 4) do
-      {_, inclusion_proof} = ife.tx_seen_in_blocks_at
-
-      %{
-        in_flight_txbytes: Transaction.raw_txbytes(tx),
-        in_flight_output_pos: utxo_of_doublespend,
-        in_flight_proof: inclusion_proof,
-        spending_txbytes: Transaction.raw_txbytes(competing_ktx.signed_tx),
-        spending_input_index: his_doublespend_input_index,
-        spending_sig: Enum.at(competing_ktx.signed_tx.sigs, his_doublespend_input_index)
-      }
+  # gets any proof of a particular invalid piggyback, after we have figured the exact piggyback index affected
+  defp get_proof_for_particular_piggyback(pb_index, proof_materials) do
+    proof_materials
+    |> Map.get(pb_index)
+    |> case do
+      nil -> {:error, :no_double_spend_on_particular_piggyback}
+      # any challenging tx will do, taking the very first
+      [proof | _] -> {:ok, proof}
     end
   end
 
-  @spec get_invalid_piggybacks(ExitProcessor.Request.t(), __MODULE__.t()) :: [
-          {binary, [Transaction.input_index_t()], [Transaction.input_index_t()]}
-        ]
-  defp get_invalid_piggybacks(
+  @spec prepare_piggyback_challenge_response(
+          InFlightExitInfo.t(),
+          pb_type_t(),
+          non_neg_integer(),
+          DoubleSpend.t()
+        ) ::
+          input_challenge_data() | output_challenge_data()
+  defp prepare_piggyback_challenge_response(ife, :input, input_index, proof) do
+    %{
+      in_flight_txbytes: Transaction.raw_txbytes(ife.tx),
+      in_flight_input_index: input_index,
+      spending_txbytes: Transaction.raw_txbytes(proof.known_tx.signed_tx),
+      spending_input_index: proof.known_spent_index,
+      spending_sig: Enum.at(proof.known_tx.signed_tx.sigs, proof.known_spent_index)
+    }
+  end
+
+  defp prepare_piggyback_challenge_response(ife, :output, _output_index, proof) do
+    {_, inclusion_proof} = ife.tx_seen_in_blocks_at
+
+    %{
+      in_flight_txbytes: Transaction.raw_txbytes(ife.tx),
+      in_flight_output_pos: proof.utxo_pos,
+      in_flight_proof: inclusion_proof,
+      spending_txbytes: Transaction.raw_txbytes(proof.known_tx.signed_tx),
+      spending_input_index: proof.known_spent_index,
+      spending_sig: Enum.at(proof.known_tx.signed_tx.sigs, proof.known_spent_index)
+    }
+  end
+
+  # respec
+  @spec get_invalid_piggybacks_events(ExitProcessor.Request.t(), __MODULE__.t()) :: list(Event.InvalidPiggyback.t())
+  defp get_invalid_piggybacks_events(
          %ExitProcessor.Request{blocks_result: blocks},
-         state
+         %__MODULE__{in_flight_exits: ifes} = state
        ) do
     known_txs = get_known_txs(state) ++ get_known_txs(blocks)
-    bad_piggybacks_on_inputs = get_invalid_piggybacks_on_inputs(known_txs, state)
-    bad_piggybacks_on_outputs = get_invalid_piggybacks_on_outputs(known_txs, state)
-    # produce only one event per IFE, with both piggybacks on inputs and outputs
-    (bad_piggybacks_on_inputs ++ bad_piggybacks_on_outputs)
-    |> Enum.group_by(&elem(&1, 1), fn {_, _, ins, outs, _} ->
-      {ins, outs}
-    end)
-    |> Enum.map(fn {txhash, zipped_bad_piggyback_indexes} ->
-      {all_ins, all_outs} = Enum.unzip(zipped_bad_piggyback_indexes)
-      {txhash, List.flatten(all_ins), List.flatten(all_outs)}
+
+    ifes
+    |> Map.values()
+    |> all_invalid_piggybacks_by_ife(known_txs)
+    |> group_by_txbytes()
+    |> materials_to_events()
+  end
+
+  defp all_invalid_piggybacks_by_ife(ifes_values, known_txs),
+    do: [:input, :output] |> Enum.flat_map(fn pb_type -> invalid_piggybacks_by_ife(known_txs, pb_type, ifes_values) end)
+
+  # we need to produce only one event per IFE, with both piggybacks on inputs and outputs
+  defp group_by_txbytes(invalid_piggybacks) do
+    invalid_piggybacks
+    |> Enum.map(fn {ife, type, materials} -> {Transaction.raw_txbytes(ife.tx), type, materials} end)
+    |> Enum.group_by(&elem(&1, 0), fn {_, type, materials} -> {type, materials} end)
+  end
+
+  defp materials_to_events(invalid_piggybacks_by_txbytes) do
+    invalid_piggybacks_by_txbytes
+    |> Enum.map(fn {txbytes, type_materials_pairs} ->
+      %Event.InvalidPiggyback{
+        txbytes: txbytes,
+        inputs: invalid_piggyback_indices(type_materials_pairs, :input),
+        outputs: invalid_piggyback_indices(type_materials_pairs, :output)
+      }
     end)
   end
 
-  @spec get_invalid_piggybacks_on_inputs([KnownTx.t()], t()) :: [
-          {InFlightExitInfo.t(), Transaction.tx_hash(), [input_pb, ...], [],
-           %{
-             input_pb => [
-               {double_spending_tx :: KnownTx.t(), input_utxo :: Utxo.Position.t(),
-                doublespend_index :: Transaction.input_index_t()}
-             ]
-           }}
-        ]
-        when input_pb: Transaction.input_index_t()
-  defp get_invalid_piggybacks_on_inputs(known_txs, %__MODULE__{in_flight_exits: ifes}) do
+  defp invalid_piggyback_indices(type_materials_pairs, pb_type) do
+    # here we need to additionally group the materials found by type input/output
+    # then we gut just the list of indices to present to the user in the event
+    type_materials_pairs
+    |> Enum.filter(fn {type, _materials} -> type == pb_type end)
+    |> Enum.flat_map(fn {_type, materials} -> Map.keys(materials) end)
+  end
+
+  @spec invalid_piggybacks_by_ife(list(KnownTx.t()), pb_type_t(), list(InFlightExitInfo.t())) ::
+          list({InFlightExitInfo.t(), pb_type_t(), %{non_neg_integer => DoubleSpend.t()}})
+  defp invalid_piggybacks_by_ife(known_txs, pb_type, ifes) do
     known_txs = :lists.usort(known_txs)
 
     # getting invalid piggybacks on inputs
     ifes
-    |> Map.values()
-    |> Enum.map(fn %InFlightExitInfo{tx: tx} = ife ->
-      inputs =
-        tx
-        |> Transaction.get_inputs()
-        |> Enum.with_index()
-        |> Enum.filter(fn {_input, index} -> InFlightExitInfo.is_input_piggybacked?(ife, index) end)
-
-      {ife, inputs}
+    |> Enum.map(&InFlightExitInfo.indexed_piggybacks_by_ife(&1, pb_type))
+    |> Enum.filter(&ife_has_something?/1)
+    |> Enum.map(fn {ife, indexed_piggybacked_utxo_positions} ->
+      proof_materials = all_double_spends_by_index(indexed_piggybacked_utxo_positions, known_txs, ife)
+      {ife, pb_type, proof_materials}
     end)
-    |> Enum.filter(fn {_ife, inputs} -> inputs != [] end)
-    |> Enum.map(fn {ife, inputs} ->
-      proof_materials = find_spends(inputs, known_txs, ife.tx.raw_tx)
-      {ife, Transaction.raw_txbytes(ife.tx), Map.keys(proof_materials), [], proof_materials}
-    end)
-    |> Enum.filter(fn {_, _, on_inputs, _, _} -> on_inputs != [] end)
+    |> Enum.filter(&ife_has_something?/1)
   end
 
-  @spec get_invalid_piggybacks_on_outputs([KnownTx.t()], t()) :: [
-          {InFlightExitInfo.t(), Transaction.tx_hash(), [], [output_pb, ...],
-           %{
-             output_pb => [
-               {double_spending_tx :: KnownTx.t(), input_utxo :: Utxo.Position.t(),
-                his_doublespend :: Transaction.input_index_t()}
-             ]
-           }}
-        ]
-        when output_pb: Transaction.input_index_t()
-  defp get_invalid_piggybacks_on_outputs(known_txs, %__MODULE__{in_flight_exits: ifes}) do
-    # To find bad piggybacks on outputs of IFE, we need to find spends on those outputs.
-    # To do that, we first need to find IFE inclusion position.
-    # If IFE was included, the value of :tx_seen_in_blocks_at is set.
-    # Next, check its spends, which are already included into request.blocks_result
+  defp ife_has_something?({_ife, finds_for_ife}), do: !Enum.empty?(finds_for_ife)
+  defp ife_has_something?({_ife, _, finds_for_ife}), do: !Enum.empty?(finds_for_ife)
 
-    # TODO: drop next line
-    known_txs = :lists.usort(known_txs)
-
-    ifes
-    |> Map.values()
-    |> Enum.map(fn ife ->
-      piggybacked_output_utxos =
-        ife
-        |> InFlightExitInfo.get_piggybacked_outputs_positions()
-        |> Enum.map(&{&1, Utxo.Position.oindex(&1)})
-
-      {ife, piggybacked_output_utxos}
-    end)
-    |> Enum.filter(fn {_ife, piggybacked_output_utxos} -> piggybacked_output_utxos != [] end)
-    |> Enum.map(fn {ife, piggybacked_output_utxos} ->
-      proof_materials = find_spends(piggybacked_output_utxos, known_txs, ife.tx.raw_tx)
-      {ife, Transaction.raw_txbytes(ife.tx), [], Map.keys(proof_materials), proof_materials}
-    end)
-    |> Enum.filter(fn {_, _, _, on_outputs, _} -> on_outputs != [] end)
-  end
-
-  defp find_spends(single_tx_indexed_inputs, known_txs, original_tx) do
+  defp all_double_spends_by_index(indexed_utxo_positions, known_txs, ife) do
     # Will find all spenders of provided indexed inputs.
     known_txs
-    |> Enum.filter(&(original_tx != &1.signed_tx.raw_tx))
-    |> Enum.map(fn ktx -> {ktx, get_double_spends(single_tx_indexed_inputs, ktx)} end)
-    |> Enum.filter(fn {_ktx, doublespends} -> doublespends != [] end)
-    |> Enum.flat_map(fn {ktx, dbl_spends} ->
-      {my_indexes, utxo_poses, his_indexes} = :lists.unzip3(dbl_spends)
-      Enum.zip([my_indexes, List.duplicate(ktx, length(my_indexes)), utxo_poses, his_indexes])
-    end)
-    |> Enum.group_by(&elem(&1, 0), &Tuple.delete_at(&1, 0))
+    |> Enum.filter(&txs_different(ife.tx, &1.signed_tx))
+    |> Enum.flat_map(&double_spends_from_known_tx(indexed_utxo_positions, &1))
+    |> Enum.group_by(& &1.index)
   end
 
-  @spec get_piggyback_challenge_data(ExitProcessor.Request.t(), t(), Transaction.Signed.tx_bytes(), 0..7) ::
+  @spec get_piggyback_challenge_data(
+          ExitProcessor.Request.t(),
+          __MODULE__.t(),
+          binary(),
+          non_neg_integer(),
+          pb_type_t()
+        ) ::
           {:ok, input_challenge_data() | output_challenge_data()} | {:error, piggyback_challenge_data_error()}
-  defp get_piggyback_challenge_data(request, %__MODULE__{in_flight_exits: ifes} = state, txbytes, pb_index) do
+  defp get_piggyback_challenge_data(%ExitProcessor.Request{blocks_result: blocks}, state, txbytes, pb_index, pb_type) do
     with {:ok, tx} <- Transaction.decode(txbytes),
-         true <- Map.has_key?(ifes, Transaction.raw_txhash(tx)) || {:error, :unknown_ife},
-         do: produce_invalid_piggyback_proof(request, state, tx, pb_index)
+         {:ok, ife} <- get_ife(tx, state) do
+      known_txs = get_known_txs(blocks) ++ get_known_txs(state)
+      produce_invalid_piggyback_proof(ife, known_txs, pb_index, pb_type)
+    end
   end
 
   @spec get_invalid_exits_based_on_ifes(t()) :: list(%{Utxo.Position.t() => ExitInfo.t()})
@@ -1082,8 +1069,8 @@ defmodule OMG.Watcher.ExitProcessor.Core do
     # find its competitor and use it to prepare the requested data
     with {:ok, ife_tx} <- Transaction.decode(ife_txbytes),
          {:ok, %InFlightExitInfo{tx: signed_ife_tx}} <- get_ife(ife_tx, state),
-         {:ok, known_signed_tx} <- find_competitor(known_txs, signed_ife_tx),
-         do: {:ok, prepare_competitor_response(known_signed_tx, signed_ife_tx, blocks)}
+         {:ok, double_spend} <- find_competitor(known_txs, signed_ife_tx),
+         do: {:ok, prepare_competitor_response(double_spend, signed_ife_tx, blocks)}
   end
 
   @doc """
@@ -1104,19 +1091,15 @@ defmodule OMG.Watcher.ExitProcessor.Core do
   end
 
   defp prepare_competitor_response(
-         %KnownTx{signed_tx: known_signed_tx, utxo_pos: known_tx_utxo_pos},
+         %DoubleSpend{
+           index: in_flight_input_index,
+           known_spent_index: competing_input_index,
+           known_tx: %KnownTx{signed_tx: known_signed_tx, utxo_pos: known_tx_utxo_pos}
+         },
          signed_ife_tx,
          blocks
        ) do
-    ife_inputs = Transaction.get_inputs(signed_ife_tx)
-
-    known_spent_inputs = Transaction.get_inputs(known_signed_tx)
     {:ok, input_owners} = Transaction.Signed.get_spenders(signed_ife_tx)
-
-    # get info about the double spent input and it's respective indices in transactions
-    spent_input = competitor_for(signed_ife_tx, known_signed_tx)
-    in_flight_input_index = Enum.find_index(ife_inputs, &(&1 == spent_input))
-    competing_input_index = Enum.find_index(known_spent_inputs, &(&1 == spent_input))
 
     owner = Enum.at(input_owners, in_flight_input_index)
 
@@ -1149,7 +1132,7 @@ defmodule OMG.Watcher.ExitProcessor.Core do
 
   defp find_competitor(known_txs, signed_ife_tx) do
     known_txs
-    |> Enum.find(fn known -> competitor_for(signed_ife_tx, known) end)
+    |> Enum.find_value(fn known -> competitor_for(signed_ife_tx, known) end)
     |> case do
       nil -> {:error, :competitor_not_found}
       value -> {:ok, value}
@@ -1166,60 +1149,30 @@ defmodule OMG.Watcher.ExitProcessor.Core do
   end
 
   # Tells whether a single transaction is a competitor for another single transactions, by returning nil or the
-  # UTXO position of the input double spent.
+  # `DoubleSpend` information package if the `known_tx` is in fact a competitor
   # Returns single result, even if there are multiple double-spends!
-  @spec competitor_for(Transaction.Signed.t(), Transaction.Signed.t() | KnownTx.t() | Transaction.t()) ::
-          Utxo.Position.t() | nil
-
-  # this function doesn't care, if the second argument holds additional information about the utxo position
-  defp competitor_for(signed1, %KnownTx{signed_tx: signed2}),
-    do: competitor_for(signed1, signed2)
-
-  defp competitor_for(tx, known_tx) do
-    inputs = Transaction.get_inputs(tx)
-    known_spent_inputs = Transaction.get_inputs(known_tx)
-
-    with true <- Transaction.raw_txhash(known_tx) != Transaction.raw_txhash(tx),
-         Utxo.position(_, _, _) = double_spent_input <- inputs |> Enum.find(&Enum.member?(known_spent_inputs, &1)),
-         do: double_spent_input
+  defp competitor_for(tx, %KnownTx{signed_tx: known_signed_tx} = known_tx) do
+    with true <- txs_different(tx, known_signed_tx) || nil,
+         double_spends = tx |> Transaction.get_inputs() |> Enum.with_index() |> double_spends_from_known_tx(known_tx),
+         true <- !Enum.empty?(double_spends) || nil,
+         do: hd(double_spends)
   end
 
   # Intersects utxos, looking for duplicates. Gives full list of double-spends with indexes for
   # a pair of transactions.
-  @spec get_double_spends(tx_input_info, tx_input_info) :: [
-          {Transaction.input_index_t(), Utxo.Position.t(), Transaction.input_index_t()}
-        ]
-        when tx_input_info:
-               Transaction.Signed.t()
-               | Transaction.t()
-               | KnownTx.t()
-               | [{Transaction.input(), Transaction.input_index_t()}]
-  defp get_double_spends(inputs, known_spent_inputs) when is_list(inputs) and is_list(known_spent_inputs) do
+  @spec double_spends_from_known_tx(list({Utxo.Position.t(), non_neg_integer()}), KnownTx.t()) ::
+          list(DoubleSpend.t())
+  defp double_spends_from_known_tx(inputs, %KnownTx{signed_tx: signed} = known_tx) when is_list(inputs) do
+    known_spent_inputs = signed |> Transaction.get_inputs() |> Enum.with_index()
+
     # TODO: possibly ineffective if Transaction.max_inputs >> 4
-    list =
-      for {left, left_index} <- inputs,
-          {right, right_index} <- known_spent_inputs,
-          left == right,
-          do: {left_index, left, right_index}
-
-    :lists.usort(list)
+    for {left, left_index} <- inputs,
+        {right, right_index} <- known_spent_inputs,
+        left == right,
+        do: %DoubleSpend{index: left_index, utxo_pos: left, known_spent_index: right_index, known_tx: known_tx}
   end
 
-  defp get_double_spends(inputs, known_spent_inputs) do
-    get_double_spends(index_inputs(inputs), index_inputs(known_spent_inputs))
-  end
-
-  defp index_inputs(inputs_list) when is_list(inputs_list) do
-    inputs_list
-  end
-
-  defp index_inputs(%KnownTx{signed_tx: signed}), do: index_inputs(signed)
-
-  defp index_inputs(tx) do
-    tx
-    |> Transaction.get_inputs()
-    |> Enum.with_index()
-  end
+  defp txs_different(tx1, tx2), do: Transaction.raw_txhash(tx1) != Transaction.raw_txhash(tx2)
 
   defp get_known_txs(%__MODULE__{} = state) do
     TxAppendix.get_all(state)

--- a/apps/omg_watcher/lib/omg_watcher/exit_processor/in_flight_exit_info.ex
+++ b/apps/omg_watcher/lib/omg_watcher/exit_processor/in_flight_exit_info.ex
@@ -231,18 +231,10 @@ defmodule OMG.Watcher.ExitProcessor.InFlightExitInfo do
     end
   end
 
-  @spec challenge_piggyback(t(), integer()) :: {:ok, t()} | {:error, :non_existent_exit | :cannot_challenge}
-  def challenge_piggyback(ife, index)
-
   def challenge_piggyback(%__MODULE__{exit_map: exit_map} = ife, index) when index in @exit_map_index_range do
-    with %{is_piggybacked: true, is_finalized: false} <- Map.get(exit_map, index) do
-      {:ok, %{ife | exit_map: Map.merge(exit_map, %{index => %{is_piggybacked: false, is_finalized: false}})}}
-    else
-      _ -> {:error, :cannot_challenge}
-    end
+    %{is_piggybacked: true, is_finalized: false} = Map.get(exit_map, index)
+    %{ife | exit_map: Map.replace!(exit_map, index, %{is_piggybacked: false, is_finalized: false})}
   end
-
-  def challenge_piggyback(%__MODULE__{}, _), do: {:error, :non_existent_exit}
 
   @spec respond_to_challenge(t(), Utxo.Position.t()) ::
           {:ok, t()} | {:error, :responded_with_too_young_tx | :cannot_respond}

--- a/apps/omg_watcher/lib/omg_watcher/exit_processor/tools.ex
+++ b/apps/omg_watcher/lib/omg_watcher/exit_processor/tools.ex
@@ -1,0 +1,108 @@
+# Copyright 2018 OmiseGO Pte Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defmodule OMG.Watcher.ExitProcessor.Tools do
+  @moduledoc """
+  Private tools that various components of the `ExitProcessor` share
+  """
+
+  alias OMG.Crypto
+  alias OMG.State.Transaction
+  alias OMG.TypedDataHash
+  alias OMG.Utxo
+
+  require Utxo
+
+  defmodule KnownTx do
+    @moduledoc """
+    Wrapps information about a particular signed transaction known from somewhere, optionally with its UTXO position
+
+    Private
+    """
+    defstruct [:signed_tx, :utxo_pos]
+
+    @type t() :: %__MODULE__{
+            signed_tx: Transaction.Signed.t(),
+            utxo_pos: Utxo.Position.t() | nil
+          }
+  end
+
+  defmodule DoubleSpend do
+    @moduledoc """
+    Wraps information about a single double spend occuring between a verified transaction and a known transaction
+    """
+
+    defstruct [:index, :utxo_pos, :known_spent_index, :known_tx]
+
+    @type t() :: %__MODULE__{
+            index: non_neg_integer(),
+            utxo_pos: Utxo.Position.t(),
+            known_spent_index: non_neg_integer,
+            known_tx: KnownTx.t()
+          }
+  end
+
+  # Intersects utxos, looking for duplicates. Gives full list of double-spends with indexes for
+  # a pair of transactions.
+  @spec double_spends_from_known_tx(list({Utxo.Position.t(), non_neg_integer()}), KnownTx.t()) ::
+          list(DoubleSpend.t())
+  def double_spends_from_known_tx(inputs, %KnownTx{signed_tx: signed} = known_tx) when is_list(inputs) do
+    known_spent_inputs = signed |> Transaction.get_inputs() |> Enum.with_index()
+
+    # TODO: possibly ineffective if Transaction.max_inputs >> 4
+    for {left, left_index} <- inputs,
+        {right, right_index} <- known_spent_inputs,
+        left == right,
+        do: %DoubleSpend{index: left_index, utxo_pos: left, known_spent_index: right_index, known_tx: known_tx}
+  end
+
+  # based on an enumberable of `Utxo.Position` and a mapping that tells whether one exists it will pick
+  # only those that **were checked** and were missing
+  # (i.e. those not checked are assumed to be present)
+  def only_utxos_checked_and_missing(utxo_positions, utxo_exists?) do
+    # the default value below is true, so that the assumption is that utxo not checked is **present**
+    # TODO: rather inefficient, but no as inefficient as the nested `filter` calls in searching for competitors
+    #       consider optimizing using `MapSet`
+
+    Enum.filter(utxo_positions, fn utxo_pos -> !Map.get(utxo_exists?, utxo_pos, true) end)
+  end
+
+  @doc """
+  Finds the exact signature which signed the particular transaction for the given owner address
+  """
+  @spec find_sig(Transaction.Signed.t(), Crypto.address_t()) :: {:ok, Crypto.sig_t()} | nil
+  def find_sig(%Transaction.Signed{sigs: sigs, raw_tx: raw_tx}, owner) do
+    tx_hash = TypedDataHash.hash_struct(raw_tx)
+
+    Enum.find(sigs, fn sig ->
+      {:ok, owner} == Crypto.recover_address(tx_hash, sig)
+    end)
+    |> case do
+      nil -> nil
+      other -> {:ok, other}
+    end
+  end
+
+  @doc """
+  Throwing version of `find_sig/2`
+
+  At some point having a tx that wasn't actually signed is an error, hence pattern match
+  if `find_sig/2` returns nil it means somethings very wrong - the owner taken (effectively) from the contract
+  doesn't appear to have signed the potential competitor, which means that some prior signature checking was skipped
+  """
+  def find_sig!(tx, owner) do
+    {:ok, sig} = find_sig(tx, owner)
+    sig
+  end
+end

--- a/apps/omg_watcher/test/omg_watcher/exit_processor/core/standard_exit_challenge_test.exs
+++ b/apps/omg_watcher/test/omg_watcher/exit_processor/core/standard_exit_challenge_test.exs
@@ -59,7 +59,7 @@ defmodule OMG.Watcher.ExitProcessor.Core.StandardExitChallengeTest do
                |> Core.determine_standard_challenge_queries(processor)
     end
 
-    test "asks for correct data: deposit utxo double spent not in IFE",
+    test "asks for correct data: deposit utxo double spent outside an IFE",
          %{alice: alice, processor_empty: processor} do
       processor = processor |> start_se_from_deposit(@utxo_pos_deposit, alice)
 
@@ -79,7 +79,7 @@ defmodule OMG.Watcher.ExitProcessor.Core.StandardExitChallengeTest do
                |> Core.determine_standard_challenge_queries(processor)
     end
 
-    test "asks for correct data: tx utxo double spent not in IFE",
+    test "asks for correct data: tx utxo double spent outside an IFE",
          %{alice: alice, processor_empty: processor} do
       processor = processor |> start_se_from_block_tx(@utxo_pos_tx, alice)
 
@@ -151,7 +151,7 @@ defmodule OMG.Watcher.ExitProcessor.Core.StandardExitChallengeTest do
                |> Core.create_challenge(processor)
     end
 
-    test "creates challenge: deposit utxo double spent not in IFE",
+    test "creates challenge: deposit utxo double spent outside an IFE",
          %{alice: alice, processor_empty: processor} do
       processor = processor |> start_se_from_deposit(@utxo_pos_deposit, alice)
 
@@ -179,7 +179,7 @@ defmodule OMG.Watcher.ExitProcessor.Core.StandardExitChallengeTest do
                |> Core.create_challenge(processor)
     end
 
-    test "creates challenge: tx utxo double spent not in IFE",
+    test "creates challenge: tx utxo double spent outside an IFE",
          %{alice: alice, processor_empty: processor} do
       processor = processor |> start_se_from_block_tx(@utxo_pos_tx, alice)
 
@@ -195,7 +195,7 @@ defmodule OMG.Watcher.ExitProcessor.Core.StandardExitChallengeTest do
                |> Core.create_challenge(processor)
     end
 
-    test "creates challenge: tx utxo double spent not in IFE, but there is an unrelated IFE open",
+    test "creates challenge: tx utxo double spent outside an IFE, but there is an unrelated IFE open",
          %{alice: alice, processor_empty: processor} do
       unrelated = TestHelper.create_recovered([{@blknum, 10, 0, alice}], @eth, [])
       processor = processor |> start_se_from_block_tx(@utxo_pos_tx, alice) |> start_ife_from(unrelated)

--- a/apps/omg_watcher/test/omg_watcher/exit_processor/core_test.exs
+++ b/apps/omg_watcher/test/omg_watcher/exit_processor/core_test.exs
@@ -360,15 +360,6 @@ defmodule OMG.Watcher.ExitProcessor.CoreTest do
     assert [%{piggybacked_inputs: []}, %{piggybacked_inputs: []}] = Core.get_active_in_flight_exits(processor)
   end
 
-  test "challenge piggybacks sanity checks", %{processor_filled: state, ife_tx_hashes: [tx_hash | _]} do
-    # cannot challenge piggyback of unknown ife
-    assert {state, []} == Core.challenge_piggybacks(state, [%{tx_hash: 0, output_index: 0}])
-    # cannot challenge not piggybacked output
-    assert {state, []} == Core.challenge_piggybacks(state, [%{tx_hash: tx_hash, output_index: 0}])
-    # other sanity checks
-    assert {state, []} == Core.challenge_piggybacks(state, [%{tx_hash: tx_hash, output_index: 8}])
-  end
-
   test "detect invalid standard exit based on ife tx which spends same input",
        %{processor_empty: processor, alice: alice} do
     standard_exit_tx = TestHelper.create_recovered([{1, 0, 0, alice}], @eth, [{alice, 10}])

--- a/apps/omg_watcher/test/omg_watcher/exit_processor/core_test.exs
+++ b/apps/omg_watcher/test/omg_watcher/exit_processor/core_test.exs
@@ -980,8 +980,8 @@ defmodule OMG.Watcher.ExitProcessor.CoreTest do
     test "fail when asked to produce proof for wrong txhash",
          %{invalid_piggyback_on_input: %{state: state, request: request}, unrelated_tx: comp} do
       comp_txbytes = Transaction.raw_txbytes(comp)
-      assert {:error, :unknown_ife} = Core.get_input_challenge_data(request, state, comp_txbytes, 0)
-      assert {:error, :unknown_ife} = Core.get_output_challenge_data(request, state, comp_txbytes, 0)
+      assert {:error, :ife_not_known_for_tx} = Core.get_input_challenge_data(request, state, comp_txbytes, 0)
+      assert {:error, :ife_not_known_for_tx} = Core.get_output_challenge_data(request, state, comp_txbytes, 0)
     end
 
     test "fail when asked to produce proof for wrong badly encoded tx",


### PR DESCRIPTION
references #608

Solves multiple issues with `ExitProcessor.Core`:
  - dries consumption of ethereum events
  - dries and clarifies the flows related to piggyback invalidity checks
  - adds some tests (changes to `core_test.exs` are only additive or cleanups)
  - separates some code into submodules
  - dries the double spend functionality which was implemented three-fold (for competitors, for piggybacks and for ife-se cross checks)
  - makes handling of piggyback indices (with either the magical "4" added or not) cleaner - now "4" is added only on the "outside". Inside of `ExitProcessor.Core` "natural" indices are used + an explicit indication whether `input` or `output` is meant, as necessary