### PR TITLE
fix: make deposits written to WatcherDB always come before getter's txs

### DIFF
--- a/apps/omg_watcher/lib/supervisor.ex
+++ b/apps/omg_watcher/lib/supervisor.ex
@@ -35,11 +35,14 @@ defmodule OMG.Watcher.Supervisor do
 
     %{
       depositor: [finality_margin: deposit_finality_margin],
-      convenience_deposit_processor: [waits_for: [:depositor], finality_margin: finality_margin],
-      "Elixir.OMG.Watcher.BlockGetter": [waits_for: [depositor: :no_margin], finality_margin: 0],
+      convenience_deposit_processor: [waits_for: [:depositor], finality_margin: deposit_finality_margin],
+      "Elixir.OMG.Watcher.BlockGetter": [
+        waits_for: [depositor: :no_margin, convenience_deposit_processor: :no_margin],
+        finality_margin: 0
+      ],
       exit_processor: [waits_for: :depositor, finality_margin: finality_margin],
       convenience_exit_processor: [
-        waits_for: [:depositor, :"Elixir.OMG.Watcher.BlockGetter"],
+        waits_for: [:convenience_deposit_processor, :"Elixir.OMG.Watcher.BlockGetter"],
         finality_margin: finality_margin
       ],
       exit_finalizer: [

--- a/apps/omg_watcher/test/supervisor_test.exs
+++ b/apps/omg_watcher/test/supervisor_test.exs
@@ -54,29 +54,34 @@ defmodule OMG.Watcher.SupervisorTest do
     assert %{sync_height: 1, root_chain_height: 10} = Core.get_synced_info(state, @pid[getter])
 
     # depositor advances
-    assert {:ok, state} = Core.check_in(state, @pid[:depositor], 10, :depositor)
+    assert {:ok, state} = Core.check_in(state, @pid[:depositor], 9, :depositor)
     assert %{sync_height: 9, root_chain_height: 9} = Core.get_synced_info(state, @pid[:exit_processor])
     assert %{sync_height: 9, root_chain_height: 9} = Core.get_synced_info(state, @pid[:in_flight_exit_processor])
     assert %{sync_height: 9, root_chain_height: 9} = Core.get_synced_info(state, @pid[:convenience_deposit_processor])
 
+    # convenience depositor advances allowing to put blocks into Postgres via `BlockGetter`
+    assert %{sync_height: 1, root_chain_height: 10} = Core.get_synced_info(state, @pid[getter])
+    assert {:ok, state} = Core.check_in(state, @pid[:convenience_deposit_processor], 9, :convenience_deposit_processor)
+    assert %{sync_height: 10, root_chain_height: 10} = Core.get_synced_info(state, @pid[getter])
+
     # exit_processor advances
     assert %{sync_height: 0, root_chain_height: 9} = Core.get_synced_info(state, @pid[:exit_challenger])
-    assert {:ok, state} = Core.check_in(state, @pid[:exit_processor], 10, :exit_processor)
+    assert {:ok, state} = Core.check_in(state, @pid[:exit_processor], 9, :exit_processor)
     assert %{sync_height: 9, root_chain_height: 9} = Core.get_synced_info(state, @pid[:exit_challenger])
 
     # in flights advance
     assert %{sync_height: 0, root_chain_height: 9} = Core.get_synced_info(state, @pid[:piggyback_processor])
     assert %{sync_height: 0, root_chain_height: 9} = Core.get_synced_info(state, @pid[:competitor_processor])
-    assert {:ok, state} = Core.check_in(state, @pid[:in_flight_exit_processor], 10, :in_flight_exit_processor)
+    assert {:ok, state} = Core.check_in(state, @pid[:in_flight_exit_processor], 9, :in_flight_exit_processor)
     assert %{sync_height: 9, root_chain_height: 9} = Core.get_synced_info(state, @pid[:piggyback_processor])
     assert %{sync_height: 9, root_chain_height: 9} = Core.get_synced_info(state, @pid[:competitor_processor])
 
     assert %{sync_height: 0, root_chain_height: 9} = Core.get_synced_info(state, @pid[:piggyback_challenges_processor])
-    assert {:ok, state} = Core.check_in(state, @pid[:piggyback_processor], 10, :piggyback_processor)
+    assert {:ok, state} = Core.check_in(state, @pid[:piggyback_processor], 9, :piggyback_processor)
     assert %{sync_height: 9, root_chain_height: 9} = Core.get_synced_info(state, @pid[:piggyback_challenges_processor])
 
     assert %{sync_height: 0, root_chain_height: 9} = Core.get_synced_info(state, @pid[:challenges_responds_processor])
-    assert {:ok, state} = Core.check_in(state, @pid[:competitor_processor], 10, :competitor_processor)
+    assert {:ok, state} = Core.check_in(state, @pid[:competitor_processor], 9, :competitor_processor)
     assert %{sync_height: 9, root_chain_height: 9} = Core.get_synced_info(state, @pid[:challenges_responds_processor])
 
     # BlockGetter advances
@@ -90,10 +95,10 @@ defmodule OMG.Watcher.SupervisorTest do
 
     # root chain advances
     assert {:ok, state} = Core.update_root_chain_height(state, 100)
-    assert %{sync_height: 10, root_chain_height: 99} = Core.get_synced_info(state, @pid[:exit_finalizer])
-    assert %{sync_height: 10, root_chain_height: 99} = Core.get_synced_info(state, @pid[:convenience_exit_processor])
-    assert %{sync_height: 10, root_chain_height: 99} = Core.get_synced_info(state, @pid[:ife_exit_finalizer])
+    assert %{sync_height: 9, root_chain_height: 99} = Core.get_synced_info(state, @pid[:exit_finalizer])
+    assert %{sync_height: 9, root_chain_height: 99} = Core.get_synced_info(state, @pid[:convenience_exit_processor])
+    assert %{sync_height: 9, root_chain_height: 99} = Core.get_synced_info(state, @pid[:ife_exit_finalizer])
     assert %{sync_height: 99, root_chain_height: 99} = Core.get_synced_info(state, @pid[:depositor])
-    assert %{sync_height: 11, root_chain_height: 100} = Core.get_synced_info(state, @pid[getter])
+    assert %{sync_height: 10, root_chain_height: 100} = Core.get_synced_info(state, @pid[getter])
   end
 end


### PR DESCRIPTION
fixes #695

The problem noted was that a transaction managed to slip through and be processed on the WatcherDB end before a deposit.

Now we explicitly make the `BlockGetter` service wait for `convenience_deposit_processor`.