### PR TITLE
fix: Service 'watcher' depends on service 'postgres' which is undefined.

### DIFF
--- a/docs/run_local_watcher.md
+++ b/docs/run_local_watcher.md
@@ -14,7 +14,7 @@ The `docker-compose` tooling in the root of `elixir-omg` allows users to run the
 
 2) From the root of the `elixir-omg` execute:
 
-- `docker-compose -f docker-compose-watcher-mac.yml up` (Mac)
-- `docker-compose -f docker-compose-watcher-non-mac.yml up` (Linux/Windows)
+- `docker-compose -f docker-compose.yml -f docker-compose-watcher-mac.yml up` (Mac)
+- `docker-compose -f docker-compose.yml -f docker-compose-watcher-non-mac.yml up` (Linux/Windows)
 
 Modify the other environment variables for connecting to other networks.


### PR DESCRIPTION
Howdy

## Overview

Local watcher run needs Postgres service.

## Changes

Describe your changes and implementation choices. More details make PRs easier to review.

- Manually specify the default docker-compose file because it's not being picked up on 
```
Linux
docker-compose version 1.24.0, build 0aa59064
Mac
docker-compose version 1.23.2, build 1110ad01
```
## Testing

