### PR TITLE
590 Remove 'Content-Type' header enforcing

### DIFF
--- a/apps/omg_watcher_rpc/lib/web/router.ex
+++ b/apps/omg_watcher_rpc/lib/web/router.ex
@@ -17,7 +17,6 @@ defmodule OMG.WatcherRPC.Web.Router do
 
   pipeline :api do
     plug(:accepts, ["json"])
-    plug(:enforce_json_content)
   end
 
   scope "/", OMG.WatcherRPC.Web do
@@ -46,22 +45,5 @@ defmodule OMG.WatcherRPC.Web.Router do
 
     # NOTE: This *has to* be the last route, catching all unhandled paths
     match(:*, "/*path", Controller.Fallback, Route.NotFound)
-  end
-
-  def enforce_json_content(conn, _opts) do
-    headers = conn |> get_req_header("content-type")
-
-    if "application/json" in headers do
-      conn
-    else
-      conn
-      |> json(
-        OMG.Utils.HttpRPC.Error.serialize(
-          "operation:invalid_content",
-          "Content type of application/json header is required for all requests."
-        )
-      )
-      |> halt()
-    end
   end
 end

--- a/apps/omg_watcher_rpc/test/omg_watcher_rpc/web/controllers/enforce_content_plug_test.exs
+++ b/apps/omg_watcher_rpc/test/omg_watcher_rpc/web/controllers/enforce_content_plug_test.exs
@@ -13,6 +13,11 @@
 # limitations under the License.
 
 defmodule OMG.WatcherRPC.Web.Controller.EnforceContentPlugTest do
+  @moduledoc """
+  This test module tested header enforcing which we decided to remove in #759. Instead of removing it, it was reversed
+  to show no header is required. We can remove this test as it basically shows HTTP protocol behavior.
+  """
+
   use ExUnitFixtures
   use ExUnit.Case, async: false
   use OMG.Fixtures
@@ -20,7 +25,7 @@ defmodule OMG.WatcherRPC.Web.Controller.EnforceContentPlugTest do
   alias OMG.Utils.HttpRPC.Encoding
 
   @tag fixtures: [:phoenix_ecto_sandbox]
-  test "Request missing expected content type header is rejected" do
+  test "Content type header is no longer required" do
     no_account = Encoding.to_hex(<<0::160>>)
     post = conn(:post, "account.get_balance", %{"address" => no_account})
     response = OMG.WatcherRPC.Web.Endpoint.call(post, [])
@@ -28,12 +33,8 @@ defmodule OMG.WatcherRPC.Web.Controller.EnforceContentPlugTest do
     assert response.status == 200
 
     assert %{
-             "data" => %{
-               "code" => "operation:invalid_content",
-               "description" => "Content type of application/json header is required for all requests.",
-               "object" => "error"
-             },
-             "success" => false,
+             "data" => [],
+             "success" => true,
              "version" => "1.0"
            } == Jason.decode!(response.resp_body)
   end

--- a/docs/api_specs/errors.md
+++ b/docs/api_specs/errors.md
@@ -22,7 +22,6 @@ Code | Description
 server:internal_server_error | Something went wrong on the server. Try again soon.
 operation:bad_request | Parameters required by this operation are missing or incorrect. More information about error in response object `data/messages` property.
 operation:not_found | Operation cannot be found. Check request URL.
-operation:invalid_content | Content type of application/json header is required for all requests.
 challenge:exit_not_found | The challenge of particular exit is impossible because exit is inactive or missing
 challenge:utxo_not_spent | The challenge of particular exit is impossible because provided utxo is not spent
 exit:invalid | Utxo was spent or does not exist.


### PR DESCRIPTION
:clipboard: Fixes #590 
## Overview

Following HTTP-RPC we required every request specifies header `Content-Type: application/json`. This causes issues with REST clients on paths that passes no data in the body.

## Changes
Removes header enforcing.


- [apps/omg_watcher/lib/omg_watcher/web/router.ex](https://github.com/omisego/elixir-omg/blob/d4a529836c56d8c1ac70d9d850d8d9737a493a0b/apps/omg_watcher/lib/omg_watcher/web/router.ex)

## Testing

No need to test - it's HTTP protocol behavior.