### PR TITLE
Api response proper version

### DIFF
--- a/apps/omg_utils/lib/omg_utils/http_rpc/response.ex
+++ b/apps/omg_utils/lib/omg_utils/http_rpc/response.ex
@@ -69,7 +69,7 @@ defmodule OMG.Utils.HttpRPC.Response do
 
   defp to_response(data, result),
     do: %{
-      version: "1.0",
+      version: "0.2",
       success: result == :success,
       data: data
     }

--- a/apps/omg_watcher/test/support/test_helper.ex
+++ b/apps/omg_watcher/test/support/test_helper.ex
@@ -25,6 +25,7 @@ defmodule OMG.Watcher.TestHelper do
   use Phoenix.ConnTest
 
   @endpoint OMG.WatcherRPC.Web.Endpoint
+  @api_version "0.2"
 
   def wait_for_process(pid, timeout \\ :infinity) when is_pid(pid) do
     ref = Process.monitor(pid)
@@ -40,19 +41,19 @@ defmodule OMG.Watcher.TestHelper do
 
   def success?(path, body \\ nil) do
     response_body = rpc_call(path, body, 200)
-    %{"version" => "1.0", "success" => true, "data" => data} = response_body
+    %{"version" => @api_version, "success" => true, "data" => data} = response_body
     data
   end
 
   def no_success?(path, body \\ nil) do
     response_body = rpc_call(path, body, 200)
-    %{"version" => "1.0", "success" => false, "data" => data} = response_body
+    %{"version" => @api_version, "success" => false, "data" => data} = response_body
     data
   end
 
   def server_error?(path, body \\ nil) do
     response_body = rpc_call(path, body, 500)
-    %{"version" => "1.0", "success" => false, "data" => data} = response_body
+    %{"version" => @api_version, "success" => false, "data" => data} = response_body
     data
   end
 

--- a/apps/omg_watcher_rpc/test/omg_watcher_rpc/web/controllers/enforce_content_plug_test.exs
+++ b/apps/omg_watcher_rpc/test/omg_watcher_rpc/web/controllers/enforce_content_plug_test.exs
@@ -31,11 +31,6 @@ defmodule OMG.WatcherRPC.Web.Controller.EnforceContentPlugTest do
     response = OMG.WatcherRPC.Web.Endpoint.call(post, [])
 
     assert response.status == 200
-
-    assert %{
-             "data" => [],
-             "success" => true,
-             "version" => "1.0"
-           } == Jason.decode!(response.resp_body)
+    assert %{"success" => true} = Jason.decode!(response.resp_body)
   end
 end


### PR DESCRIPTION
:clipboard: Reported by @jbunce 

## Overview

Changes API version in standard response to corresponds to OMG network version.

## Changes

Quick fix changes the string in response template.
Proper fix is to use configuration value of https://github.com/omisego/elixir-omg/blob/591cff16177d3e588b3c8be43983d67ba3546728/apps/omg/config/config.exs#L13 which requires contract redeployment

## Testing

