### PR TITLE
Proper ife response handler

### DIFF
--- a/apps/omg_watcher/lib/omg_watcher/exit_processor.ex
+++ b/apps/omg_watcher/lib/omg_watcher/exit_processor.ex
@@ -318,22 +318,20 @@ defmodule OMG.Watcher.ExitProcessor do
     # TODO: run_status_gets and getting all non-existent UTXO positions imaginable can be optimized out heavily
     #       only the UTXO positions being inputs to `txbytes` must be looked at, but it becomes problematic as
     #       txbytes can be invalid so we'd need a with here...
+    new_state = update_with_ife_txs_from_blocks(state)
+
     competitor_result =
       %ExitProcessor.Request{}
-      |> fill_request_with_spending_data(state)
-      |> Core.get_competitor_for_ife(state, txbytes)
+      |> fill_request_with_spending_data(new_state)
+      |> Core.get_competitor_for_ife(new_state, txbytes)
 
-    {:reply, competitor_result, state}
+    {:reply, competitor_result, new_state}
   end
 
   def handle_call({:prove_canonical_for_ife, txbytes}, _from, state) do
-    # TODO: same comment as above in get_competitor_for_ife
-    canonicity_result =
-      %ExitProcessor.Request{}
-      |> fill_request_with_spending_data(state)
-      |> Core.prove_canonical_for_ife(txbytes)
-
-    {:reply, canonicity_result, state}
+    new_state = update_with_ife_txs_from_blocks(state)
+    canonicity_result = Core.prove_canonical_for_ife(new_state, txbytes)
+    {:reply, canonicity_result, new_state}
   end
 
   def handle_call({:get_input_challenge_data, txbytes, input_index}, _from, state) do

--- a/apps/omg_watcher/lib/omg_watcher/exit_processor.ex
+++ b/apps/omg_watcher/lib/omg_watcher/exit_processor.ex
@@ -150,7 +150,8 @@ defmodule OMG.Watcher.ExitProcessor do
   a non-canonical in-flight exit
   """
   @decorate measure_event()
-  @spec get_competitor_for_ife(binary()) :: {:ok, Core.competitor_data_t()} | {:error, :competitor_not_found}
+  @spec get_competitor_for_ife(binary()) ::
+          {:ok, Core.competitor_data_t()} | {:error, :competitor_not_found} | {:error, :no_viable_competitor_found}
   def get_competitor_for_ife(txbytes) do
     GenServer.call(__MODULE__, {:get_competitor_for_ife, txbytes})
   end
@@ -160,7 +161,8 @@ defmodule OMG.Watcher.ExitProcessor do
   for a challenged in-flight exit
   """
   @decorate measure_event()
-  @spec prove_canonical_for_ife(binary()) :: {:ok, Core.prove_canonical_data_t()} | {:error, :canonical_not_found}
+  @spec prove_canonical_for_ife(binary()) ::
+          {:ok, Core.prove_canonical_data_t()} | {:error, :no_viable_canonical_proof_found}
   def prove_canonical_for_ife(txbytes) do
     GenServer.call(__MODULE__, {:prove_canonical_for_ife, txbytes})
   end

--- a/apps/omg_watcher/lib/omg_watcher/exit_processor/core.ex
+++ b/apps/omg_watcher/lib/omg_watcher/exit_processor/core.ex
@@ -979,7 +979,7 @@ defmodule OMG.Watcher.ExitProcessor.Core do
   Gets the root chain contract-required set of data to challenge a non-canonical ife
   """
   @spec get_competitor_for_ife(ExitProcessor.Request.t(), __MODULE__.t(), binary()) ::
-          {:ok, competitor_data_t()} | {:error, :competitor_not_found}
+          {:ok, competitor_data_t()} | {:error, :competitor_not_found} | {:error, :no_viable_competitor_found}
   def get_competitor_for_ife(
         %ExitProcessor.Request{blocks_result: blocks},
         %__MODULE__{} = state,
@@ -1001,11 +1001,11 @@ defmodule OMG.Watcher.ExitProcessor.Core do
   contract but which is known to be canonical locally because included in one of the blocks
   """
   @spec prove_canonical_for_ife(t(), binary()) ::
-          {:ok, prove_canonical_data_t()} | {:error, :canonical_not_found}
+          {:ok, prove_canonical_data_t()} | {:error, :no_viable_canonical_proof_found}
   def prove_canonical_for_ife(%__MODULE__{} = state, ife_txbytes) do
     with {:ok, raw_ife_tx} <- Transaction.decode(ife_txbytes),
          {:ok, ife} <- get_ife(raw_ife_tx, state),
-         true <- InFlightExitInfo.is_invalidly_challenged?(ife) || {:error, :canonical_not_found},
+         true <- InFlightExitInfo.is_invalidly_challenged?(ife) || {:error, :no_viable_canonical_proof_found},
          do: {:ok, prepare_canonical_response(ife)}
   end
 

--- a/apps/omg_watcher/lib/omg_watcher/exit_processor/in_flight_exit_info.ex
+++ b/apps/omg_watcher/lib/omg_watcher/exit_processor/in_flight_exit_info.ex
@@ -372,7 +372,7 @@ defmodule OMG.Watcher.ExitProcessor.InFlightExitInfo do
 
   @doc """
   First, it determines if it is challenged at all - if it isn't returns false.
-  Decond, If the tx hasn't been seen at all then it will be false
+  Second, If the tx hasn't been seen at all then it will be false
   If it is challenged (hence non-canonical) and seen it will figure out if the IFE tx has been seen in an older than
   oldest competitor's position.
   """

--- a/apps/omg_watcher/lib/omg_watcher/exit_processor/in_flight_exit_info.ex
+++ b/apps/omg_watcher/lib/omg_watcher/exit_processor/in_flight_exit_info.ex
@@ -261,7 +261,7 @@ defmodule OMG.Watcher.ExitProcessor.InFlightExitInfo do
           t() | {:error, :responded_with_too_young_tx | :cannot_respond}
   def respond_to_challenge(ife, tx_position)
 
-  def respond_to_challenge(%__MODULE__{oldest_competitor: current_oldest, contract_tx_pos: nil} = ife, tx_position) do
+  def respond_to_challenge(%__MODULE__{oldest_competitor: current_oldest} = ife, tx_position) do
     decoded = Utxo.Position.decode!(tx_position)
 
     if is_nil(current_oldest) or is_older?(decoded, current_oldest) do

--- a/apps/omg_watcher/test/omg_watcher/exit_processor/core_test.exs
+++ b/apps/omg_watcher/test/omg_watcher/exit_processor/core_test.exs
@@ -775,43 +775,6 @@ defmodule OMG.Watcher.ExitProcessor.CoreTest do
       assert {:error, _} = Core.get_output_challenge_data(request, state, txbytes(tx), 0)
     end
 
-    test "handles well situation when syncing is in progress",
-         %{processor_filled: state, ife_tx_hashes: [ife_id | _]} do
-      state = piggyback_ife_from(state, ife_id, 4)
-
-      assert %ExitProcessor.Request{utxos_to_check: [], ife_input_utxos_to_check: []} =
-               %ExitProcessor.Request{eth_height_now: 13, blknum_now: 0}
-               |> Core.determine_ife_input_utxos_existence_to_get(state)
-               |> Core.determine_utxo_existence_to_get(state)
-    end
-
-    test "seeks piggybacked-output-spending txs in blocks",
-         %{processor_filled: processor, transactions: [tx | _], ife_tx_hashes: [ife_id | _]} do
-      # if an output-piggybacking transaction is included in some block, we need to seek blocks that could be spending
-      processor = piggyback_ife_from(processor, ife_id, 4)
-
-      tx_blknum = 3000
-
-      exit_processor_request = %ExitProcessor.Request{
-        blknum_now: 5000,
-        eth_height_now: 5,
-        blocks_result: [Block.hashed_txs_at([tx], tx_blknum)]
-      }
-
-      # for one piggybacked output, we're asking for its inputs positions to check utxo existence
-      request = Core.determine_ife_input_utxos_existence_to_get(exit_processor_request, processor)
-      assert Utxo.position(1, 0, 0) in request.ife_input_utxos_to_check
-      assert Utxo.position(1, 2, 1) in request.ife_input_utxos_to_check
-
-      # if it turns out to not exists, we're fetching the spending block
-      request =
-        exit_processor_request
-        |> struct!(%{ife_input_utxos_to_check: [Utxo.position(1, 0, 0)], ife_input_utxo_exists_result: [false]})
-        |> Core.determine_ife_spends_to_get(processor)
-
-      assert Utxo.position(1, 0, 0) in request.ife_input_spends_to_get
-    end
-
     test "detects multiple double-spends in single IFE, correctly as more piggybacks appear",
          %{alice: alice, processor_filled: state, transactions: [tx | _], ife_tx_hashes: [ife_id | _]} do
       tx_blknum = 3000
@@ -1128,58 +1091,134 @@ defmodule OMG.Watcher.ExitProcessor.CoreTest do
       comp_txbytes = txbytes(comp)
       other_blknum = 3000
 
-      exit_processor_request = %ExitProcessor.Request{
+      request = %ExitProcessor.Request{
         blknum_now: 5000,
         eth_height_now: 5,
-        blocks_result: [Block.hashed_txs_at([comp, comp], other_blknum)]
+        blocks_result: [Block.hashed_txs_at([comp, comp], other_blknum)],
+        ife_input_spending_blocks_result: [Block.hashed_txs_at([comp, comp], other_blknum)]
       }
 
-      # the transaction is firstmost submitted as a competitor and used to challenge with no inclusion proof
-      processor = processor |> start_ife_from(comp)
-      challenge = ife_challenge(tx1, comp)
+      # the transaction is firstmost submitted as a competitor, plus we run the preliminary lookup
+      processor = processor |> start_ife_from(comp) |> Core.find_ifes_in_blocks(request)
 
-      # sanity check - there's two non-canonicals, because IFE compete with each other
-      # after the first challenge there should be only one, after the final challenge - none
-      assert {:ok, [_, _]} = exit_processor_request |> check_validity_filtered(processor, only: [Event.NonCanonicalIFE])
+      # after the first, intermediate challenges, there should still be that event active
+      assert_intermediate_result = fn processor ->
+        assert {:ok, [%Event.NonCanonicalIFE{txbytes: ^txbytes}]} =
+                 request |> check_validity_filtered(processor, only: [Event.NonCanonicalIFE])
 
-      assert_competitors_work = fn processor ->
-        # should be `assert {:ok, [_, _]}` but we have OMG-441 (see other comment)
-        assert {:ok, [_]} = exit_processor_request |> check_validity_filtered(processor, only: [Event.NonCanonicalIFE])
-
+        # this request always returns the oldest competitor, even if we later use a different one
         assert {:ok, %{competing_txbytes: ^comp_txbytes, competing_tx_pos: Utxo.position(^other_blknum, 0, 0)}} =
-                 exit_processor_request |> Core.get_competitor_for_ife(processor, txbytes)
+                 request |> Core.get_competitor_for_ife(processor, txbytes)
       end
 
-      # challenge with IFE (no position)
-      {processor, _} = Core.new_ife_challenges(processor, [challenge])
-      assert_competitors_work.(processor)
+      # sanity check - no challenges yet
+      assert_intermediate_result.(processor)
 
-      # challenge with the younger competitor (incomplete challenge)
+      # now `comp` is used to challenge with no inclusion proof: challenge with IFE (no position, incomplete)
+      challenge = ife_challenge(tx1, comp)
+      {processor, _} = Core.new_ife_challenges(processor, [challenge])
+      assert_intermediate_result.(processor)
+
+      # challenge with the younger competitor (still incomplete challenge)
       young_challenge = ife_challenge(tx1, comp, competitor_position: Utxo.position(other_blknum, 1, 0))
       {processor, _} = Core.new_ife_challenges(processor, [young_challenge])
-      assert_competitors_work.(processor)
+      assert_intermediate_result.(processor)
 
-      # challenge with the older competitor (final)
+      # challenge with the older competitor (complete!)
       older_challenge = ife_challenge(tx1, comp, competitor_position: Utxo.position(other_blknum, 0, 0))
       {processor, _} = Core.new_ife_challenges(processor, [older_challenge])
-      # NOTE: should be like this - only the "other" IFE remains challenged, because our main one got challenged by the
-      # oldest competitor now):
-      # assert {:ok, [_]} = exit_processor_request |> check_validity_filtered(processor, only: [Event.NonCanonicalIFE])?
-      #
-      # i.e. if the challenge present is no the oldest competitor, we still should challenge. After it is the oldest
-      # we stop bothering, see OMG-441
-      #
-      # this is temporary behavior being tested:
-      assert_competitors_work.(processor)
+      # the tx1 IFE got challenged by the oldest competitor now; finally, it's over:
+      assert {:ok, []} = request |> check_validity_filtered(processor, only: [Event.NonCanonicalIFE])
+      assert {:error, :no_viable_competitor_found} = request |> Core.get_competitor_for_ife(processor, txbytes)
     end
 
-    test "none if IFE is challenged enough already",
+    test "don't show competitors, if IFE tx is included",
          %{processor_filled: processor, transactions: [tx1 | _], competing_tx: comp} do
       txbytes = txbytes(tx1)
       comp_txbytes = txbytes(comp)
       other_blknum = 3000
 
-      exit_processor_request = %ExitProcessor.Request{
+      request = %ExitProcessor.Request{
+        blknum_now: 5000,
+        eth_height_now: 5,
+        ife_input_spending_blocks_result: [Block.hashed_txs_at([tx1], other_blknum)]
+      }
+
+      processor = processor |> start_ife_from(comp) |> Core.find_ifes_in_blocks(request)
+
+      # notice this is `comp` having a competitor reported, not `tx1`
+      assert {:ok, [%Event.NonCanonicalIFE{txbytes: ^comp_txbytes}]} =
+               request |> check_validity_filtered(processor, only: [Event.NonCanonicalIFE])
+
+      assert {:error, :no_viable_competitor_found} = request |> Core.get_competitor_for_ife(processor, txbytes)
+    end
+
+    test "don't show competitors, if IFE tx is included and is the oldest",
+         %{processor_filled: processor, transactions: [tx1 | _], competing_tx: comp} do
+      txbytes = txbytes(tx1)
+      other_blknum = 3000
+
+      request = %ExitProcessor.Request{
+        blknum_now: 5000,
+        eth_height_now: 5,
+        blocks_result: [Block.hashed_txs_at([tx1, comp], other_blknum)],
+        ife_input_spending_blocks_result: [Block.hashed_txs_at([tx1, comp], other_blknum)]
+      }
+
+      processor = processor |> Core.find_ifes_in_blocks(request)
+      # notice this is `comp` having a competitor reported, not `tx1`
+      assert {:ok, []} = request |> check_validity_filtered(processor, only: [Event.NonCanonicalIFE])
+      assert {:error, :no_viable_competitor_found} = request |> Core.get_competitor_for_ife(processor, txbytes)
+    end
+
+    test "show competitors, if IFE tx is included but not the oldest",
+         %{processor_filled: processor, transactions: [tx1 | _], competing_tx: comp} do
+      txbytes = txbytes(tx1)
+      other_blknum = 3000
+
+      request = %ExitProcessor.Request{
+        blknum_now: 5000,
+        eth_height_now: 5,
+        blocks_result: [Block.hashed_txs_at([comp, tx1], other_blknum)],
+        ife_input_spending_blocks_result: [Block.hashed_txs_at([comp, tx1], other_blknum)]
+      }
+
+      processor = processor |> Core.find_ifes_in_blocks(request)
+      # notice this is `comp` having a competitor reported, not `tx1`
+      assert {:ok, [%Event.NonCanonicalIFE{txbytes: ^txbytes}]} =
+               request |> check_validity_filtered(processor, only: [Event.NonCanonicalIFE])
+
+      assert {:ok, %{}} = request |> Core.get_competitor_for_ife(processor, txbytes)
+    end
+
+    test "show competitors, if IFE tx is included but not the oldest - distinct blocks",
+         %{processor_filled: processor, transactions: [tx1 | _], competing_tx: comp} do
+      txbytes = txbytes(tx1)
+      block1 = Block.hashed_txs_at([comp], 3000)
+      block2 = Block.hashed_txs_at([tx1], 4000)
+
+      request = %ExitProcessor.Request{
+        blknum_now: 5000,
+        eth_height_now: 5,
+        blocks_result: [block1, block2],
+        # note the flipped order here, all still works as the blocks should be processed starting from oldest
+        ife_input_spending_blocks_result: [block2, block1]
+      }
+
+      processor = processor |> Core.find_ifes_in_blocks(request)
+      # notice this is `comp` having a competitor reported, not `tx1`
+      assert {:ok, [%Event.NonCanonicalIFE{txbytes: ^txbytes}]} =
+               request |> check_validity_filtered(processor, only: [Event.NonCanonicalIFE])
+
+      assert {:ok, %{}} = request |> Core.get_competitor_for_ife(processor, txbytes)
+    end
+
+    test "none if IFE is challenged enough already",
+         %{processor_filled: processor, transactions: [tx1 | _], competing_tx: comp} do
+      txbytes = txbytes(tx1)
+      other_blknum = 3000
+
+      request = %ExitProcessor.Request{
         blknum_now: 5000,
         eth_height_now: 5,
         blocks_result: [Block.hashed_txs_at([comp], other_blknum)]
@@ -1190,11 +1229,8 @@ defmodule OMG.Watcher.ExitProcessor.CoreTest do
 
       {processor, _} = Core.new_ife_challenges(processor, [challenge])
 
-      assert {:ok, []} = exit_processor_request |> check_validity_filtered(processor, only: [Event.NonCanonicalIFE])
-
-      # getting the competitor is still valid, so allowing this
-      assert {:ok, %{competing_txbytes: ^comp_txbytes, competing_tx_pos: Utxo.position(other_blknum, 0, 0)}} =
-               exit_processor_request |> Core.get_competitor_for_ife(processor, txbytes)
+      assert {:ok, []} = request |> check_validity_filtered(processor, only: [Event.NonCanonicalIFE])
+      assert {:error, :no_viable_competitor_found} = request |> Core.get_competitor_for_ife(processor, txbytes)
     end
 
     test "a competitor having the double-spend on various input indices",
@@ -1394,8 +1430,11 @@ defmodule OMG.Watcher.ExitProcessor.CoreTest do
       exit_processor_request = %ExitProcessor.Request{
         blknum_now: 5000,
         eth_height_now: 5,
-        blocks_result: [Block.hashed_txs_at(txs, other_blknum)]
+        blocks_result: [Block.hashed_txs_at(txs, other_blknum)],
+        ife_input_spending_blocks_result: [Block.hashed_txs_at(txs, other_blknum)]
       }
+
+      challenged_processor = challenged_processor |> Core.find_ifes_in_blocks(exit_processor_request)
 
       assert {:ok, [%Event.InvalidIFEChallenge{txbytes: ^txbytes}]} =
                exit_processor_request |> Core.check_validity(challenged_processor)
@@ -1425,15 +1464,39 @@ defmodule OMG.Watcher.ExitProcessor.CoreTest do
                %ExitProcessor.Request{blknum_now: 5000, eth_height_now: 5} |> Core.prove_canonical_for_ife(<<0>>)
     end
 
-    test "none if ifes are canonical", %{processor_filled: processor} do
+    test "none if ifes are fresh and canonical by default", %{processor_filled: processor} do
       assert {:ok, []} =
                %ExitProcessor.Request{blknum_now: 5000, eth_height_now: 5}
                |> check_validity_filtered(processor, exclude: [Event.PiggybackAvailable])
     end
 
-    # TODO: implement more behavior tests
     test "none if challenge gets responded and ife canonical",
-         %{} do
+         %{processor_filled: processor, transactions: [tx | _] = txs, competing_tx: comp} do
+      {processor, _} = Core.new_ife_challenges(processor, [ife_challenge(tx, comp)])
+      txbytes = Transaction.raw_txbytes(tx)
+      other_blknum = 3000
+
+      request = %ExitProcessor.Request{
+        blknum_now: 5000,
+        eth_height_now: 5,
+        blocks_result: [Block.hashed_txs_at(txs, other_blknum)],
+        ife_input_spending_blocks_result: [Block.hashed_txs_at(txs, other_blknum)]
+      }
+
+      processor = processor |> Core.find_ifes_in_blocks(request)
+
+      # sanity check
+      assert {:ok, [%Event.InvalidIFEChallenge{}]} = request |> Core.check_validity(processor)
+
+      {processor, _} =
+        processor
+        |> Core.respond_to_in_flight_exits_challenges([ife_response(tx, Utxo.position(other_blknum, 0, 0))])
+
+      assert {:ok, []} = request |> Core.check_validity(processor)
+
+      assert {:ok, %{}} =
+               request
+               |> Core.prove_canonical_for_ife(txbytes)
     end
   end
 
@@ -1634,6 +1697,67 @@ defmodule OMG.Watcher.ExitProcessor.CoreTest do
     @tag :capture_log
     test "asks for the right blocks if some spends are missing" do
       assert [1000] = Core.handle_spent_blknum_result([:not_found, 1000], [@utxo_pos2, @utxo_pos1])
+    end
+  end
+
+  describe "finding IFE txs in blocks" do
+    test "handles well situation when syncing is in progress", %{processor_filled: state} do
+      assert %ExitProcessor.Request{utxos_to_check: [], ife_input_utxos_to_check: []} =
+               %ExitProcessor.Request{eth_height_now: 13, blknum_now: 0}
+               |> Core.determine_ife_input_utxos_existence_to_get(state)
+               |> Core.determine_utxo_existence_to_get(state)
+    end
+
+    test "seeks all IFE txs' inputs spends in blocks", %{processor_filled: processor} do
+      request = %ExitProcessor.Request{
+        blknum_now: 5000,
+        eth_height_now: 5
+      }
+
+      # for one piggybacked output, we're asking for its inputs positions to check utxo existence
+      request = Core.determine_ife_input_utxos_existence_to_get(request, processor)
+
+      assert [Utxo.position(1, 0, 0), Utxo.position(1, 2, 1), Utxo.position(2, 1, 0), Utxo.position(2, 2, 1)] ==
+               request.ife_input_utxos_to_check
+
+      # if it turns out to not exists, we're fetching the spending block
+      request =
+        request
+        |> struct!(%{ife_input_utxo_exists_result: [false, true, true, true]})
+        |> Core.determine_ife_spends_to_get(processor)
+
+      assert [Utxo.position(1, 0, 0)] == request.ife_input_spends_to_get
+    end
+
+    test "seeks IFE txs in blocks, correctly if IFE inputs duplicate", %{processor_filled: processor, alice: alice} do
+      other_tx = TestHelper.create_recovered([{1, 0, 0, alice}], [])
+      processor = processor |> start_ife_from(other_tx)
+
+      request = %ExitProcessor.Request{
+        blknum_now: 5000,
+        eth_height_now: 5
+      }
+
+      # for one piggybacked output, we're asking for its inputs positions to check utxo existence
+      request = Core.determine_ife_input_utxos_existence_to_get(request, processor)
+
+      assert [Utxo.position(1, 0, 0), Utxo.position(1, 2, 1), Utxo.position(2, 1, 0), Utxo.position(2, 2, 1)] ==
+               request.ife_input_utxos_to_check
+    end
+
+    test "seeks IFE txs in blocks only if not already found",
+         %{processor_filled: processor, transactions: [tx | _]} do
+      request = %ExitProcessor.Request{
+        blknum_now: 5000,
+        eth_height_now: 5,
+        ife_input_spending_blocks_result: [Block.hashed_txs_at([tx], 3000)]
+      }
+
+      processor = processor |> Core.find_ifes_in_blocks(request)
+      # for one piggybacked output, we're asking for its inputs positions to check utxo existence
+      request = Core.determine_ife_input_utxos_existence_to_get(request, processor)
+
+      assert [Utxo.position(2, 1, 0), Utxo.position(2, 2, 1)] == request.ife_input_utxos_to_check
     end
   end
 

--- a/apps/omg_watcher/test/omg_watcher/exit_processor/core_test.exs
+++ b/apps/omg_watcher/test/omg_watcher/exit_processor/core_test.exs
@@ -1485,7 +1485,7 @@ defmodule OMG.Watcher.ExitProcessor.CoreTest do
 
       processor = processor |> Core.find_ifes_in_blocks(request)
       assert {:ok, []} = request |> check_validity_filtered(processor, only: [Event.InvalidIFEChallenge])
-      assert {:error, :canonical_not_found} = Core.prove_canonical_for_ife(processor, txbytes)
+      assert {:error, :no_viable_canonical_proof_found} = Core.prove_canonical_for_ife(processor, txbytes)
     end
   end
 

--- a/apps/omg_watcher/test/omg_watcher/exit_processor/persistence_test.exs
+++ b/apps/omg_watcher/test/omg_watcher/exit_processor/persistence_test.exs
@@ -29,6 +29,8 @@ defmodule OMG.Watcher.ExitProcessor.PersistenceTest do
 
   require Utxo
 
+  import OMG.Watcher.ExitProcessor.TestHelper
+
   @eth OMG.Eth.RootChain.eth_pseudo_address()
   @zero_address OMG.Eth.zero_address()
 
@@ -97,22 +99,18 @@ defmodule OMG.Watcher.ExitProcessor.PersistenceTest do
     |> persist_finalize_exits({[], [@utxo_pos1, @utxo_pos2]}, db_pid)
   end
 
-  test "persist challenges and challenge responses",
+  test "persist challenges",
        %{processor_empty: processor, db_pid: db_pid, exits: {exit_events, statuses}} do
     processor
     |> persist_new_exits(exit_events, statuses, db_pid)
     |> persist_challenge_exits([@utxo_pos1], db_pid)
-    # NOTE: this might break when respond_to_in_flight_exits_challenges is actually implemented, it works because noop
-    |> persist_respond_to_in_flight_exits_challenges([@utxo_pos1], db_pid)
   end
 
-  test "persist multiple challenges and challenge responses",
+  test "persist multiple challenges",
        %{processor_empty: processor, db_pid: db_pid, exits: {exit_events, statuses}} do
     processor
     |> persist_new_exits(exit_events, statuses, db_pid)
     |> persist_challenge_exits([@utxo_pos2, @utxo_pos1], db_pid)
-    # NOTE: this might break when respond_to_in_flight_exits_challenges is actually implemented, it works because noop
-    |> persist_respond_to_in_flight_exits_challenges([@utxo_pos2, @utxo_pos1], db_pid)
   end
 
   test "persist started ifes regardless of status",
@@ -154,6 +152,7 @@ defmodule OMG.Watcher.ExitProcessor.PersistenceTest do
     |> persist_new_ife_challenges([challenge], db_pid)
     |> persist_challenge_piggybacks(piggybacks2, db_pid)
     |> persist_challenge_piggybacks(piggybacks1, db_pid)
+    |> persist_respond_to_in_flight_exits_challenges([ife_response(tx, @utxo_pos1)], db_pid)
   end
 
   test "persist ife finalizations",

--- a/apps/omg_watcher/test/omg_watcher/integration/in_flight_exit_test.exs
+++ b/apps/omg_watcher/test/omg_watcher/integration/in_flight_exit_test.exs
@@ -60,18 +60,7 @@ defmodule OMG.Watcher.Integration.InFlightExitTest do
       |> Transaction.Signed.encode()
     )
 
-    in_flight_exit_submit = tx_submit1 |> Transaction.Signed.encode() |> TestHelper.get_in_flight_exit()
-
-    # IFE tx 1
-    {:ok, %{"status" => "0x1"}} =
-      OMG.Eth.RootChain.in_flight_exit(
-        in_flight_exit_submit["in_flight_tx"],
-        in_flight_exit_submit["input_txs"],
-        in_flight_exit_submit["input_txs_inclusion_proofs"],
-        in_flight_exit_submit["in_flight_tx_sigs"],
-        alice.addr
-      )
-      |> Eth.DevHelpers.transact_sync!()
+    {:ok, %{"status" => "0x1"}} = exit_in_flight(tx_submit1, alice)
 
     txbytes1 = Transaction.raw_txbytes(tx_submit1)
     {:ok, ife_id} = OMG.Eth.RootChain.get_in_flight_exit_id(txbytes1)
@@ -116,7 +105,7 @@ defmodule OMG.Watcher.Integration.InFlightExitTest do
     assert %{
              "byzantine_events" => [
                %{"event" => "invalid_piggyback"},
-               %{"event" => "non_canonical_ife"},
+               # only a single non_canonical event, since on of the IFE tx is included!
                %{"event" => "non_canonical_ife"},
                # only piggyback_available for tx2 is present, tx1 is included in block and does not spawn that event
                %{"event" => "piggyback_available"}
@@ -169,13 +158,81 @@ defmodule OMG.Watcher.Integration.InFlightExitTest do
   end
 
   @tag fixtures: [:watcher, :alice, :bob, :child_chain, :token, :alice_deposits]
-  test "in-flight exit competitor is detected by watcher",
+  test "in-flight exit competitor is detected by watcher and proven with position immediately",
        %{alice: alice, bob: bob, alice_deposits: {deposit_blknum, _}} do
-    # Bob, we need you (Bob's going to send some Ethereum transactions)
-    Eth.DevHelpers.import_unlock_fund(bob)
-
     # tx1 is submitted then in-flight-exited
     # tx2 is in-flight-exited
+    tx1 = OMG.TestHelper.create_signed([{deposit_blknum, 0, 0, alice}], @eth, [{alice, 5}, {alice, 5}])
+    tx2 = OMG.TestHelper.create_signed([{deposit_blknum, 0, 0, alice}], @eth, [{bob, 10}])
+
+    assert %{
+             "blknum" => blknum,
+             "txindex" => 0,
+             "txhash" => <<_::256>>
+           } = TestHelper.submit(tx1 |> Transaction.Signed.encode())
+
+    IntegrationTest.wait_for_block_fetch(blknum, @timeout)
+
+    raw_tx2_bytes = tx2 |> Transaction.raw_txbytes()
+
+    {:ok, %{"status" => "0x1", "blockNumber" => _}} = exit_in_flight(tx1, alice)
+    {:ok, %{"status" => "0x1", "blockNumber" => ife_eth_height}} = exit_in_flight(tx2, alice)
+    # sanity check in-flight exit has started on root chain, wait for finality
+    assert {:ok, [_, _]} = OMG.Eth.RootChain.get_in_flight_exit_starts(0, ife_eth_height)
+    exit_finality_margin = Application.fetch_env!(:omg_watcher, :exit_finality_margin)
+    Eth.DevHelpers.wait_for_root_chain_block(ife_eth_height + exit_finality_margin + 1)
+
+    ###
+    # EVENTS DETECTION
+    ###
+
+    # existence of competitors detected by checking if `non_canonical_ife` events exists
+    # Also, there should be piggybacks on input/output available
+    assert %{
+             "byzantine_events" => [
+               # only a single non_canonical event, since on of the IFE tx is included!
+               %{"event" => "non_canonical_ife"},
+               %{"event" => "piggyback_available"}
+             ]
+           } = TestHelper.success?("/status.get")
+
+    # Check if IFE is recognized as IFE by watcher (kept separate from the above for readability)
+    assert %{"in_flight_exits" => [%{}, %{}]} = TestHelper.success?("/status.get")
+
+    ###
+    # CANONICITY GAME
+    ###
+
+    assert %{"competing_tx_pos" => id, "competing_proof" => proof} =
+             get_competitor_response = TestHelper.get_in_flight_exit_competitors(raw_tx2_bytes)
+
+    assert id > 0
+    assert proof != ""
+
+    {:ok, %{"status" => "0x1", "blockNumber" => challenge_eth_height}} =
+      OMG.Eth.RootChain.challenge_in_flight_exit_not_canonical(
+        get_competitor_response["in_flight_txbytes"],
+        get_competitor_response["in_flight_input_index"],
+        get_competitor_response["competing_txbytes"],
+        get_competitor_response["competing_input_index"],
+        get_competitor_response["competing_tx_pos"],
+        get_competitor_response["competing_proof"],
+        get_competitor_response["competing_sig"],
+        alice.addr
+      )
+      |> Eth.DevHelpers.transact_sync!()
+
+    Eth.DevHelpers.wait_for_root_chain_block(challenge_eth_height + exit_finality_margin + 1)
+
+    # vanishing of `non_canonical_ife` event
+    assert %{"byzantine_events" => [%{"event" => "piggyback_available"}]} = TestHelper.success?("/status.get")
+  end
+
+  @tag fixtures: [:watcher, :alice, :bob, :child_chain, :token, :alice_deposits]
+  test "invalid in-flight exit challenge is detected by watcher, because it contains no position",
+       %{alice: alice, bob: bob, alice_deposits: {deposit_blknum, _}} do
+    # tx1 is submitted then in-flight-exited
+    # tx2 is in-flight-exited, it will be _invalidly_ used to challenge tx1!
     tx1 = OMG.TestHelper.create_signed([{deposit_blknum, 0, 0, alice}], @eth, [{alice, 5}, {alice, 5}])
     tx2 = OMG.TestHelper.create_signed([{deposit_blknum, 0, 0, alice}], @eth, [{bob, 10}])
 
@@ -190,117 +247,53 @@ defmodule OMG.Watcher.Integration.InFlightExitTest do
     raw_tx1_bytes = tx1 |> Transaction.raw_txbytes()
     raw_tx2_bytes = tx2 |> Transaction.raw_txbytes()
 
-    get_in_flight_exit_response1 = tx1 |> Transaction.Signed.encode() |> TestHelper.get_in_flight_exit()
-    get_in_flight_exit_response2 = tx2 |> Transaction.Signed.encode() |> TestHelper.get_in_flight_exit()
-
-    {:ok, %{"status" => "0x1"}} =
-      OMG.Eth.RootChain.in_flight_exit(
-        get_in_flight_exit_response1["in_flight_tx"],
-        get_in_flight_exit_response1["input_txs"],
-        get_in_flight_exit_response1["input_txs_inclusion_proofs"],
-        get_in_flight_exit_response1["in_flight_tx_sigs"],
-        alice.addr
-      )
-      |> Eth.DevHelpers.transact_sync!()
-
-    {:ok, %{"status" => "0x1", "blockNumber" => eth_height}} =
-      OMG.Eth.RootChain.in_flight_exit(
-        get_in_flight_exit_response2["in_flight_tx"],
-        get_in_flight_exit_response2["input_txs"],
-        get_in_flight_exit_response2["input_txs_inclusion_proofs"],
-        get_in_flight_exit_response2["in_flight_tx_sigs"],
-        alice.addr
-      )
-      |> Eth.DevHelpers.transact_sync!()
-
-    # check in-flight exit has started on root chain, wait for finalization
-    raw_tx1_hash = Transaction.raw_txhash(tx1)
-    raw_tx2_hash = Transaction.raw_txhash(tx2)
-    alice_address = alice.addr
-
-    assert {:ok,
-            [
-              %{initiator: ^alice_address, tx_hash: ^raw_tx1_hash},
-              %{initiator: ^alice_address, tx_hash: ^raw_tx2_hash}
-            ]} = OMG.Eth.RootChain.get_in_flight_exit_starts(0, eth_height)
-
+    {:ok, %{"status" => "0x1", "blockNumber" => _}} = exit_in_flight(tx1, alice)
+    {:ok, %{"status" => "0x1", "blockNumber" => ife_eth_height}} = exit_in_flight(tx2, alice)
+    # sanity check in-flight exit has started on root chain, wait for finality
+    assert {:ok, [_, _]} = OMG.Eth.RootChain.get_in_flight_exit_starts(0, ife_eth_height)
     exit_finality_margin = Application.fetch_env!(:omg_watcher, :exit_finality_margin)
-    Eth.DevHelpers.wait_for_root_chain_block(eth_height + exit_finality_margin + 1)
+    Eth.DevHelpers.wait_for_root_chain_block(ife_eth_height + exit_finality_margin + 1)
 
-    ###
-    # EVENTS DETECTION
-    ###
-
-    # existence of competitors detected by checking if `non_canonical_ife` events exists
-    # Also, there should be piggybacks on input/output available
-    assert %{
-             "byzantine_events" => [
-               %{"event" => "non_canonical_ife"},
-               %{"event" => "non_canonical_ife"},
-               %{"event" => "piggyback_available"}
-             ]
-           } = TestHelper.success?("/status.get")
-
-    # Check if IFE is recognized as IFE by watcher (kept separate from the above for readability)
-    assert %{"in_flight_exits" => [%{}, %{}]} = TestHelper.success?("/status.get")
-
-    ###
-    # PIGGYBACK GAME
-    ###
-
-    # Do the piggybacks
-    {:ok, %{"status" => "0x1"}} =
-      OMG.Eth.RootChain.piggyback_in_flight_exit(raw_tx2_bytes, 0, alice.addr)
-      |> Eth.DevHelpers.transact_sync!()
-
-    {:ok, %{"status" => "0x1"}} =
-      OMG.Eth.RootChain.piggyback_in_flight_exit(raw_tx2_bytes, 4 + 0, bob.addr)
-      |> Eth.DevHelpers.transact_sync!()
+    # EVENTS DETECTION (tested in the other test, skipping)
+    # Check if IFE is recognized (tested in the other test, skipping)
 
     ###
     # CANONICITY GAME
     ###
 
-    # to challenge canonicity, get chain inclusion proof
-    assert %{"competing_tx_pos" => 0, "competing_proof" => ""} =
-             get_competitor_response = TestHelper.get_in_flight_exit_competitors(raw_tx1_bytes)
+    # we're unable to get the invalid challenge using `in_flight_exit.get_competitor`!
+    # ...so we need to stich it together from some pieces we have:
+    %{sigs: [competing_sig | _]} = tx2
 
-    # we'll be using the above response to integrate, but we need to test whether the included tx2, if used to challenge
-    # would give us the opportunity to get the inclusion info (since `get_competitor_response` doesn't include that)
-    assert %{"competing_tx_pos" => id, "competing_proof" => proof} =
-             TestHelper.get_in_flight_exit_competitors(raw_tx2_bytes)
-
-    assert id > 0
-    assert proof != ""
-
-    {:ok, %{"status" => "0x1", "blockNumber" => eth_height}} =
+    {:ok, %{"status" => "0x1", "blockNumber" => challenge_eth_height}} =
       OMG.Eth.RootChain.challenge_in_flight_exit_not_canonical(
-        get_competitor_response["in_flight_txbytes"],
-        get_competitor_response["in_flight_input_index"],
-        get_competitor_response["competing_txbytes"],
-        get_competitor_response["competing_input_index"],
-        get_competitor_response["competing_tx_pos"],
-        get_competitor_response["competing_proof"],
-        get_competitor_response["competing_sig"],
+        raw_tx1_bytes,
+        0,
+        raw_tx2_bytes,
+        0,
+        0,
+        "",
+        competing_sig,
         alice.addr
       )
       |> Eth.DevHelpers.transact_sync!()
 
-    Eth.DevHelpers.wait_for_root_chain_block(eth_height + exit_finality_margin + 1)
+    Eth.DevHelpers.wait_for_root_chain_block(challenge_eth_height + exit_finality_margin + 1)
 
-    # existence of `non_canonical_ife` and `invalid_ife_challenge` events
+    # existence of `invalid_ife_challenge` event
     assert %{
              "byzantine_events" => [
-               %{"event" => "invalid_piggyback"},
+               # this is the tx2's non-canonical-ife which we leave as is
                %{"event" => "non_canonical_ife"},
-               %{"event" => "invalid_ife_challenge"}
+               %{"event" => "invalid_ife_challenge"},
+               %{"event" => "piggyback_available"}
              ]
            } = TestHelper.success?("/status.get")
 
     # now included IFE transaction tx1 is challenged and non-canonical, let's respond
     get_prove_canonical_response = TestHelper.get_prove_canonical(raw_tx1_bytes)
 
-    {:ok, %{"status" => "0x1"}} =
+    {:ok, %{"status" => "0x1", "blockNumber" => response_eth_height}} =
       OMG.Eth.RootChain.respond_to_non_canonical_challenge(
         get_prove_canonical_response["in_flight_txbytes"],
         get_prove_canonical_response["in_flight_tx_pos"],
@@ -308,6 +301,12 @@ defmodule OMG.Watcher.Integration.InFlightExitTest do
         alice.addr
       )
       |> Eth.DevHelpers.transact_sync!()
+
+    Eth.DevHelpers.wait_for_root_chain_block(response_eth_height + exit_finality_margin + 1)
+
+    # dissapearing of `invalid_ife_challenge` event
+    assert %{"byzantine_events" => [%{"event" => "non_canonical_ife"}, %{"event" => "piggyback_available"}]} =
+             TestHelper.success?("/status.get")
   end
 
   @tag fixtures: [:watcher, :alice, :bob, :child_chain, :token, :alice_deposits]
@@ -342,21 +341,22 @@ defmodule OMG.Watcher.Integration.InFlightExitTest do
     assert %{"in_flight_exits" => [_], "byzantine_events" => [_]} = TestHelper.success?("/status.get")
   end
 
-  defp exit_in_flight_and_wait_for_ife(tx, exiting_user) do
-    exit_finality_margin = Application.fetch_env!(:omg_watcher, :exit_finality_margin)
-
+  defp exit_in_flight(tx, exiting_user) do
     get_in_flight_exit_response = tx |> Transaction.Signed.encode() |> TestHelper.get_in_flight_exit()
 
-    {:ok, %{"status" => "0x1", "blockNumber" => eth_height}} =
-      OMG.Eth.RootChain.in_flight_exit(
-        get_in_flight_exit_response["in_flight_tx"],
-        get_in_flight_exit_response["input_txs"],
-        get_in_flight_exit_response["input_txs_inclusion_proofs"],
-        get_in_flight_exit_response["in_flight_tx_sigs"],
-        exiting_user.addr
-      )
-      |> Eth.DevHelpers.transact_sync!()
+    OMG.Eth.RootChain.in_flight_exit(
+      get_in_flight_exit_response["in_flight_tx"],
+      get_in_flight_exit_response["input_txs"],
+      get_in_flight_exit_response["input_txs_inclusion_proofs"],
+      get_in_flight_exit_response["in_flight_tx_sigs"],
+      exiting_user.addr
+    )
+    |> Eth.DevHelpers.transact_sync!()
+  end
 
+  defp exit_in_flight_and_wait_for_ife(tx, exiting_user) do
+    {:ok, %{"status" => "0x1", "blockNumber" => eth_height}} = exit_in_flight(tx, exiting_user)
+    exit_finality_margin = Application.fetch_env!(:omg_watcher, :exit_finality_margin)
     Eth.DevHelpers.wait_for_root_chain_block(eth_height + exit_finality_margin + 1)
   end
 

--- a/apps/omg_watcher/test/support/exit_processor/test_helper.ex
+++ b/apps/omg_watcher/test/support/exit_processor/test_helper.ex
@@ -71,5 +71,8 @@ defmodule OMG.Watcher.ExitProcessor.TestHelper do
     }
   end
 
+  def ife_response(tx, position),
+    do: %{tx_hash: Transaction.raw_txhash(tx), challenge_position: Utxo.Position.encode(position)}
+
   defp get_sigs(%{signed_tx: %{sigs: sigs}}), do: sigs
 end


### PR DESCRIPTION
There used to be a small deficiency of the IFE canonicity game left behind: the responses to invalid IFE challenges would not be recognized by the Watcher.

Also, the Watcher would tell the user to challenge a (suposedly) non-canonical IFE, even if it was canonical, and the competitors it had **were younger than the IFE tx**.

E.g. when there's tx1, IFEd and included in some block and a competing tx2 IFEd only, we used to report two non-canonical byzantine events, despite the challenge to tx1 doesn't make sense.

After the changes proposed, this is no longer the case. The watcher asseses the sensibility of the canonicity challenge in full extent, i.e. it analyzes the inclusion and age of competitors and only tells to challenge if the tx in question is truly non-canonical (according to current Watcher's knowledge, of course).

As a side effect, we also leverage the `ife_input_spending_blocks_result` in `OMG.Watcher.ExitProcessor.Request` to a more general purpose; it will now hold all the blocks that might contain an ife tx included (regardless of piggybacks). This allows us to much more conveniently look for data like:
  - invalid ife challenges
  - proving canonicity
  - avoiding "available_piggyback" when the IFE tx is included

As an option to review, the commits can be looked at separately

For future reference: this solves an old ticket tracked elsewhere: OMG-441 