### PR TITLE
refactor: prefix and configuration cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,7 +288,7 @@ This setting is usually set by running the `Mix.Tasks.Xomg.Watcher.Start` with t
 
 ### `OMG.DB` configuration - `:omg_db` app
 
-* **`leveldb_path`** - path to the directory holding the LevelDB data store
+* **`path`** - path to the directory holding the LevelDB data store
 
 * **`server_module`** - the module to use when talking to the `OMG.DB`
 

--- a/apps/omg_db/config/config.exs
+++ b/apps/omg_db/config/config.exs
@@ -3,14 +3,7 @@ use Mix.Config
 # see [here](README.md) for documentation
 
 config :omg_db,
-  # :leveldb, #:ets
-  type: :leveldb,
-  # leveldb
-  leveldb_path: Path.join([System.get_env("HOME"), ".omg/data"]),
-  # leveldb
-  server_module: OMG.DB.LevelDB.Server,
-  # leveldb
-  server_name: OMG.DB.LevelDB.Server,
-  r_server_module: OMG.DB.RocksDB.Server,
-  # leveldb
-  r_server_name: OMG.DB.RocksDB.Server
+  type: :rocksdb,
+  path: Path.join([System.get_env("HOME"), ".omg/data"]),
+  leveldb: [server_module: OMG.DB.LevelDB.Server, server_name: OMG.DB.LevelDB.Server],
+  rocksdb: [server_module: OMG.DB.RocksDB.Server, server_name: OMG.DB.RocksDB.Server]

--- a/apps/omg_db/config/config.exs
+++ b/apps/omg_db/config/config.exs
@@ -3,7 +3,7 @@ use Mix.Config
 # see [here](README.md) for documentation
 
 config :omg_db,
-  type: :rocksdb,
+  type: :leveldb,
   path: Path.join([System.get_env("HOME"), ".omg/data"]),
   leveldb: [server_module: OMG.DB.LevelDB.Server, server_name: OMG.DB.LevelDB.Server],
   rocksdb: [server_module: OMG.DB.RocksDB.Server, server_name: OMG.DB.RocksDB.Server]

--- a/apps/omg_db/lib/omg_db/level_db.ex
+++ b/apps/omg_db/lib/omg_db/level_db.ex
@@ -34,9 +34,8 @@ defmodule OMG.DB.LevelDB do
   end
 
   def child_spec do
-    db_path = Application.fetch_env!(:omg_db, :leveldb_path)
-    server_module = Application.fetch_env!(:omg_db, :server_module)
-    server_name = Application.fetch_env!(:omg_db, :server_name)
+    db_path = Application.fetch_env!(:omg_db, :path)
+    [server_module: server_module, server_name: server_name] = Application.fetch_env!(:omg_db, :leveldb)
     args = [db_path: db_path, name: server_name]
 
     %{
@@ -47,7 +46,7 @@ defmodule OMG.DB.LevelDB do
   end
 
   def child_spec([db_path: _db_path, name: server_name] = args) do
-    server_module = Application.fetch_env!(:omg_db, :server_module)
+    [server_module: server_module, server_name: _] = Application.fetch_env!(:omg_db, :leveldb)
 
     %{
       id: server_name,
@@ -128,9 +127,9 @@ defmodule OMG.DB.LevelDB do
   @doc """
   Does all of the initialization of `OMG.DB` based on the configured path
   """
-  def init, do: do_init(@server_name, Application.fetch_env!(:omg_db, :leveldb_path))
+  def init, do: do_init(@server_name, Application.fetch_env!(:omg_db, :path))
   def init(path) when is_binary(path), do: do_init(@server_name, path)
-  def init(server_name), do: do_init(server_name, Application.fetch_env!(:omg_db, :leveldb_path))
+  def init(server_name), do: do_init(server_name, Application.fetch_env!(:omg_db, :path))
   def init(server_name, path), do: do_init(server_name, path)
 
   defp do_init(server_name, path) do

--- a/apps/omg_db/lib/omg_db/leveldb/server.ex
+++ b/apps/omg_db/lib/omg_db/leveldb/server.ex
@@ -108,6 +108,7 @@ defmodule OMG.DB.LevelDB.Server do
     {:reply, result, state}
   end
 
+  @decorate measure_event()
   defp do_utxos(state) do
     result = get_all_by_type(:utxo, state)
     {:reply, result, state}

--- a/apps/omg_db/lib/omg_db/release_tasks/init_key_value_db.ex
+++ b/apps/omg_db/lib/omg_db/release_tasks/init_key_value_db.ex
@@ -21,7 +21,7 @@ defmodule OMG.DB.ReleaseTasks.InitKeyValueDB do
   alias OMG.Utils.CLI
 
   def run do
-    path = Application.get_env(:omg_db, :leveldb_path)
+    path = Application.get_env(:omg_db, :path)
     _ = process(path)
     :ok
   end

--- a/apps/omg_db/lib/omg_db/release_tasks/set_key_value_db.ex
+++ b/apps/omg_db/lib/omg_db/release_tasks/set_key_value_db.ex
@@ -21,7 +21,7 @@ defmodule OMG.DB.ReleaseTasks.SetKeyValueDB do
   @impl Provider
   def init(_args) do
     path = get_env("DB_PATH")
-    :ok = Application.put_env(:omg_db, :leveldb_path, path, persistent: true)
+    :ok = Application.put_env(:omg_db, :path, path, persistent: true)
   end
 
   defp get_env(key), do: validate(System.get_env(key))

--- a/apps/omg_db/lib/omg_db/rocks_db.ex
+++ b/apps/omg_db/lib/omg_db/rocks_db.ex
@@ -34,9 +34,8 @@ defmodule OMG.DB.RocksDB do
   end
 
   def child_spec do
-    db_path = Application.fetch_env!(:omg_db, :leveldb_path)
-    server_module = Application.fetch_env!(:omg_db, :r_server_module)
-    server_name = Application.fetch_env!(:omg_db, :r_server_name)
+    db_path = Application.fetch_env!(:omg_db, :path)
+    [server_module: server_module, server_name: server_name] = Application.fetch_env!(:omg_db, :rocksdb)
     args = [db_path: db_path, name: server_name]
 
     %{
@@ -47,7 +46,7 @@ defmodule OMG.DB.RocksDB do
   end
 
   def child_spec([db_path: _db_path, name: server_name] = args) do
-    server_module = Application.fetch_env!(:omg_db, :r_server_module)
+    [server_module: server_module, server_name: _] = Application.fetch_env!(:omg_db, :rocksdb)
 
     %{
       id: server_name,
@@ -128,9 +127,9 @@ defmodule OMG.DB.RocksDB do
   @doc """
   Does all of the initialization of `OMG.DB` based on the configured path
   """
-  def init, do: do_init(@server_name, Application.fetch_env!(:omg_db, :leveldb_path))
+  def init, do: do_init(@server_name, Application.fetch_env!(:omg_db, :path))
   def init(path) when is_binary(path), do: do_init(@server_name, path)
-  def init(server_name), do: do_init(server_name, Application.fetch_env!(:omg_db, :leveldb_path))
+  def init(server_name), do: do_init(server_name, Application.fetch_env!(:omg_db, :path))
   def init(server_name, path), do: do_init(server_name, path)
 
   defp do_init(server_name, path) do

--- a/apps/omg_db/lib/omg_db/rocksdb/server.ex
+++ b/apps/omg_db/lib/omg_db/rocksdb/server.ex
@@ -118,6 +118,7 @@ defmodule OMG.DB.RocksDB.Server do
     {:reply, result, state}
   end
 
+  @decorate measure_event()
   defp do_utxos(state) do
     result = get_all_by_type(:utxo, state)
     {:reply, result, state}

--- a/apps/omg_db/test/fixtures.exs
+++ b/apps/omg_db/test/fixtures.exs
@@ -22,13 +22,13 @@ defmodule OMG.DB.Fixtures do
     :ok = Application.put_env(:omg_db, :type, :leveldb, persistent: true)
     {:ok, briefly} = Application.ensure_all_started(:briefly)
     db_path = Briefly.create!(directory: true)
-    Application.put_env(:omg_db, :leveldb_path, db_path, persistent: true)
+    Application.put_env(:omg_db, :path, db_path, persistent: true)
 
     :ok = OMG.DB.init()
     {:ok, started_apps} = Application.ensure_all_started(:omg_db)
 
     on_exit(fn ->
-      Application.put_env(:omg_db, :leveldb_path, nil)
+      Application.put_env(:omg_db, :path, nil)
 
       (briefly ++ started_apps)
       |> Enum.reverse()

--- a/apps/omg_performance/lib/performance.ex
+++ b/apps/omg_performance/lib/performance.ex
@@ -146,7 +146,7 @@ defmodule OMG.Performance do
     DeferredConfig.populate(:omg_watcher)
     {:ok, _} = Application.ensure_all_started(:briefly)
     {:ok, dbdir} = Briefly.create(directory: true, prefix: "leveldb")
-    Application.put_env(:omg_db, :leveldb_path, dbdir, persistent: true)
+    Application.put_env(:omg_db, :path, dbdir, persistent: true)
     _ = Logger.info("Perftest leveldb path: #{inspect(dbdir)}")
 
     :ok = OMG.DB.init()
@@ -199,7 +199,7 @@ defmodule OMG.Performance do
 
     _ = Application.stop(:briefly)
 
-    Application.put_env(:omg_db, :leveldb_path, nil)
+    Application.put_env(:omg_db, :path, nil)
     :ok
   end
 

--- a/apps/omg_watcher/test/fixtures.exs
+++ b/apps/omg_watcher/test/fixtures.exs
@@ -120,7 +120,7 @@ defmodule OMG.Watcher.Fixtures do
     [] = DB.Block.get_all()
 
     on_exit(fn ->
-      Application.put_env(:omg_db, :leveldb_path, nil)
+      Application.put_env(:omg_db, :path, nil)
 
       (started_apps ++ started_watcher)
       |> Enum.reverse()

--- a/apps/omg_watcher/test/fixtures.exs
+++ b/apps/omg_watcher/test/fixtures.exs
@@ -39,7 +39,7 @@ defmodule OMG.Watcher.Fixtures do
     |> IO.binwrite("""
       #{OMG.Eth.DevHelpers.create_conf_file(contract)}
 
-      config :omg_db, leveldb_path: "#{db_path}"
+      config :omg_db, path: "#{db_path}"
       # this causes the inner test child chain server process to log debug. To see these logs adjust test's log level
       config :logger, level: :debug
       config :omg_child_chain, fee_specs_file_name: "#{fee_file}"

--- a/docs/manual_service_startup.md
+++ b/docs/manual_service_startup.md
@@ -160,7 +160,7 @@ You need to use a **different** location of the `OMG.DB` for the Watcher, so in 
 
 ```elixir
 config :omg_db,
-  leveldb_path: Path.join([System.get_env("HOME"), ".omg/data_watcher"])
+  path: Path.join([System.get_env("HOME"), ".omg/data_watcher"])
 ```
 
 #### Initialize the Watcher's databases

--- a/launcher.py
+++ b/launcher.py
@@ -261,7 +261,7 @@ class WatcherLauncher:
         self.contracts['GORLI'] = GORLI_CONTRACT
         self.watcher_additional_config = [
             'config :omg_db,',
-            '  leveldb_path: Path.join([System.get_env("HOME"), ".omg/data_watcher"])' # noqa E501
+            '  path: Path.join([System.get_env("HOME"), ".omg/data_watcher"])' # noqa E501
         ]
         self.contract_exchanger_url = contract_exchanger_url
         self.ethereum_rpc_url = ethereum_rpc_url


### PR DESCRIPTION
This addresses some of the configuration issues of using two databases with same configuration and sorts out the key prefixes used for iterator scans.
Also adds same measurements as we have for LDB.
