### PR TITLE
feature: make local watcher run a proper OTP release

### DIFF
--- a/Dockerfile.watcher
+++ b/Dockerfile.watcher
@@ -35,6 +35,7 @@ RUN apk add --update --no-cache --virtual .watcher-runtime \
 
 #libsecp256k1
 RUN apk add --no-cache gmp-dev
+
 COPY rootfs /
 
 # USER directive is not being used here since privileges are dropped via

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ ENV_PROD        ?= env MIX_ENV=prod
 deps: deps-elixir-omg
 
 deps-elixir-omg:
-	mix deps.get
+	HEX_HTTP_TIMEOUT=120 mix deps.get
 
 .PHONY: deps deps-elixir-omg
 

--- a/apps/omg_eth/lib/omg_eth/release_tasks/set_contract.ex
+++ b/apps/omg_eth/lib/omg_eth/release_tasks/set_contract.ex
@@ -25,7 +25,7 @@ defmodule OMG.Eth.ReleaseTasks.SetContract do
   """
   @impl Provider
   def init(_args) do
-    case get_env("NETWORK") do
+    case get_env("ETHEREUM_NETWORK") do
       "RINKEBY" = network -> :ok = apply_settings(network)
       _ -> exit("Rinkeby or not implemented. There's no contracts that the release could point to.")
     end

--- a/apps/omg_eth/lib/omg_eth/release_tasks/set_ethereum_client.ex
+++ b/apps/omg_eth/lib/omg_eth/release_tasks/set_ethereum_client.ex
@@ -12,17 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-defmodule OMG.DB.ReleaseTasks.SetKeyValueDB do
-  @moduledoc """
-  Gets the DB path from environment and perstists it to configuration.
-  """
+defmodule OMG.Eth.ReleaseTasks.SetEthereumClient do
+  @moduledoc false
   use Mix.Releases.Config.Provider
 
+  @doc """
+  Gets the environment setting for the ethereum client location.
+  """
   @impl Provider
   def init(_args) do
-    case get_env("DB_PATH") do
-      path when is_binary(path) -> :ok = Application.put_env(:omg_db, :path, path, persistent: true)
-      _ -> :ok = Application.put_env(:omg_db, :path, System.user_home!(), persistent: true)
+    case get_env("ETHEREUM_RPC_URL") do
+      url when is_binary(url) -> Application.put_env(:ethereumex, :url, url, persistent: true)
+      _ -> Application.put_env(:ethereumex, :url, "http://localhost:8545", persistent: true)
     end
 
     :ok

--- a/apps/omg_watcher/lib/omg_watcher/block_getter/supervisor.ex
+++ b/apps/omg_watcher/lib/omg_watcher/block_getter/supervisor.ex
@@ -37,7 +37,7 @@ defmodule OMG.Watcher.BlockGetter.Supervisor do
       }
     ]
 
-    opts = [strategy: :one_for_all, max_restarts: 500, max_seconds: 5]
+    opts = [strategy: :one_for_all]
 
     _ = Logger.info("Starting #{inspect(__MODULE__)}")
     Supervisor.init(children, opts)

--- a/apps/omg_watcher/lib/omg_watcher/block_getter/supervisor.ex
+++ b/apps/omg_watcher/lib/omg_watcher/block_getter/supervisor.ex
@@ -37,7 +37,7 @@ defmodule OMG.Watcher.BlockGetter.Supervisor do
       }
     ]
 
-    opts = [strategy: :one_for_all, max_restarts: 1000, max_seconds: 60]
+    opts = [strategy: :one_for_all, max_restarts: 500, max_seconds: 5]
 
     _ = Logger.info("Starting #{inspect(__MODULE__)}")
     Supervisor.init(children, opts)

--- a/docker-compose-watcher-mac.yml
+++ b/docker-compose-watcher-mac.yml
@@ -15,16 +15,13 @@ services:
       timeout: 3s
       retries: 5
 
-  elixir-omg:
-    build: .
-    image: elixir-omg:dockercompose
-
   watcher:
-    image: elixir-omg:dockercompose
-    entrypoint: /bin/bash -c "./launcher.py && elixir --erl '-sname watcher' -S mix xomg.watcher.start --convenience --config ~/config_watcher.exs "
+    image: omisego/watcher:latest
+    command: "full_local"
+    build:
+      context: ./
+      dockerfile: Dockerfile.watcher
     environment:
-      - MIX_ENV=dev
-      - ELIXIR_SERVICE=WATCHER
       - ETHEREUM_RPC_URL=https://rinkeby.infura.io/v3/<your_api_key>
       - CHILD_CHAIN_URL=http://samrong.omg.network
       - ETHEREUM_NETWORK=RINKEBY
@@ -32,7 +29,7 @@ services:
       - RINKEBY_TXHASH_CONTRACT=0x29f8cd44b4b94a148f779105f0e09e06f762b411ebef6c499281b74d45818c1c
       - RINKEBY_AUTHORITY_ADDRESS=0x41863dafbdf8cfc2a33fc38c0b525b6343d857b3
       - DATABASE_URL=postgres://omisego_dev:omisego_dev@docker.for.mac.localhost:5433/omisego_dev
-    restart: always
+      - NODE_HOST=127.0.0.1
     ports:
       - "7434:7434"
     network_mode: "host"

--- a/docker-compose-watcher-non-mac.yml
+++ b/docker-compose-watcher-non-mac.yml
@@ -15,16 +15,10 @@ services:
       timeout: 3s
       retries: 5
 
-  elixir-omg:
-    build: .
-    image: elixir-omg:dockercompose
-
   watcher:
-    image: elixir-omg:dockercompose
-    entrypoint: /bin/bash -c "./launcher.py && elixir --erl '-sname watcher' -S mix xomg.watcher.start --convenience --config ~/config_watcher.exs "
+    image: omisego/watcher:latest
+    command: "full_local"
     environment:
-      - MIX_ENV=dev
-      - ELIXIR_SERVICE=WATCHER
       - ETHEREUM_RPC_URL=https://rinkeby.infura.io/v3/<your_api_key>
       - CHILD_CHAIN_URL=http://samrong.omg.network
       - ETHEREUM_NETWORK=RINKEBY
@@ -32,6 +26,7 @@ services:
       - RINKEBY_TXHASH_CONTRACT=0x29f8cd44b4b94a148f779105f0e09e06f762b411ebef6c499281b74d45818c1c
       - RINKEBY_AUTHORITY_ADDRESS=0x41863dafbdf8cfc2a33fc38c0b525b6343d857b3
       - DATABASE_URL=postgres://omisego_dev:omisego_dev@localhost:5433/omisego_dev
+      - NODE_HOST=127.0.0.1
     restart: always
     ports:
       - "7434:7434"

--- a/rel/config.exs
+++ b/rel/config.exs
@@ -41,6 +41,7 @@ release :watcher do
   set(
     config_providers: [
       {OMG.Eth.ReleaseTasks.SetContract, ["${RELEASE_ROOT_DIR}/config/config.exs"]},
+      {OMG.Eth.ReleaseTasks.SetEthereumClient, ["${RELEASE_ROOT_DIR}/config/config.exs"]},
       {OMG.DB.ReleaseTasks.SetKeyValueDB, ["${RELEASE_ROOT_DIR}/config/config.exs"]}
     ]
   )
@@ -72,6 +73,7 @@ release :child_chain do
   set(
     config_providers: [
       {OMG.Eth.ReleaseTasks.SetContract, ["${RELEASE_ROOT_DIR}/config/config.exs"]},
+      {OMG.Eth.ReleaseTasks.SetEthereumClient, ["${RELEASE_ROOT_DIR}/config/config.exs"]},
       {OMG.DB.ReleaseTasks.SetKeyValueDB, ["${RELEASE_ROOT_DIR}/config/config.exs"]}
     ]
   )

--- a/rootfs/child_chain_entrypoint
+++ b/rootfs/child_chain_entrypoint
@@ -50,14 +50,10 @@ s6-env REPLACE_OS_VARS=yes
 ifelse { test $1 == "init_key_value_db" } { /app/bin/child_chain $@ }
 
 ifelse { test $1 == "foreground" } {
-  importas -D true SERVE_ENDPOINTS SERVE_ENDPOINTS
-  s6-env SERVE_ENDPOINTS=$SERVE_ENDPOINTS
   /app/bin/child_chain $@
 }
 
 ifelse { test $1 == "console" } {
-  importas -D false SERVE_ENDPOINTS SERVE_ENDPOINTS
-  s6-env SERVE_ENDPOINTS=$SERVE_ENDPOINTS
   /app/bin/child_chain $@
 }
 

--- a/rootfs/watcher_entrypoint
+++ b/rootfs/watcher_entrypoint
@@ -30,6 +30,15 @@ importas -iu default_cookie default_cookie
 importas -D $default_cookie ERLANG_COOKIE ERLANG_COOKIE
 s6-env ERLANG_COOKIE=$ERLANG_COOKIE
 
+## NODE_DNS
+##
+## Used in clustering; by default wallet is configured to discover nodes via
+## DNS. Registering nodes to the cluster is a responsibility of cluster tools
+## e.g. Kubernetes.
+##
+importas -D localhost NODE_DNS NODE_DNS
+s6-env NODE_DNS=$NODE_DNS
+
 ## HOME
 ##
 ## Home is required to be set since some tools use it to create e.g. cache.
@@ -47,18 +56,18 @@ s6-env REPLACE_OS_VARS=yes
 
 ## Known commands
 ##
+
 ifelse { test $1 == "init_key_value_db" } { /app/bin/watcher $@ }
 ifelse { test $1 == "init_postgresql_db" } { /app/bin/watcher $@ }
+ifelse { test $1 == "full_local" } {
+  /bin/bash -c "/app/bin/watcher init_postgresql_db && /app/bin/watcher init_key_value_db && /app/bin/watcher foreground"
+}
 
 ifelse { test $1 == "foreground" } {
-  importas -D true SERVE_ENDPOINTS SERVE_ENDPOINTS
-  s6-env SERVE_ENDPOINTS=$SERVE_ENDPOINTS
   /app/bin/watcher $@
 }
 
 ifelse { test $1 == "console" } {
-  importas -D false SERVE_ENDPOINTS SERVE_ENDPOINTS
-  s6-env SERVE_ENDPOINTS=$SERVE_ENDPOINTS
   /app/bin/watcher $@
 }
 


### PR DESCRIPTION
#579 

## Overview

Ha! The local watcher now pulls in a the latest image created from master, tagged as *latest*!

## Changes

Describe your changes and implementation choices. More details make PRs easier to review.

- Getting the proper ethereum client address from env, and setting it in the sys.config via config providers.
- adding a command `full_local` that wipes the DB's every run. Ecto reset and KV wipe.

## Testing

make docker-watcher && docker-compose -f docker-compose-watcher-mac.yml up
