### PR TITLE
feature: swap DB type via env

### DIFF
--- a/apps/omg_db/config/config.exs
+++ b/apps/omg_db/config/config.exs
@@ -3,7 +3,7 @@ use Mix.Config
 # see [here](README.md) for documentation
 
 config :omg_db,
-  type: :leveldb,
+  type: {:system, "DB_TYPE", :leveldb, {String, :to_atom}},
   path: Path.join([System.get_env("HOME"), ".omg/data"]),
   leveldb: [server_module: OMG.DB.LevelDB.Server, server_name: OMG.DB.LevelDB.Server],
   rocksdb: [server_module: OMG.DB.RocksDB.Server, server_name: OMG.DB.RocksDB.Server]

--- a/apps/omg_db/lib/db.ex
+++ b/apps/omg_db/lib/db.ex
@@ -72,8 +72,15 @@ defmodule OMG.DB do
   def child_spec, do: driver().child_spec()
   def child_spec(args), do: driver().child_spec(args)
 
-  def init(path), do: driver().init(path)
-  def init, do: driver().init()
+  def init(path) do
+    DeferredConfig.populate(:omg_db)
+    driver().init(path)
+  end
+
+  def init do
+    DeferredConfig.populate(:omg_db)
+    driver().init()
+  end
 
   @doc """
   Puts all zeroes and other init values to a generically initialized `OMG.DB`

--- a/apps/omg_db/lib/omg_db/application.ex
+++ b/apps/omg_db/lib/omg_db/application.ex
@@ -18,6 +18,7 @@ defmodule OMG.DB.Application do
   use Application
 
   def start(_type, _args) do
+    DeferredConfig.populate(:omg_db)
     children = [OMG.DB.child_spec()]
     opts = [strategy: :one_for_one, name: OMG.DB.Supervisor]
     Supervisor.start_link(children, opts)


### PR DESCRIPTION
Slack.

## Overview

RocksDB is implemented, but not tested "in the wild".

## Changes

- Pull the DB type from ENV.

## Testing
Hey, If it works, it works.
