### PR TITLE
feat: return rich syncing information from /status.get

### DIFF
--- a/apps/omg/lib/omg/ethereum_event_listener.ex
+++ b/apps/omg/lib/omg/ethereum_event_listener.ex
@@ -66,7 +66,7 @@ defmodule OMG.EthereumEventListener do
         get_events_callback: get_events_callback,
         process_events_callback: process_events_callback
       }) do
-    _ = Logger.info("Starting EthereumEventListener for #{service_name}.")
+    _ = Logger.info("Starting #{inspect(__MODULE__)} for #{service_name}.")
     {:ok, contract_deployment_height} = OMG.Eth.RootChain.get_root_deployment_height()
     {:ok, last_event_block_height} = OMG.DB.get_single_value(update_key)
     # we don't need to ever look at earlier than contract deployment
@@ -88,6 +88,8 @@ defmodule OMG.EthereumEventListener do
       |> String.to_atom()
 
     {:ok, _} = Recorder.start_link(%Recorder{name: name, parent: self()})
+
+    _ = Logger.info("Started #{inspect(__MODULE__)} for #{service_name}, synced_height: #{inspect(height_to_check_in)}")
 
     {:noreply, {initial_state, callbacks_map}}
   end

--- a/apps/omg/lib/omg/root_chain_coordinator.ex
+++ b/apps/omg/lib/omg/root_chain_coordinator.ex
@@ -64,6 +64,15 @@ defmodule OMG.RootChainCoordinator do
     GenServer.call(__MODULE__, :get_sync_info)
   end
 
+  @doc """
+  Gets all the current synced height for all the services checked in
+  """
+  @decorate measure_event()
+  @spec get_ethereum_heights() :: {:ok, Core.ethereum_heights_result_t()}
+  def get_ethereum_heights do
+    GenServer.call(__MODULE__, :get_ethereum_heights)
+  end
+
   def init(configs_services) do
     {:ok, configs_services, {:continue, :setup}}
   end
@@ -93,6 +102,10 @@ defmodule OMG.RootChainCoordinator do
 
   def handle_call(:get_sync_info, {pid, _}, state) do
     {:reply, Core.get_synced_info(state, pid), state}
+  end
+
+  def handle_call(:get_ethereum_heights, _from, state) do
+    {:reply, {:ok, Core.get_ethereum_heights(state)}, state}
   end
 
   def handle_info(:update_root_chain_height, state) do

--- a/apps/omg/test/omg/root_chain_coordinator/core_test.exs
+++ b/apps/omg/test/omg/root_chain_coordinator/core_test.exs
@@ -90,6 +90,17 @@ defmodule OMG.RootChainCoordinator.CoreTest do
   end
 
   @tag fixtures: [:initial_state]
+  test "reports synced heights", %{initial_state: state} do
+    exiter_pid = :c.pid(0, 2, 0)
+
+    assert %{root_chain_height: 10} == Core.get_ethereum_heights(state)
+    assert {:ok, state} = Core.check_in(state, exiter_pid, 10, :exiter)
+    assert %{root_chain_height: 10, exiter: 10} == Core.get_ethereum_heights(state)
+    assert {:ok, state} = Core.update_root_chain_height(state, 11)
+    assert %{root_chain_height: 11, exiter: 10} == Core.get_ethereum_heights(state)
+  end
+
+  @tag fixtures: [:initial_state]
   test "prevents huge queries to Ethereum client", %{initial_state: state} do
     depositor_pid = :c.pid(0, 1, 0)
     exiter_pid = :c.pid(0, 2, 0)

--- a/apps/omg_child_chain/lib/omg_child_chain/block_queue.ex
+++ b/apps/omg_child_chain/lib/omg_child_chain/block_queue.ex
@@ -182,7 +182,7 @@ defmodule OMG.ChildChain.BlockQueue do
     end
 
     defp log_init_error(fields) do
-      config = Application.get_all_env(:omg_eth) |> Keyword.take([:contract_addr, :authority_addr, :txhash_contract])
+      config = Eth.Diagnostics.get_child_chain_config()
       fields = Keyword.update!(fields, :known_hashes, fn hashes -> Enum.map(hashes, &Eth.Encoding.to_hex/1) end)
       diagnostic = fields |> Enum.into(%{config: config})
 
@@ -196,19 +196,8 @@ defmodule OMG.ChildChain.BlockQueue do
     end
 
     defp log_eth_node_error do
-      eth_node_diagnostics = get_eth_node_diagnostics()
+      eth_node_diagnostics = Eth.Diagnostics.get_node_diagnostics()
       Logger.error("Ethereum operation failed, additional diagnostics: #{inspect(eth_node_diagnostics)}")
-    end
-
-    defp get_eth_node_diagnostics do
-      ["personal_listWallets", "admin_nodeInfo", "parity_enode"]
-      |> Enum.into(%{}, &get_eth_node_diagnostic/1)
-    end
-
-    defp get_eth_node_diagnostic(rpc_call_name) when is_binary(rpc_call_name) do
-      {rpc_call_name, Ethereumex.HttpClient.request(rpc_call_name, [], [])}
-    rescue
-      error -> {rpc_call_name, inspect(error)}
     end
   end
 end

--- a/apps/omg_eth/lib/eth.ex
+++ b/apps/omg_eth/lib/eth.ex
@@ -91,6 +91,16 @@ defmodule OMG.Eth do
     end
   end
 
+  def get_block_timestamp_by_number(height) do
+    case Ethereumex.HttpClient.eth_get_block_by_number(to_hex(height), false) do
+      {:ok, %{"timestamp" => timestamp_hex}} ->
+        {:ok, int_from_hex(timestamp_hex)}
+
+      other ->
+        other
+    end
+  end
+
   @doc """
   Returns placeholder for non-existent Ethereum address
   """

--- a/apps/omg_eth/lib/omg_eth/application.ex
+++ b/apps/omg_eth/lib/omg_eth/application.ex
@@ -15,10 +15,16 @@
 defmodule OMG.Eth.Application do
   @moduledoc false
 
+  alias OMG.Eth
+
   use Application
+  use OMG.Utils.LoggerExt
 
   def start(_type, _args) do
     DeferredConfig.populate(:omg_eth)
+
+    _ = Logger.info("Started #{inspect(__MODULE__)}, config used: #{inspect(Eth.Diagnostics.get_child_chain_config())}")
+
     {:ok, self()}
   end
 end

--- a/apps/omg_eth/lib/omg_eth/diagnostics.ex
+++ b/apps/omg_eth/lib/omg_eth/diagnostics.ex
@@ -1,0 +1,43 @@
+# Copyright 2018 OmiseGO Pte Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defmodule OMG.Eth.Diagnostics do
+  @moduledoc """
+  Facilities to get various diagnostics related to the interactions with the Ethereum node
+  """
+
+  @doc """
+  Gets an excerpt of the application's configuration describing which child chain (contract address etc.) are we
+  talking to
+  """
+  def get_child_chain_config do
+    Application.get_all_env(:omg_eth) |> Keyword.take([:contract_addr, :authority_addr, :txhash_contract])
+  end
+
+  @doc """
+  Returns a map of responses to basic queries that help to figure out, what node are we talking to.
+
+  Designed so that it never throws, so is safe to use in error recovery code, logging etc.
+  """
+  def get_node_diagnostics do
+    ["personal_listWallets", "admin_nodeInfo", "parity_enode"]
+    |> Enum.into(%{}, &get_node_diagnostic/1)
+  end
+
+  defp get_node_diagnostic(rpc_call_name) when is_binary(rpc_call_name) do
+    {rpc_call_name, Ethereumex.HttpClient.request(rpc_call_name, [], [])}
+  rescue
+    error -> {rpc_call_name, inspect(error)}
+  end
+end

--- a/apps/omg_eth/mix.exs
+++ b/apps/omg_eth/mix.exs
@@ -33,7 +33,7 @@ defmodule OMG.Eth.MixProject do
   defp deps do
     [
       {:ex_abi, "~> 0.2.1"},
-      {:ethereumex, "~> 0.5.2"},
+      {:ethereumex, "~> 0.5.4"},
       {:deferred_config, "~> 0.1.1"},
       {
         :plasma_contracts,

--- a/apps/omg_eth/test/omg_eth/eth_test.exs
+++ b/apps/omg_eth/test/omg_eth/eth_test.exs
@@ -33,9 +33,11 @@ defmodule OMG.EthTest do
   @moduletag :common
 
   @tag fixtures: [:eth_node]
-  test "get_ethereum_height returns integer" do
+  test "get_ethereum_height and get_block_timestamp_by_number return integers" do
     assert {:ok, number} = Eth.get_ethereum_height()
+    assert {:ok, timestamp} = Eth.get_block_timestamp_by_number(number)
     assert is_integer(number)
+    assert is_integer(timestamp)
   end
 
   @tag fixtures: [:contract]

--- a/apps/omg_watcher/lib/omg_watcher/api/status.ex
+++ b/apps/omg_watcher/lib/omg_watcher/api/status.ex
@@ -18,6 +18,7 @@ defmodule OMG.Watcher.API.Status do
   """
 
   alias OMG.Eth
+  alias OMG.RootChainCoordinator
   alias OMG.State
   alias OMG.Watcher.BlockGetter
   alias OMG.Watcher.Event
@@ -27,42 +28,67 @@ defmodule OMG.Watcher.API.Status do
 
   @opaque t() :: %{
             last_validated_child_block_number: non_neg_integer(),
+            last_validated_child_block_timestamp: non_neg_integer(),
             last_mined_child_block_number: non_neg_integer(),
             last_mined_child_block_timestamp: non_neg_integer(),
+            last_seen_eth_block_number: non_neg_integer(),
+            last_seen_eth_block_timestamp: non_neg_integer(),
             eth_syncing: boolean(),
-            byzantine_events: list(Event.t())
+            byzantine_events: list(Event.t()),
+            in_flight_exits: ExitProcessor.Core.in_flight_exits_response_t(),
+            contract_addr: binary,
+            services_synced_heights: RootChainCoordinator.Core.ethereum_heights_result_t()
           }
 
   @doc """
   Returns status of the watcher. Status consists of last validated child block number,
   last mined child block number and it's timestamp, and a flag indicating if watcher is syncing with Ethereum.
+
+  This function calls into a number of services (internal and external), collects the results. If any of the underlying
+  services are unavailable, it will crash
   """
   @decorate measure_event()
-  @spec get_status() :: {:ok, t()} | {:error, atom}
+  @spec get_status() :: {:ok, t()}
   def get_status do
-    with {:ok, last_mined_child_block_number} <- Eth.RootChain.get_mined_child_block(),
-         {:ok, {_root, last_mined_child_block_timestamp}} <-
-           Eth.RootChain.get_child_chain(last_mined_child_block_number),
-         {:ok, child_block_interval} <- Eth.RootChain.get_child_block_interval() do
-      {state_current_block, _} = State.get_status()
+    {:ok, eth_block_number} = Eth.get_ethereum_height()
+    {:ok, eth_block_timestamp} = Eth.get_block_timestamp_by_number(eth_block_number)
+    eth_syncing = Eth.syncing?()
 
-      {_, events_processor} = ExitProcessor.check_validity()
-      {_, events_block_getter} = BlockGetter.get_events()
-      {:ok, in_flight_exits} = ExitProcessor.get_active_in_flight_exits()
+    validated_child_block_number = get_validated_child_block_number()
 
-      status = %{
-        last_validated_child_block_number: state_current_block - child_block_interval,
-        last_mined_child_block_number: last_mined_child_block_number,
-        last_mined_child_block_timestamp: last_mined_child_block_timestamp,
-        eth_syncing: Eth.syncing?(),
-        byzantine_events: events_processor ++ events_block_getter,
-        in_flight_exits: in_flight_exits
-      }
+    {:ok, mined_child_block_number} = Eth.RootChain.get_mined_child_block()
+    {:ok, {_root, mined_child_block_timestamp}} = Eth.RootChain.get_child_chain(mined_child_block_number)
+    {:ok, {_root, validated_child_block_timestamp}} = Eth.RootChain.get_child_chain(validated_child_block_number)
 
-      {:ok, status}
-    else
-      :error -> {:error, :unknown}
-      {:error, _} = error -> error
-    end
+    {:ok, services_synced_heights} = RootChainCoordinator.get_ethereum_heights()
+
+    contract_addr = Eth.Diagnostics.get_child_chain_config()[:contract_addr] |> Eth.Encoding.from_hex()
+
+    {_, events_processor} = ExitProcessor.check_validity()
+    {:ok, in_flight_exits} = ExitProcessor.get_active_in_flight_exits()
+
+    {_, events_block_getter} = BlockGetter.get_events()
+
+    status = %{
+      last_validated_child_block_number: validated_child_block_number,
+      last_validated_child_block_timestamp: validated_child_block_timestamp,
+      last_mined_child_block_number: mined_child_block_number,
+      last_mined_child_block_timestamp: mined_child_block_timestamp,
+      last_seen_eth_block_number: eth_block_number,
+      last_seen_eth_block_timestamp: eth_block_timestamp,
+      eth_syncing: eth_syncing,
+      byzantine_events: events_processor ++ events_block_getter,
+      in_flight_exits: in_flight_exits,
+      contract_addr: contract_addr,
+      services_synced_heights: services_synced_heights
+    }
+
+    {:ok, status}
+  end
+
+  defp get_validated_child_block_number do
+    {:ok, child_block_interval} = Eth.RootChain.get_child_block_interval()
+    {state_current_block, _} = State.get_status()
+    state_current_block - child_block_interval
   end
 end

--- a/apps/omg_watcher/lib/omg_watcher/coordinator_setup.ex
+++ b/apps/omg_watcher/lib/omg_watcher/coordinator_setup.ex
@@ -24,17 +24,17 @@ defmodule OMG.Watcher.CoordinatorSetup do
     %{
       depositor: [finality_margin: deposit_finality_margin],
       convenience_deposit_processor: [waits_for: [:depositor], finality_margin: deposit_finality_margin],
-      "Elixir.OMG.Watcher.BlockGetter": [
+      block_getter: [
         waits_for: [depositor: :no_margin, convenience_deposit_processor: :no_margin],
         finality_margin: 0
       ],
       exit_processor: [waits_for: :depositor, finality_margin: finality_margin],
       convenience_exit_processor: [
-        waits_for: [:convenience_deposit_processor, :"Elixir.OMG.Watcher.BlockGetter"],
+        waits_for: [:convenience_deposit_processor, :block_getter],
         finality_margin: finality_margin
       ],
       exit_finalizer: [
-        waits_for: [:depositor, :"Elixir.OMG.Watcher.BlockGetter", :exit_processor],
+        waits_for: [:depositor, :block_getter, :exit_processor],
         finality_margin: finality_margin
       ],
       exit_challenger: [waits_for: :exit_processor, finality_margin: finality_margin],
@@ -44,7 +44,7 @@ defmodule OMG.Watcher.CoordinatorSetup do
       challenges_responds_processor: [waits_for: :competitor_processor, finality_margin: finality_margin],
       piggyback_challenges_processor: [waits_for: :piggyback_processor, finality_margin: finality_margin],
       ife_exit_finalizer: [
-        waits_for: [:depositor, :"Elixir.OMG.Watcher.BlockGetter", :in_flight_exit_processor, :piggyback_processor],
+        waits_for: [:depositor, :block_getter, :in_flight_exit_processor, :piggyback_processor],
         finality_margin: finality_margin
       ]
     }

--- a/apps/omg_watcher/lib/omg_watcher/exit_processor.ex
+++ b/apps/omg_watcher/lib/omg_watcher/exit_processor.ex
@@ -28,7 +28,6 @@ defmodule OMG.Watcher.ExitProcessor do
   # NOTE: future of using `ExitProcessor.Request` struct not certain, see that module for details
   alias OMG.Watcher.ExitProcessor
   alias OMG.Watcher.ExitProcessor.Core
-  alias OMG.Watcher.ExitProcessor.InFlightExitInfo
   alias OMG.Watcher.ExitProcessor.StandardExitChallenge
   alias OMG.Watcher.Recorder
 
@@ -138,11 +137,10 @@ defmodule OMG.Watcher.ExitProcessor do
   end
 
   @doc """
-  Returns a map of requested in flight exits, where keys are IFE hashes and values are IFES
-  If given empty list of hashes, all IFEs are returned.
+  Returns a map of requested in flight exits, keyed by transaction hash
   """
   @decorate measure_event()
-  @spec get_active_in_flight_exits() :: {:ok, %{binary() => InFlightExitInfo.t()}}
+  @spec get_active_in_flight_exits() :: {:ok, Core.in_flight_exits_response_t()}
   def get_active_in_flight_exits do
     GenServer.call(__MODULE__, :get_active_in_flight_exits)
   end

--- a/apps/omg_watcher/lib/omg_watcher/exit_processor/core.ex
+++ b/apps/omg_watcher/lib/omg_watcher/exit_processor/core.ex
@@ -109,6 +109,15 @@ defmodule OMG.Watcher.ExitProcessor.Core do
   @type piggyback_type_t() :: :input | :output
   @type piggyback_t() :: {piggyback_type_t(), non_neg_integer()}
 
+  @type in_flight_exit_response_t() :: %{
+          txhash: binary(),
+          txbytes: binary(),
+          eth_height: non_neg_integer(),
+          piggybacked_inputs: list(non_neg_integer()),
+          piggybacked_outputs: list(non_neg_integer())
+        }
+  @type in_flight_exits_response_t() :: %{binary() => in_flight_exit_response_t()}
+
   @doc """
   Reads database-specific list of exits and turns them into current state
   """

--- a/apps/omg_watcher/lib/omg_watcher/web/views/status.ex
+++ b/apps/omg_watcher/lib/omg_watcher/web/views/status.ex
@@ -26,16 +26,18 @@ defmodule OMG.Watcher.Web.View.Status do
     |> Response.serialize()
   end
 
-  defp format_byzantine_events(%{byzantine_events: byzantine_events} = status) do
+  defp format_byzantine_events(%{byzantine_events: byzantine_events, services_synced_heights: heights} = status) do
     prepared_events = Enum.map(byzantine_events, &format_byzantine_event/1)
+    prepared_heights = Enum.map(heights, &format_synced_height/1)
 
-    %{status | byzantine_events: prepared_events}
+    %{status | byzantine_events: prepared_events, services_synced_heights: prepared_heights}
   end
 
   defp format_byzantine_event(%{name: name} = event) do
-    %{
-      event: name,
-      details: event
-    }
+    %{event: name, details: event}
+  end
+
+  defp format_synced_height({name, height}) do
+    %{service: name, height: height}
   end
 end

--- a/apps/omg_watcher/priv/swagger/watcher_api_specs.yaml
+++ b/apps/omg_watcher/priv/swagger/watcher_api_specs.yaml
@@ -366,23 +366,36 @@ responses:
               data:
                 type: object
                 properties:
+                  last_validated_child_block_timestamp:
+                    type: integer
+                    format: int64
                   last_validated_child_block_number:
                     type: integer
-                    format: int64                  
+                    format: int64
                   last_mined_child_block_timestamp:
                     type: integer
-                    format: int64                  
+                    format: int64
                   last_mined_child_block_number:
                     type: integer
-                    format: int64                  
+                    format: int64
+                  last_seen_eth_block_timestamp:
+                    type: integer
+                    format: int64
+                  last_seen_eth_block_number:
+                    type: integer
+                    format: int64
                   eth_syncing:
                     type: boolean
                   byzantine_events:
-                    type: array                  
+                    type: array
                   in_flight_txs:
-                    type: array                  
+                    type: array
                   in_flight_exits:
-                    type: array                  
+                    type: array
+                  contract_addr:
+                    type: string
+                  services_synced_heights:
+                    type: array
             example:
               data:
                 last_validated_child_block_number: 10000

--- a/apps/omg_watcher/test/omg_watcher/supervisor_test.exs
+++ b/apps/omg_watcher/test/omg_watcher/supervisor_test.exs
@@ -44,14 +44,13 @@ defmodule OMG.Watcher.SupervisorTest do
   test "syncs services correctly", %{state: state} do
     # NOTE: this assumes some finality margines embedded in `config/test.exs`. Consider refactoring if these
     #       needs to change and break this test, instead of modifying this test!
-    getter = :"Elixir.OMG.Watcher.BlockGetter"
 
     # start - only depositor and getter allowed to move
     assert %{sync_height: 9, root_chain_height: 9} = Core.get_synced_info(state, @pid[:depositor])
     assert %{sync_height: 0, root_chain_height: 9} = Core.get_synced_info(state, @pid[:exit_processor])
     assert %{sync_height: 0, root_chain_height: 9} = Core.get_synced_info(state, @pid[:in_flight_exit_processor])
     assert %{sync_height: 0, root_chain_height: 9} = Core.get_synced_info(state, @pid[:convenience_deposit_processor])
-    assert %{sync_height: 1, root_chain_height: 10} = Core.get_synced_info(state, @pid[getter])
+    assert %{sync_height: 1, root_chain_height: 10} = Core.get_synced_info(state, @pid[:block_getter])
 
     # depositor advances
     assert {:ok, state} = Core.check_in(state, @pid[:depositor], 9, :depositor)
@@ -60,9 +59,9 @@ defmodule OMG.Watcher.SupervisorTest do
     assert %{sync_height: 9, root_chain_height: 9} = Core.get_synced_info(state, @pid[:convenience_deposit_processor])
 
     # convenience depositor advances allowing to put blocks into Postgres via `BlockGetter`
-    assert %{sync_height: 1, root_chain_height: 10} = Core.get_synced_info(state, @pid[getter])
+    assert %{sync_height: 1, root_chain_height: 10} = Core.get_synced_info(state, @pid[:block_getter])
     assert {:ok, state} = Core.check_in(state, @pid[:convenience_deposit_processor], 9, :convenience_deposit_processor)
-    assert %{sync_height: 10, root_chain_height: 10} = Core.get_synced_info(state, @pid[getter])
+    assert %{sync_height: 10, root_chain_height: 10} = Core.get_synced_info(state, @pid[:block_getter])
 
     # exit_processor advances
     assert %{sync_height: 0, root_chain_height: 9} = Core.get_synced_info(state, @pid[:exit_challenger])
@@ -88,7 +87,7 @@ defmodule OMG.Watcher.SupervisorTest do
     assert %{sync_height: 0, root_chain_height: 9} = Core.get_synced_info(state, @pid[:exit_finalizer])
     assert %{sync_height: 0, root_chain_height: 9} = Core.get_synced_info(state, @pid[:convenience_exit_processor])
     assert %{sync_height: 0, root_chain_height: 9} = Core.get_synced_info(state, @pid[:ife_exit_finalizer])
-    assert {:ok, state} = Core.check_in(state, @pid[getter], 10, getter)
+    assert {:ok, state} = Core.check_in(state, @pid[:block_getter], 10, :block_getter)
     assert %{sync_height: 9, root_chain_height: 9} = Core.get_synced_info(state, @pid[:exit_finalizer])
     assert %{sync_height: 9, root_chain_height: 9} = Core.get_synced_info(state, @pid[:convenience_exit_processor])
     assert %{sync_height: 9, root_chain_height: 9} = Core.get_synced_info(state, @pid[:ife_exit_finalizer])
@@ -99,6 +98,6 @@ defmodule OMG.Watcher.SupervisorTest do
     assert %{sync_height: 9, root_chain_height: 99} = Core.get_synced_info(state, @pid[:convenience_exit_processor])
     assert %{sync_height: 9, root_chain_height: 99} = Core.get_synced_info(state, @pid[:ife_exit_finalizer])
     assert %{sync_height: 99, root_chain_height: 99} = Core.get_synced_info(state, @pid[:depositor])
-    assert %{sync_height: 10, root_chain_height: 100} = Core.get_synced_info(state, @pid[getter])
+    assert %{sync_height: 10, root_chain_height: 100} = Core.get_synced_info(state, @pid[:block_getter])
   end
 end

--- a/apps/omg_watcher/test/omg_watcher/web/controllers/status_test.exs
+++ b/apps/omg_watcher/test/omg_watcher/web/controllers/status_test.exs
@@ -23,30 +23,25 @@ defmodule OMG.Watcher.Web.Controller.StatusTest do
   @tag fixtures: [:watcher, :root_chain_contract_config]
   test "status endpoint returns expected response format" do
     assert %{
-             "last_validated_child_block_number" => last_validated_child_block_number,
-             "last_mined_child_block_number" => last_mined_child_block_number,
-             "last_mined_child_block_timestamp" => last_mined_child_block_timestamp,
+             "last_validated_child_block_number" => 0,
+             "last_validated_child_block_timestamp" => 0,
+             "last_mined_child_block_number" => 0,
+             "last_mined_child_block_timestamp" => 0,
+             "last_seen_eth_block_number" => eth_height_now,
+             "last_seen_eth_block_timestamp" => eth_timestamp_now,
              "eth_syncing" => eth_syncing,
-             "byzantine_events" => byzantine_events
+             "byzantine_events" => [],
+             "in_flight_exits" => [],
+             "contract_addr" => contract_addr,
+             "services_synced_heights" => services_synced_heights
            } = TestHelper.success?("status.get")
 
-    assert is_integer(last_validated_child_block_number)
-    assert is_integer(last_mined_child_block_number)
-    assert is_integer(last_mined_child_block_timestamp)
+    assert is_integer(eth_height_now)
+    assert is_integer(eth_timestamp_now)
     assert is_atom(eth_syncing)
-    assert is_list(byzantine_events)
-  end
-
-  @tag fixtures: [:phoenix_ecto_sandbox]
-  test "status endpoint returns error when ethereum node is missing" do
-    # we're not running geth, but need to pretend that the root chain contract is configured somehow though:
-    Application.put_env(:omg_eth, :contract_addr, "0x00", persistent: true)
-
-    {:ok, started_apps} = Application.ensure_all_started(:omg_eth)
-
-    assert %{"code" => "get_status:econnrefused", "description" => "Cannot connect to the Ethereum node."} =
-             TestHelper.no_success?("status.get")
-
-    started_apps |> Enum.each(fn app -> :ok = Application.stop(app) end)
+    assert is_binary(contract_addr)
+    assert %{"height" => height, "service" => service_name} = services_synced_heights |> hd
+    assert is_integer(height)
+    assert is_binary(service_name)
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -22,7 +22,7 @@
   "eleveldb": {:hex, :eleveldb, "2.2.20", "1fff63a5055bbf4bf821f797ef76065882b193f5e8095f95fcd9287187773b58", [:rebar3], [], "hexpm"},
   "erlex": {:hex, :erlex, "0.2.1", "cee02918660807cbba9a7229cae9b42d1c6143b768c781fa6cee1eaf03ad860b", [:mix], [], "hexpm"},
   "erlexec": {:hex, :erlexec, "1.9.5", "5ac0f70fb43c298a60b65a3e1bcad58714b0b1f6cd0a70b1e116ff42e65f954c", [:rebar3], [], "hexpm"},
-  "ethereumex": {:hex, :ethereumex, "0.5.3", "a1783a759692d9ca473e5f8afb5c2d8b6cfb1a89a6a8f779171d3a2840ada615", [:mix], [{:httpoison, "~> 1.4.0", [hex: :httpoison, repo: "hexpm", optional: false]}, {:jason, "~> 1.1", [hex: :jason, repo: "hexpm", optional: false]}, {:poolboy, "~> 1.5.1", [hex: :poolboy, repo: "hexpm", optional: false]}], "hexpm"},
+  "ethereumex": {:hex, :ethereumex, "0.5.4", "f4dc7f8dd6b141d2fd28c7c98e54c361ef2e7cc707b3147a216bf4857077033b", [:mix], [{:httpoison, "~> 1.4.0", [hex: :httpoison, repo: "hexpm", optional: false]}, {:jason, "~> 1.1", [hex: :jason, repo: "hexpm", optional: false]}, {:poolboy, "~> 1.5.1", [hex: :poolboy, repo: "hexpm", optional: false]}], "hexpm"},
   "ex_abi": {:hex, :ex_abi, "0.2.1", "e8224ef22782b58d535bf3e29e73379af48df52cc9a941746980d14b32e793c2", [:mix], [{:exth_crypto, "~> 0.1.6", [hex: :exth_crypto, repo: "hexpm", optional: false]}], "hexpm"},
   "ex_doc": {:hex, :ex_doc, "0.19.3", "3c7b0f02851f5fc13b040e8e925051452e41248f685e40250d7e40b07b9f8c10", [:mix], [{:earmark, "~> 1.2", [hex: :earmark, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.10", [hex: :makeup_elixir, repo: "hexpm", optional: false]}], "hexpm"},
   "ex_rlp": {:hex, :ex_rlp, "0.5.2", "7f4ce7bd55e543c054ce6d49629b01e9833c3462e3d547952be89865f39f2c58", [:mix], [], "hexpm"},


### PR DESCRIPTION
On a couple of occasions we wished `status.get` returned richer information about the status the watcher's syncing is in.

Also, such information (like how old is the head of ethereum **as seen by the watcher**) is security-critical information - we're only secure and able to spend and use the child chain if we're fully up-to-date with ethereum.

So this is a proposition to put more stuff into the `status.get` response:

```
iex(30)> ~c(echo '{}' | http POST #{watcher_url}/status.get) |>  :os.cmd() |>  Poison.decode!()
%{
  "data" => %{
    "byzantine_events" => [],
!! NEW !! ===> "contract_addr" => "0x3c651506beb2ce64806f8fcf03522a211de19133",
    "eth_syncing" => false,
    "in_flight_exits" => [],
    "last_mined_child_block_number" => 1000,
    "last_mined_child_block_timestamp" => 1558535130,
!! NEW !! ===> "last_seen_eth_block_number" => 4427041,
!! NEW !! ===> "last_seen_eth_block_timestamp" => 1558535190,
    "last_validated_child_block_number" => 1000, !! NEW !! ===> "last_validated_child_block_timestamp" => 1558535130,
!! NEW !! ===> "services_synced_heights" => [
!! NEW !! ===> %{"height" => 4427041, "service" => "block_getter"},
!! NEW !! ===> %{"height" => 4427029, "service" => "challenges_responds_processor"},
!! NEW !! ===> %{"height" => 4427029, "service" => "competitor_processor"},
!! NEW !! ===> %{"height" => 4427031, "service" => "convenience_deposit_processor"},
!! NEW !! ===> %{"height" => 4427029, "service" => "convenience_exit_processor"},
!! NEW !! ===> %{"height" => 4427031, "service" => "depositor"},
!! NEW !! ===> %{"height" => 4427029, "service" => "exit_challenger"},
!! NEW !! ===> %{"height" => 4427029, "service" => "exit_finalizer"},
!! NEW !! ===> %{"height" => 4427029, "service" => "exit_processor"},
!! NEW !! ===> %{"height" => 4427029, "service" => "ife_exit_finalizer"},
!! NEW !! ===> %{"height" => 4427029, "service" => "in_flight_exit_processor"},
!! NEW !! ===> %{"height" => 4427029, "service" => "piggyback_challenges_processor"},
!! NEW !! ===> %{"height" => 4427029, "service" => "piggyback_processor"},
!! NEW !! ===> %{"height" => 4427041, "service" => "root_chain_height"}
    ]
  },
  "success" => true,
  "version" => "1.0"
}
```

As a related bonus, some more logs about syncing are now being displayed on application startup