### PR TITLE
fix: Change from waiting for k8s readiness to full e2e

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -318,7 +318,7 @@ jobs:
             kubectl set image statefulset childchain-samrong childchain=$DOCKER_IMAGE
             while true; do if [ "$(kubectl get pods childchain-samrong-0 -o jsonpath=\"{.status.phase}\" | grep Running)" ]; then break; fi; done
             kubectl set image statefulset watcher-samrong watcher=$DOCKER_IMAGE
-            while true; do if [ "$(kubectl get pods watcher-samrong-0 | grep 1/1)" ]; then break; fi; done
+            while true; do if [ "$(curl ${WATCHER_DEVELOPMENT}" ]; then break; fi; done
       - run:
           name: Functional Tests
           command: |


### PR DESCRIPTION
## Overview

The test-runner fails because the service isn't ready after a deploy. This halts execution of the test-runner until the ingress is live.

## Changes

`kubectl` -> `curl`

## Testing


