### PR TITLE
fix: fix docker compose to handle DB conn & startup correctly

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,16 +43,6 @@ RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 
 RUN usermod -aG sudo elixir-user
 
-COPY . /home/elixir-user/elixir-omg/
-
-RUN chown -R elixir-user:elixir-user /home/elixir-user
-
-USER elixir-user
-
-ENV LC_ALL=C.UTF-8
-ENV LANG=C.UTF-8
-ENV HEX_HTTP_TIMEOUT=240
-
 WORKDIR /home/elixir-user/elixir-omg/
 
 RUN wget https://github.com/ethereum/solidity/releases/download/v0.4.25/solc-static-linux \
@@ -64,7 +54,15 @@ RUN sudo -H pip3 install --upgrade pip \
   && sudo -H -n ln -s /usr/bin/python3 python \
   && sudo -H -n pip3 install requests gitpython retry
 
-WORKDIR /home/elixir-user/elixir-omg/
+COPY . /home/elixir-user/elixir-omg/
+
+RUN chown -R elixir-user:elixir-user /home/elixir-user
+
+USER elixir-user
+
+ENV LC_ALL=C.UTF-8
+ENV LANG=C.UTF-8
+ENV HEX_HTTP_TIMEOUT=240
 
 RUN mix do local.hex --force, local.rebar --force
 

--- a/docker-compose-full-services-mac.yml
+++ b/docker-compose-full-services-mac.yml
@@ -70,7 +70,7 @@ services:
 
   watcher:
     image: elixir-omg:dockercompose
-    entrypoint: /bin/bash -c "./launcher.py && mix ecto.reset --no-start && elixir --erl '-sname watcher' -S mix xomg.watcher.start --convenience --config ~/config_watcher.exs "
+    entrypoint: /bin/bash -c "./launcher.py && elixir --erl '-sname watcher' -S mix xomg.watcher.start --convenience --config ~/config_watcher.exs "
     environment:
       - MIX_ENV=dev
       - ELIXIR_SERVICE=WATCHER

--- a/docker-compose-full-services-non-mac.yml
+++ b/docker-compose-full-services-non-mac.yml
@@ -54,7 +54,7 @@ services:
 
   watcher:
     image: elixir-omg:dockercompose
-    entrypoint: /bin/bash -c "./launcher.py && mix ecto.reset --no-start && elixir --erl '-sname watcher' -S mix xomg.watcher.start --convenience --config ~/config_watcher.exs"
+    entrypoint: /bin/bash -c "./launcher.py && elixir --erl '-sname watcher' -S mix xomg.watcher.start --convenience --config ~/config_watcher.exs"
     environment:
       - MIX_ENV=dev
       - ELIXIR_SERVICE=WATCHER

--- a/docker-compose-watcher-mac.yml
+++ b/docker-compose-watcher-mac.yml
@@ -21,20 +21,21 @@ services:
 
   watcher:
     image: elixir-omg:dockercompose
-    entrypoint: /bin/bash -c "./launcher.py && mix ecto.reset --no-start && elixir --erl '-sname watcher' -S mix xomg.watcher.start --convenience --config ~/config_watcher.exs "
+    entrypoint: /bin/bash -c "./launcher.py && elixir --erl '-sname watcher' -S mix xomg.watcher.start --convenience --config ~/config_watcher.exs "
     environment:
       - MIX_ENV=dev
       - ELIXIR_SERVICE=WATCHER
       - ETHEREUM_RPC_URL=https://rinkeby.infura.io/v3/<your_api_key>
-      - CHILD_CHAIN_URL=http://ari.omg.network
+      - CHILD_CHAIN_URL=http://samrong.omg.network
       - ETHEREUM_NETWORK=RINKEBY
-      - RINKEBY_CONTRACT_ADDRESS=0x44de0ec539b8c4a4b530c78620fe8320167f2f74
-      - RINKEBY_TXHASH_CONTRACT=0x3259a7533fb46486e362cc6f33ff1dbf422af96177ef34cafd3348e5d01e6083
-      - RINKEBY_AUTHORITY_ADDRESS=0xeac4eedfb51c682f6eb2082093ee81791dfa9bc7
+      - RINKEBY_CONTRACT_ADDRESS=0x740ecec4c0ee99c285945de8b44e9f5bfb71eea7
+      - RINKEBY_TXHASH_CONTRACT=0x29f8cd44b4b94a148f779105f0e09e06f762b411ebef6c499281b74d45818c1c
+      - RINKEBY_AUTHORITY_ADDRESS=0x41863dafbdf8cfc2a33fc38c0b525b6343d857b3
       - DATABASE_URL=postgres://omisego_dev:omisego_dev@docker.for.mac.localhost:5433/omisego_dev
     restart: always
     ports:
       - "7434:7434"
+    network_mode: "host"
     healthcheck:
       test: curl docker.for.mac.localhost:7434
       interval: 5s

--- a/docker-compose-watcher-non-mac.yml
+++ b/docker-compose-watcher-non-mac.yml
@@ -21,20 +21,21 @@ services:
 
   watcher:
     image: elixir-omg:dockercompose
-    entrypoint: /bin/bash -c "./launcher.py && mix ecto.reset --no-start && elixir --erl '-sname watcher' -S mix xomg.watcher.start --convenience --config ~/config_watcher.exs "
+    entrypoint: /bin/bash -c "./launcher.py && elixir --erl '-sname watcher' -S mix xomg.watcher.start --convenience --config ~/config_watcher.exs "
     environment:
       - MIX_ENV=dev
       - ELIXIR_SERVICE=WATCHER
       - ETHEREUM_RPC_URL=https://rinkeby.infura.io/v3/<your_api_key>
-      - CHILD_CHAIN_URL=http://ari.omg.network
+      - CHILD_CHAIN_URL=http://samrong.omg.network
       - ETHEREUM_NETWORK=RINKEBY
-      - RINKEBY_CONTRACT_ADDRESS=0x44de0ec539b8c4a4b530c78620fe8320167f2f74
-      - RINKEBY_TXHASH_CONTRACT=0x3259a7533fb46486e362cc6f33ff1dbf422af96177ef34cafd3348e5d01e6083
-      - RINKEBY_AUTHORITY_ADDRESS=0xeac4eedfb51c682f6eb2082093ee81791dfa9bc7
+      - RINKEBY_CONTRACT_ADDRESS=0x740ecec4c0ee99c285945de8b44e9f5bfb71eea7
+      - RINKEBY_TXHASH_CONTRACT=0x29f8cd44b4b94a148f779105f0e09e06f762b411ebef6c499281b74d45818c1c
+      - RINKEBY_AUTHORITY_ADDRESS=0x41863dafbdf8cfc2a33fc38c0b525b6343d857b3
       - DATABASE_URL=postgres://omisego_dev:omisego_dev@localhost:5433/omisego_dev
     restart: always
     ports:
       - "7434:7434"
+    network_mode: "host"
     healthcheck:
       test: curl localhost:7434
       interval: 5s

--- a/launcher.py
+++ b/launcher.py
@@ -443,7 +443,7 @@ class WatcherLauncher:
         '''
         os.chdir(os.path.expanduser('~') + '/elixir-omg')
         result = subprocess.run(
-            "mix ecto.reset",
+            "mix ecto.reset --no-start",
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             shell=True


### PR DESCRIPTION
fixes #691

## Overview

A number of orthogonal fixes that allow the docker-composed watchers to sync to `samrong`

Now it syncs fine and doesn't complain anything:

```
$ docker-compose -f docker-compose-watcher-non-mac.yml up
...
watcher_1     | 2019-05-29 10:19:05.276 [info] module=OMG.Watcher.BlockGetter function=handle_cast/2 ⋅Applied block: #51000, from eth height: 4460698 with 2 txs⋅
```

## Changes

- provide correct `samrong` contract addresses etc. in the `docker-compose` YAMLs,  to be able to sync with `master`/`v0.2`
- use `network_mode: host` for the watcher container (but not postgres, otherwise it clashes with the locally run one)
- rearrange `Dockerfile` to not have to reinstall solc/pip installs every time our code changes
- don't have the superfluous `mix ecto.reset` in the `docker-compose` YAMLs (it's done in `launcher.py`)
- `mix ecto.reset` in the `launcher.py` requires `--no-start`

## Testing

```
docker-compose -f docker-compose-watcher-non-mac.yml build
docker-compose -f docker-compose-watcher-non-mac.yml down
docker-compose -f docker-compose-watcher-non-mac.yml up
```

testing on Mac TODO, volunteers?
