### PR TITLE
fix: use Stream for the large collections of known_txs in ExitProcessor

### DIFF
--- a/apps/omg_watcher/lib/omg_watcher/exit_processor/tx_appendix.ex
+++ b/apps/omg_watcher/lib/omg_watcher/exit_processor/tx_appendix.ex
@@ -24,7 +24,7 @@ defmodule OMG.Watcher.ExitProcessor.TxAppendix do
   def get_all(%ExitProcessor.Core{in_flight_exits: ifes, competitors: competitors}) do
     ifes
     |> Map.values()
-    |> Enum.concat(Map.values(competitors))
-    |> Enum.map(&Map.get(&1, :tx))
+    |> Stream.concat(Map.values(competitors))
+    |> Stream.map(&Map.get(&1, :tx))
   end
 end


### PR DESCRIPTION
Follow up to #706

## Overview

fixes an issue found in review of  #706 - known_txs are large and undergo several steps of processing, so using Enum can be very suboptimal

## Changes

Describe your changes and implementation choices. More details make PRs easier to review.

- use `Stream` instead of `Enum` in all the spots where large collections are used in `ExitProcessor` - namely the stream of so-called `known_txs`
- we are less exposed to being hit by a large memory footprint of doing large processing pipelines of large lists using `Enum`.

## Testing

N/A - code covered by existing unit tests, behaviors stay the same
