### PR TITLE
fix: get cors settings from proper app

### DIFF
--- a/apps/omg_watcher_rpc/lib/web/endpoint.ex
+++ b/apps/omg_watcher_rpc/lib/web/endpoint.ex
@@ -32,7 +32,7 @@ defmodule OMG.WatcherRPC.Web.Endpoint do
   plug(Plug.MethodOverride)
   plug(Plug.Head)
 
-  if Application.get_env(:omg_watcher, OMG.WatcherRPC.Web.Endpoint)[:enable_cors],
+  if Application.get_env(:omg_watcher_rpc, OMG.WatcherRPC.Web.Endpoint)[:enable_cors],
     do: plug(CORSPlug)
 
   plug(OMG.WatcherRPC.Web.Router)


### PR DESCRIPTION
CORS headers missing from response

## Overview

/

## Changes

- Fetch settings from proper app

## Testing

/
