### PR TITLE
[FIX] Remove default petstore swagger from gh-pages

### DIFF
--- a/docs-ui/index.html
+++ b/docs-ui/index.html
@@ -39,7 +39,7 @@
     window.onload = function() {
       // Begin Swagger UI call region
       const ui = SwaggerUIBundle({
-        url: "https://petstore.swagger.io/v2/swagger.json",
+        url: "/master/operator_api_swagger.json",
         dom_id: '#swagger-ui',
         deepLinking: true,
         presets: [


### PR DESCRIPTION
:clipboard: https://github.com/omisego/elixir-omg/projects/2#card-21320447

**What changed and why?**

https://developer.omisego.co/elixir-omg/docs-ui/ currently shows the default swagger UI's Petstore endpoint. This upates it to just use our child chain endpoint for now.

**How was this tested?**

Visually using `caddy`:

```bash
elixir-omg/docs-ui/ $ caddy --host 0.0.0.0
```