### PR TITLE
Backport #794 to v0.1

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -31,8 +31,7 @@ config :sentry,
   tags: %{
     application: Mix.Project.config()[:app],
     eth_network: System.get_env("ETHEREUM_NETWORK"),
-    eth_node: System.get_env("ETH_NODE"),
-    mix_env: Mix.env(),
+    eth_node: System.get_env("ETH_NODE")
   }
 
 # Configs for AppSignal application monitoring

--- a/config/config.exs
+++ b/config/config.exs
@@ -29,7 +29,7 @@ config :sentry,
   included_environments: [:dev, :prod, System.get_env("APP_ENV")],
   server_name: elem(:inet.gethostname(), 1),
   tags: %{
-    application: Mix.Project.config()[:app],
+    application: System.get_env("ELIXIR_SERVICE"),
     eth_network: System.get_env("ETHEREUM_NETWORK"),
     eth_node: System.get_env("ETH_NODE")
   }

--- a/config/config.exs
+++ b/config/config.exs
@@ -23,9 +23,7 @@ config :logger,
 
 config :sentry,
   dsn: System.get_env("SENTRY_DSN"),
-  enable_source_code_context: true,
   environment_name: System.get_env("APP_ENV"),
-  root_source_code_path: File.cwd!(),
   included_environments: [:dev, :prod, System.get_env("APP_ENV")],
   server_name: elem(:inet.gethostname(), 1),
   tags: %{

--- a/config/config.exs
+++ b/config/config.exs
@@ -23,15 +23,17 @@ config :logger,
 
 config :sentry,
   dsn: {:system, "SENTRY_DSN"},
-  environment_name: {:system, "APP_ENV"},
   enable_source_code_context: true,
+  environment_name: {:system, "APP_ENV"},
   root_source_code_path: File.cwd!(),
-  tags: %{
-    mix_env: Mix.env(),
-    application: Mix.Project.config()[:app]
-  },
+  included_environments: [:dev, :prod, System.get_env("APP_ENV")],
   server_name: elem(:inet.gethostname(), 1),
-  included_environments: [:prod, :dev]
+  tags: %{
+    application: Mix.Project.config()[:app],
+    eth_network: System.get_env("ETHEREUM_NETWORK"),
+    eth_node: System.get_env("ETH_NODE"),
+    mix_env: Mix.env(),
+  }
 
 # Configs for AppSignal application monitoring
 config :appsignal, :config,

--- a/config/config.exs
+++ b/config/config.exs
@@ -22,9 +22,9 @@ config :logger,
   backends: [Sentry.LoggerBackend, :console]
 
 config :sentry,
-  dsn: {:system, "SENTRY_DSN"},
+  dsn: System.get_env("SENTRY_DSN"),
   enable_source_code_context: true,
-  environment_name: {:system, "APP_ENV"},
+  environment_name: System.get_env("APP_ENV"),
   root_source_code_path: File.cwd!(),
   included_environments: [:dev, :prod, System.get_env("APP_ENV")],
   server_name: elem(:inet.gethostname(), 1),

--- a/config/config.exs
+++ b/config/config.exs
@@ -18,6 +18,21 @@ config :logger, :console,
   discard_threshold: 2000,
   metadata: [:module, :function, :request_id]
 
+config :logger,
+  backends: [Sentry.LoggerBackend, :console]
+
+config :sentry,
+  dsn: {:system, "SENTRY_DSN"},
+  environment_name: {:system, "APP_ENV"},
+  enable_source_code_context: true,
+  root_source_code_path: File.cwd!(),
+  tags: %{
+    mix_env: Mix.env(),
+    application: Mix.Project.config()[:app]
+  },
+  server_name: elem(:inet.gethostname(), 1),
+  included_environments: [:prod, :dev]
+
 # Configs for AppSignal application monitoring
 config :appsignal, :config,
   name: "OmiseGO Plasma MoreVP Implementation",


### PR DESCRIPTION
:clipboard: #794 

## Overview

This backports our #794 Sentry environment changes to the `v0.1` branch. We already had Sentry on this branch so this should only need the configurations backported.

## Changes

* Adds current Sentry configurations.

## Testing

N/A
