### PR TITLE
Optimizing pg writes

### DIFF
--- a/apps/omg_watcher/lib/omg_watcher/db/spend.ex
+++ b/apps/omg_watcher/lib/omg_watcher/db/spend.ex
@@ -1,0 +1,29 @@
+# Copyright 2018 OmiseGO Pte Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defmodule OMG.Watcher.DB.Spend do
+  @moduledoc """
+  Ecto schema to record transaction's utxo spend
+  """
+  use Ecto.Schema
+
+  @primary_key false
+  schema "spends" do
+    field(:blknum, :integer, primary_key: true)
+    field(:txindex, :integer, primary_key: true)
+    field(:oindex, :integer, primary_key: true)
+    field(:spending_txhash, :binary)
+    field(:spending_tx_oindex, :integer)
+  end
+end

--- a/apps/omg_watcher/lib/omg_watcher/db/spend.ex
+++ b/apps/omg_watcher/lib/omg_watcher/db/spend.ex
@@ -49,4 +49,26 @@ defmodule OMG.Watcher.DB.Spend do
       }
     end)
   end
+
+  @doc """
+  Using information about spent UTXOs updates particular TxOutput records marking them as spend
+  """
+  @spec mark_utxo_spend() :: :ok
+  def mark_utxo_spend do
+    _ =
+      Ecto.Adapters.SQL.query!(
+        OMG.Watcher.DB.Repo,
+        ~s(UPDATE txoutputs AS utxo
+      SET spending_txhash = s.spending_txhash,
+          spending_tx_oindex = s.spending_tx_oindex
+     FROM spends s
+    WHERE utxo.spending_txhash IS NULL
+      AND utxo.blknum = s.blknum
+      AND utxo.txindex = s.txindex
+      AND utxo.oindex = s.oindex),
+        []
+      )
+
+    :ok
+  end
 end

--- a/apps/omg_watcher/lib/omg_watcher/db/transaction.ex
+++ b/apps/omg_watcher/lib/omg_watcher/db/transaction.ex
@@ -147,6 +147,9 @@ defmodule OMG.Watcher.DB.Transaction do
             _ = DB.Repo.insert_all_chunked(__MODULE__, db_txs)
             _ = DB.Repo.insert_all_chunked(DB.TxOutput, db_outputs)
             _ = DB.Repo.insert_all_chunked(DB.Spend, db_spends)
+
+            # TODO: during sync we can execute this after applying a batch of blocks
+            :ok = DB.Spend.mark_utxo_spend()
           end
         ]
       )

--- a/apps/omg_watcher/lib/omg_watcher/db/txoutput.ex
+++ b/apps/omg_watcher/lib/omg_watcher/db/txoutput.ex
@@ -27,7 +27,7 @@ defmodule OMG.Watcher.DB.TxOutput do
 
   require Utxo
 
-  import Ecto.Query, only: [from: 2, where: 2]
+  import Ecto.Query, only: [from: 2]
 
   @type balance() :: %{
           currency: binary(),
@@ -158,18 +158,6 @@ defmodule OMG.Watcher.DB.TxOutput do
   end
 
   @decorate measure_event()
-  @spec spend_utxos([map()]) :: :ok
-  def spend_utxos(db_inputs) do
-    db_inputs
-    |> Enum.each(fn {Utxo.position(blknum, txindex, oindex), spending_oindex, spending_txhash} ->
-      _ =
-        DB.TxOutput
-        |> where(blknum: ^blknum, txindex: ^txindex, oindex: ^oindex)
-        |> Repo.update_all(set: [spending_tx_oindex: spending_oindex, spending_txhash: spending_txhash])
-    end)
-  end
-
-  @decorate measure_event()
   @spec create_outputs(pos_integer(), integer(), binary(), Transaction.any_flavor_t()) :: [map()]
   def create_outputs(
         blknum,
@@ -203,17 +191,6 @@ defmodule OMG.Watcher.DB.TxOutput do
         creating_txhash: txhash
       }
     ]
-
-  @decorate measure_event()
-  @spec create_inputs(Transaction.any_flavor_t(), binary()) :: [tuple()]
-  def create_inputs(tx, spending_txhash) do
-    tx
-    |> Transaction.get_inputs()
-    |> Enum.with_index()
-    |> Enum.map(fn {Utxo.position(_, _, _) = input_utxo_pos, index} ->
-      {input_utxo_pos, index, spending_txhash}
-    end)
-  end
 
   @decorate measure_event()
   @spec get_sorted_grouped_utxos(OMG.Crypto.address_t()) :: %{OMG.Crypto.address_t() => list(%__MODULE__{})}

--- a/apps/omg_watcher/priv/repo/migrations/20190315095855_alter_transactions_table_add_partitial_index.exs
+++ b/apps/omg_watcher/priv/repo/migrations/20190315095855_alter_transactions_table_add_partitial_index.exs
@@ -1,11 +1,7 @@
 defmodule OMG.Watcher.DB.Repo.Migrations.AlterTransactionsTableAddPartialIndex do
   use Ecto.Migration
 
-  def up do
-    execute("CREATE INDEX transactions_metadata_index ON transactions(metadata) WHERE metadata IS NOT NULL")
-  end
-
-  def down do
-    execute("DROP INDEX transactions_metadata_index")
+  def change do
+    create index(:transactions, [:metadata], where: "metadata IS NOT NULL")
   end
 end

--- a/apps/omg_watcher/priv/repo/migrations/20190408131000_add_missing_indices_to_txoutputs.exs
+++ b/apps/omg_watcher/priv/repo/migrations/20190408131000_add_missing_indices_to_txoutputs.exs
@@ -3,7 +3,7 @@ defmodule OMG.Watcher.Repo.Migrations.AddMissingIndicesToTxOuputs do
 
   def change do
     create index(:txoutputs, [:creating_txhash, :spending_txhash])
-    create index(:txoutputs, [:creating_deposit])
+    create index(:txoutputs, [:creating_deposit], where: "creating_deposit IS NOT NULL")
     create index(:txoutputs, [:spending_txhash])
     create index(:txoutputs, [:spending_exit], where: "spending_exit IS NOT NULL")
     create index(:txoutputs, [:owner])

--- a/apps/omg_watcher/priv/repo/migrations/20190520120700_create_spends_table.exs
+++ b/apps/omg_watcher/priv/repo/migrations/20190520120700_create_spends_table.exs
@@ -1,0 +1,13 @@
+defmodule OMG.Watcher.Repo.Migrations.CreateSpendsTable do
+  use Ecto.Migration
+
+  def change do
+    create table(:spends, primary_key: false) do
+      add :blknum, :bigint, null: false, primary_key: true
+      add :txindex, :integer, null: false, primary_key: true
+      add :oindex, :integer, null: false, primary_key: true
+      add :spending_txhash,  :binary
+      add :spending_tx_oindex, :integer
+    end
+  end
+end

--- a/apps/omg_watcher/test/omg_watcher/db/spend_test.exs
+++ b/apps/omg_watcher/test/omg_watcher/db/spend_test.exs
@@ -1,0 +1,47 @@
+# Copyright 2018 OmiseGO Pte Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defmodule OMG.Watcher.DB.SpendTest do
+  @moduledoc """
+  Currently, this test focuses on testing behaviors not testable via Controllers.TransactionTest.
+
+  The reason is that we are treating the DB schema etc. as implementation detail. In case testing through controllers
+  becomes hard/slow or otherwise unreasnable, refactor these two kinds of tests appropriately
+  """
+
+  use ExUnitFixtures
+  use ExUnit.Case, async: false
+  use OMG.Fixtures
+  use Plug.Test
+
+  alias OMG.State.Transaction
+  alias OMG.Utxo
+  alias OMG.Watcher.DB
+
+  require Utxo
+
+  @tag fixtures: [:initial_blocks]
+  test "check all spends was inserted", %{initial_blocks: initial_blocks} do
+    spends = DB.Repo.all(DB.Spend)
+    assert 4 == Enum.count(spends)
+
+    [{_, _, txhash, tx} | _] = initial_blocks
+    [Utxo.position(blknum, txindex, oindex)] = Transaction.get_inputs(tx)
+
+    assert %DB.Spend{
+      spending_txhash: ^txhash,
+      spending_tx_oindex: 0
+    } = Enum.find(spends, &match?(%{blknum: ^blknum, txindex: ^txindex, oindex: ^oindex}, &1))
+  end
+end

--- a/apps/omg_watcher/test/omg_watcher/db/spend_test.exs
+++ b/apps/omg_watcher/test/omg_watcher/db/spend_test.exs
@@ -17,7 +17,7 @@ defmodule OMG.Watcher.DB.SpendTest do
   Currently, this test focuses on testing behaviors not testable via Controllers.TransactionTest.
 
   The reason is that we are treating the DB schema etc. as implementation detail. In case testing through controllers
-  becomes hard/slow or otherwise unreasnable, refactor these two kinds of tests appropriately
+  becomes hard/slow or otherwise unreasonable, refactor these two kinds of tests appropriately
   """
 
   use ExUnitFixtures
@@ -40,8 +40,8 @@ defmodule OMG.Watcher.DB.SpendTest do
     [Utxo.position(blknum, txindex, oindex)] = Transaction.get_inputs(tx)
 
     assert %DB.Spend{
-      spending_txhash: ^txhash,
-      spending_tx_oindex: 0
-    } = Enum.find(spends, &match?(%{blknum: ^blknum, txindex: ^txindex, oindex: ^oindex}, &1))
+             spending_txhash: ^txhash,
+             spending_tx_oindex: 0
+           } = Enum.find(spends, &match?(%{blknum: ^blknum, txindex: ^txindex, oindex: ^oindex}, &1))
   end
 end

--- a/apps/omg_watcher/test/omg_watcher/db/transaction_test.exs
+++ b/apps/omg_watcher/test/omg_watcher/db/transaction_test.exs
@@ -17,7 +17,7 @@ defmodule OMG.Watcher.DB.TransactionTest do
   Currently, this test focuses on testing behaviors not testable via Controllers.TransactionTest.
 
   The reason is that we are treating the DB schema etc. as implementation detail. In case testing through controllers
-  becomes hard/slow or otherwise unreasnable, refactor these two kinds of tests appropriately
+  becomes hard/slow or otherwise unreasonable, refactor these two kinds of tests appropriately
   """
 
   use ExUnitFixtures


### PR DESCRIPTION
## Current state of block population into WatcherDB
In `block_getter :apply_block` we populate postgres database with a data for Watcher's convenience API.
Data send to database are
1. Block information (negligible) 
1. Transaction (significant)
1. TxOutputs created UTXO - :point_up: transaction's outputs (significant)
1. TxOutputs mark :point_up: transaction's inputs as spend (significant)

points 2. & 3. was a chunked, parametrized insert (ecto's `insert_all`)
4. - slowest part - update each input in the loop

## Idea behind optimization
We replaced slowest 4. updates with pushing information about spend (utxo position, spending txhash & input index) with `insert_all` and then updating existing TxOutputs records with `UPDATE` statement on database

We've tried to drop foreign key constrains on all tables but results were not significantly better. Therefore FKs were restored. ([removed migration](https://gist.github.com/pnowosie/cd5b72dade6277e630ba09fc0ada6343))

## Results
Results shows improvement of write speed of 41% from avg 2100 tps to 3600 on full blocks. Not fully filled blocks have worse improvement.
[Full report](https://docs.google.com/spreadsheets/d/12p10bgdC5_xYoAfc2HbTSAo7UguOiKcA2UhIgtAJbL4/edit?usp=sharing)

## Final conclusions
Improvement observed by test are not significant enough to risk a change. However this PR could be a base to further proposition to replace parametrized inserts with `COPY FROM` operation.