### PR TITLE
Use `APP_ENV` for Sentry environment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -70,7 +70,6 @@ RUN mix deps.clean --all
 RUN mix deps.get
 
 RUN mix compile
-RUN mix sentry.recompile
 
 USER root
 

--- a/config/config.exs
+++ b/config/config.exs
@@ -31,8 +31,7 @@ config :sentry,
   tags: %{
     application: Mix.Project.config()[:app],
     eth_network: System.get_env("ETHEREUM_NETWORK"),
-    eth_node: System.get_env("ETH_NODE"),
-    mix_env: Mix.env(),
+    eth_node: System.get_env("ETH_NODE")
   }
 
 # Configs for AppSignal application monitoring

--- a/config/config.exs
+++ b/config/config.exs
@@ -29,7 +29,7 @@ config :sentry,
   included_environments: [:dev, :prod, System.get_env("APP_ENV")],
   server_name: elem(:inet.gethostname(), 1),
   tags: %{
-    application: Mix.Project.config()[:app],
+    application: System.get_env("ELIXIR_SERVICE"),
     eth_network: System.get_env("ETHEREUM_NETWORK"),
     eth_node: System.get_env("ETH_NODE")
   }

--- a/config/config.exs
+++ b/config/config.exs
@@ -23,9 +23,7 @@ config :logger,
 
 config :sentry,
   dsn: System.get_env("SENTRY_DSN"),
-  enable_source_code_context: true,
   environment_name: System.get_env("APP_ENV"),
-  root_source_code_path: File.cwd!(),
   included_environments: [:dev, :prod, System.get_env("APP_ENV")],
   server_name: elem(:inet.gethostname(), 1),
   tags: %{

--- a/config/config.exs
+++ b/config/config.exs
@@ -23,15 +23,17 @@ config :logger,
 
 config :sentry,
   dsn: {:system, "SENTRY_DSN"},
-  environment_name: {:system, "APP_ENV"},
   enable_source_code_context: true,
+  environment_name: {:system, "APP_ENV"},
   root_source_code_path: File.cwd!(),
-  tags: %{
-    mix_env: Mix.env(),
-    application: Mix.Project.config()[:app]
-  },
+  included_environments: [:dev, :prod, System.get_env("APP_ENV")],
   server_name: elem(:inet.gethostname(), 1),
-  included_environments: [:prod, :dev]
+  tags: %{
+    application: Mix.Project.config()[:app],
+    eth_network: System.get_env("ETHEREUM_NETWORK"),
+    eth_node: System.get_env("ETH_NODE"),
+    mix_env: Mix.env(),
+  }
 
 # Configs for AppSignal application monitoring
 config :appsignal, :config,

--- a/config/config.exs
+++ b/config/config.exs
@@ -22,9 +22,9 @@ config :logger,
   backends: [Sentry.LoggerBackend, :console]
 
 config :sentry,
-  dsn: {:system, "SENTRY_DSN"},
+  dsn: System.get_env("SENTRY_DSN"),
   enable_source_code_context: true,
-  environment_name: {:system, "APP_ENV"},
+  environment_name: System.get_env("APP_ENV"),
   root_source_code_path: File.cwd!(),
   included_environments: [:dev, :prod, System.get_env("APP_ENV")],
   server_name: elem(:inet.gethostname(), 1),

--- a/config/config.exs
+++ b/config/config.exs
@@ -23,11 +23,11 @@ config :logger,
 
 config :sentry,
   dsn: {:system, "SENTRY_DSN"},
-  environment_name: Mix.env(),
+  environment_name: {:system, "APP_ENV"},
   enable_source_code_context: true,
   root_source_code_path: File.cwd!(),
   tags: %{
-    env: Mix.env(),
+    mix_env: Mix.env(),
     application: Mix.Project.config()[:app]
   },
   server_name: elem(:inet.gethostname(), 1),

--- a/mix.exs
+++ b/mix.exs
@@ -52,8 +52,7 @@ defmodule OMG.Umbrella.MixProject do
       "coveralls.detail": ["coveralls.detail --no-start"],
       "coveralls.post": ["coveralls.post --no-start"],
       "ecto.setup": ["ecto.create", "ecto.migrate", "run apps/omg_watcher/priv/repo/seeds.exs"],
-      "ecto.reset": ["ecto.drop", "ecto.setup"],
-      "sentry.recompile": ["deps.compile sentry --force"]
+      "ecto.reset": ["ecto.drop", "ecto.setup"]
     ]
   end
 


### PR DESCRIPTION
:clipboard: #771
:clipboard: https://github.com/omisego/devops/pull/103

## Overview

This PR is dependent on https://github.com/omisego/devops/pull/103. This leverages `APP_ENV` to pick up our Sentry environment instead of `MIX_ENV`.

## Changes

Describe your changes and implementation choices. More details make PRs easier to review.

* Use `APP_ENV` instead of `MIX_ENV`: 1a3e70a7
* Add additional Sentry tags like `eth_network`, `mix_env`, and `eth_node`
* Remove source code context feature until a later PR. Would make our deploys a bit more difficult at the moment.

## Testing

```sh
ETH_NODE="bar" ETHEREUM_NETWORK="foo" APP_ENV="prod" MIX_ENV=dev mix sentry.send_test_event
```