### PR TITLE
Eth node streaming api has to be enabled

### DIFF
--- a/docker-compose-full-services-mac.yml
+++ b/docker-compose-full-services-mac.yml
@@ -2,7 +2,7 @@ version: "2.1"
 services:
   geth:
     image: ethereum/client-go:v1.8.21
-    entrypoint: /bin/sh -c "apk add curl && geth --targetgaslimit "6200000" --dev --dev.period 1 --rpc --rpcapi personal,web3,eth,net --rpcaddr 0.0.0.0 --rpcvhosts=* --rpcport=8545"
+    entrypoint: /bin/sh -c "apk add curl && geth --targetgaslimit "6200000" --dev --dev.period 1 --rpc --rpcapi personal,web3,eth,net --rpcaddr 0.0.0.0 --rpcvhosts=* --rpcport=8545 --ws --wsorigins='*'"
     ports:
      - "8545:8545"
     healthcheck:

--- a/docker-compose-full-services-non-mac.yml
+++ b/docker-compose-full-services-non-mac.yml
@@ -2,7 +2,7 @@ version: "2.1"
 services:
   geth:
     image: ethereum/client-go:v1.8.21
-    entrypoint: /bin/sh -c "apk add curl && geth --targetgaslimit "6200000" --dev --dev.period 1 --rpc --rpcapi personal,web3,eth,net --rpcaddr 0.0.0.0 --rpcvhosts=* --rpcport=8545"
+    entrypoint: /bin/sh -c "apk add curl && geth --targetgaslimit "6200000" --dev --dev.period 1 --rpc --rpcapi personal,web3,eth,net --rpcaddr 0.0.0.0 --rpcvhosts=* --rpcport=8545 --ws --wsorigins='*'"
     ports:
      - "8545:8545"
     network_mode: "host"

--- a/docs/manual_service_startup.md
+++ b/docs/manual_service_startup.md
@@ -44,13 +44,13 @@ A developer instance of `geth` runs Ethereum locally and prefunds an account.
 However, when `geth` terminates, the state of the Ethereum network is lost.
 
 ```bash
-geth --targetgaslimit "6200000" --dev --dev.period 1 --rpc --rpcapi personal,web3,eth,net  --rpcaddr 0.0.0.0 --ws --wsorigins='*'
+geth --targetgaslimit "6200000" --dev --dev.period 1 --rpc --rpcapi personal,web3,eth,net --ws --wsorigins='*'
 ```
 
 ##### Persistent developer `geth` instance
 Alternatively, a persistent developer instance that does not lose state can be started with the following command:
 ```bash
-geth --targetgaslimit "6200000" --dev --dev.period 1 --rpc --rpcapi personal,web3,eth,net  --rpcaddr 0.0.0.0 --ws --wsorigins='*' --datadir ~/.geth
+geth --targetgaslimit "6200000" --dev --dev.period 1 --rpc --rpcapi personal,web3,eth,net --ws --wsorigins='*' --datadir ~/.geth
 ```
 
 #### Connecting to a non-dev chain
@@ -58,7 +58,7 @@ geth --targetgaslimit "6200000" --dev --dev.period 1 --rpc --rpcapi personal,web
 Another alternative might be running the whole setup on some official testnet, ex. `rinkeby`.
 
 ```bash
-geth --rinkeby --rpc --rpcapi personal,web3,eth,net  --rpcaddr 127.0.0.1 --ws --wsorigins='*'
+geth --rinkeby --rpc --rpcapi personal,web3,eth,net --ws --wsorigins='*'
 ```
 
 **NOTE** Contrary to working with developer instance, operator's account must be manually funded with testnet Ether.

--- a/docs/manual_service_startup.md
+++ b/docs/manual_service_startup.md
@@ -44,13 +44,13 @@ A developer instance of `geth` runs Ethereum locally and prefunds an account.
 However, when `geth` terminates, the state of the Ethereum network is lost.
 
 ```bash
-geth --targetgaslimit "6200000" --dev --dev.period 1 --rpc --rpcapi personal,web3,eth,net  --rpcaddr 0.0.0.0
+geth --targetgaslimit "6200000" --dev --dev.period 1 --rpc --rpcapi personal,web3,eth,net  --rpcaddr 0.0.0.0 --ws --wsorigins='*'
 ```
 
 ##### Persistent developer `geth` instance
 Alternatively, a persistent developer instance that does not lose state can be started with the following command:
 ```bash
-geth --targetgaslimit "6200000" --dev --dev.period 1 --rpc --rpcapi personal,web3,eth,net  --rpcaddr 0.0.0.0 --datadir ~/.geth
+geth --targetgaslimit "6200000" --dev --dev.period 1 --rpc --rpcapi personal,web3,eth,net  --rpcaddr 0.0.0.0 --ws --wsorigins='*' --datadir ~/.geth
 ```
 
 #### Connecting to a non-dev chain
@@ -58,7 +58,7 @@ geth --targetgaslimit "6200000" --dev --dev.period 1 --rpc --rpcapi personal,web
 Another alternative might be running the whole setup on some official testnet, ex. `rinkeby`.
 
 ```bash
-geth --rinkeby --rpc --rpcapi personal,web3,eth,net  --rpcaddr 127.0.0.1
+geth --rinkeby --rpc --rpcapi personal,web3,eth,net  --rpcaddr 127.0.0.1 --ws --wsorigins='*'
 ```
 
 **NOTE** Contrary to working with developer instance, operator's account must be manually funded with testnet Ether.


### PR DESCRIPTION
:clipboard: Closes #802

## Overview

Now, instead of pulling eth node Watcher subscribes to `newHeads` event on web socket. When the connection is lost (or node was run without ws) this should be more visible.

## Changes

Changed log severity about lost connection from `debug` to `warn`
Changed examples in our manuals that explicitly enables ws in `geth`

## Testing

/
