### PR TITLE
because we have a very special bootup :-)

### DIFF
--- a/apps/xomg_tasks/lib/mix/tasks/watcher.ex
+++ b/apps/xomg_tasks/lib/mix/tasks/watcher.ex
@@ -38,6 +38,6 @@ defmodule Mix.Tasks.Xomg.Watcher.Start do
   defp start_watcher(args) do
     args
     |> generic_prepare_args()
-    |> generic_run([:omg_watcher])
+    |> generic_run([:omg_watcher, :omg_watcher_rpc])
   end
 end


### PR DESCRIPTION
Slack

## Overview

Application omg_watcher_rpc must be started manually.

## Changes

- Instead of the applications bootup tree being resolved it must be specified manually.

## Testing

/
