### PR TITLE
feat: improve error logs when BlockQueue has problems

### DIFF
--- a/apps/omg_api/lib/block_queue.ex
+++ b/apps/omg_api/lib/block_queue.ex
@@ -83,7 +83,7 @@ defmodule OMG.API.BlockQueue do
 
       {:ok, known_hashes} = OMG.DB.block_hashes(range)
       {:ok, {top_mined_hash, _}} = Eth.RootChain.get_child_chain(mined_num)
-      _ = Logger.info("Starting BlockQueue, top_mined_hash: #{inspect(Base.encode16(top_mined_hash))}")
+      _ = Logger.info("Starting BlockQueue, top_mined_hash: #{inspect(Eth.Encoding.to_hex(top_mined_hash))}")
 
       {:ok, state} =
         with {:ok, _state} = result <-
@@ -102,8 +102,11 @@ defmodule OMG.API.BlockQueue do
         else
           {:error, reason} = error when reason in [:mined_hash_not_found_in_db, :contract_ahead_of_db] ->
             _ =
-              Logger.error(
-                "The child chain might have not been wiped clean when starting a child chain from scratch. Check README.MD and follow the setting up child chain."
+              log_init_error(
+                known_hashes: known_hashes,
+                parent_height: parent_height,
+                mined_num: mined_num,
+                stored_child_top_num: stored_child_top_num
               )
 
             error
@@ -166,7 +169,45 @@ defmodule OMG.API.BlockQueue do
       submit_result = OMG.Eth.RootChain.submit_block(hash, nonce, gas_price)
       {:ok, newest_mined_blknum} = Eth.RootChain.get_mined_child_block()
 
-      :ok = Core.process_submit_result(submission, submit_result, newest_mined_blknum)
+      final_result = Core.process_submit_result(submission, submit_result, newest_mined_blknum)
+
+      _ =
+        case final_result do
+          {:error, _} -> log_eth_node_error()
+          _ -> :ok
+        end
+
+      :ok = final_result
+    end
+
+    defp log_init_error(fields) do
+      config = Application.get_all_env(:omg_eth) |> Keyword.take([:contract_addr, :authority_addr, :txhash_contract])
+      fields = Keyword.update!(fields, :known_hashes, fn hashes -> Enum.map(hashes, &Eth.Encoding.to_hex/1) end)
+      diagnostic = fields |> Enum.into(%{config: config})
+
+      _ =
+        Logger.error(
+          "The child chain might have not been wiped clean when starting a child chain from scratch: " <>
+            "#{inspect(diagnostic)}. Check README.MD and follow the setting up child chain."
+        )
+
+      log_eth_node_error()
+    end
+
+    defp log_eth_node_error do
+      eth_node_diagnostics = get_eth_node_diagnostics()
+      Logger.error("Ethereum operation failed, additional diagnostics: #{inspect(eth_node_diagnostics)}")
+    end
+
+    defp get_eth_node_diagnostics do
+      ["personal_listWallets", "admin_nodeInfo", "parity_enode"]
+      |> Enum.into(%{}, &get_eth_node_diagnostic/1)
+    end
+
+    defp get_eth_node_diagnostic(rpc_call_name) when is_binary(rpc_call_name) do
+      {rpc_call_name, Ethereumex.HttpClient.request(rpc_call_name, [], [])}
+    rescue
+      error -> {rpc_call_name, inspect(error)}
     end
   end
 end

--- a/apps/omg_api/lib/block_queue/core.ex
+++ b/apps/omg_api/lib/block_queue/core.ex
@@ -456,7 +456,8 @@ defmodule OMG.API.BlockQueue.Core do
         :ok
 
       {:error, %{"code" => -32_000, "message" => "authentication needed: password or unlock"}} ->
-        _ = Logger.error("It seems that authority account is locked. Check README.md")
+        diagnostic = prepare_diagnostic(submission, newest_mined_blknum)
+        _ = Logger.error("It seems that authority account is locked: #{inspect(diagnostic)}. Check README.md")
         {:error, :account_locked}
 
       {:error, %{"code" => -32_000, "message" => "nonce too low"}} ->
@@ -469,8 +470,14 @@ defmodule OMG.API.BlockQueue.Core do
       # apparently the `nonce too low` error is related to the submission having been mined while it was prepared
       :ok
     else
-      _ = Logger.error("Submission #{inspect(submission)} unexpectedly failed with nonce too low")
+      diagnostic = prepare_diagnostic(submission, newest_mined_blknum)
+      _ = Logger.error("Submission unexpectedly failed with nonce too low: #{inspect(diagnostic)}")
       {:error, :nonce_too_low}
     end
+  end
+
+  defp prepare_diagnostic(submission, newest_mined_blknum) do
+    config = Application.get_all_env(:omg_eth) |> Keyword.take([:contract_addr, :authority_addr, :txhash_contract])
+    %{submission: submission, newest_mined_blknum: newest_mined_blknum, config: config}
   end
 end

--- a/apps/omg_eth/test/support/dev_geth.ex
+++ b/apps/omg_eth/test/support/dev_geth.ex
@@ -31,7 +31,7 @@ defmodule OMG.Eth.DevGeth do
     {:ok, _} = Application.ensure_all_started(:ethereumex)
     {:ok, homedir} = Briefly.create(directory: true)
 
-    geth_pid = launch("geth --dev --dev.period=1 --rpc --rpcapi=personal,eth,web3 --datadir #{homedir} 2>&1")
+    geth_pid = launch("geth --dev --dev.period=1 --rpc --rpcapi=personal,eth,web3,admin --datadir #{homedir} 2>&1")
     {:ok, :ready} = Eth.WaitFor.eth_rpc()
 
     on_exit = fn -> stop(geth_pid) end


### PR DESCRIPTION
Covers two common situations:
 - when BlockQueue can't start because the `OMG.DB` mismatches with the contract
 - when BlockQueue can't submit blocks because the authority address is locked

When this happens we'll going to be building some relevant diagnostic data and including it in the error log.

Should help with issues like #662