### PR TITLE
fix: statix not pickedup as dependency app in a release and wss env vars

### DIFF
--- a/apps/omg_status/lib/omg_status/application.ex
+++ b/apps/omg_status/lib/omg_status/application.ex
@@ -31,6 +31,14 @@ defmodule OMG.Status.Application do
         []
       end
 
+    # if there's no SENTRY_DSN (local Watcher for example)
+    # don't attach Sentry as backend logger to report issues to
+    _ =
+      case System.get_env("SENTRY_DSN") do
+        nil -> :ok
+        _ -> {:ok, _} = Logger.add_backend(Sentry.LoggerBackend)
+      end
+
     Supervisor.start_link(children, strategy: :one_for_one, name: Status.Supervisor)
   end
 

--- a/apps/omg_utils/mix.exs
+++ b/apps/omg_utils/mix.exs
@@ -25,5 +25,5 @@ defmodule Utils.MixProject do
   defp elixirc_paths(:prod), do: ["lib"]
   defp elixirc_paths(_), do: ["lib", "test/support"]
 
-  defp deps, do: [{:appsignal, "~> 1.9"}]
+  defp deps, do: [{:statix, "~> 1.1"}, {:appsignal, "~> 1.9"}]
 end

--- a/config/config.exs
+++ b/config/config.exs
@@ -19,7 +19,7 @@ config :logger, :console,
   metadata: [:module, :function, :request_id]
 
 config :logger,
-  backends: [Sentry.LoggerBackend, :console]
+  backends: [:console]
 
 config :sentry,
   dsn: System.get_env("SENTRY_DSN"),

--- a/docker-compose-watcher-mac.yml
+++ b/docker-compose-watcher-mac.yml
@@ -8,7 +8,7 @@ services:
       dockerfile: Dockerfile.watcher
     environment:
       - ETHEREUM_RPC_URL=https://rinkeby.infura.io/v3/<your_api_key>
-      - ETHEREUM_WS_RPC_URL=wss://mainnet.infura.io/ws/v3/<your_api_key>
+      - ETHEREUM_WS_RPC_URL=wss://rinkeby.infura.io/ws/v3/<your_api_key>
       - CHILD_CHAIN_URL=http://samrong.omg.network
       - ETHEREUM_NETWORK=RINKEBY
       - RINKEBY_CONTRACT_ADDRESS=0x740ecec4c0ee99c285945de8b44e9f5bfb71eea7

--- a/docker-compose-watcher-mac.yml
+++ b/docker-compose-watcher-mac.yml
@@ -8,6 +8,7 @@ services:
       dockerfile: Dockerfile.watcher
     environment:
       - ETHEREUM_RPC_URL=https://rinkeby.infura.io/v3/<your_api_key>
+      - ETHEREUM_WS_RPC_URL=wss://mainnet.infura.io/ws/v3/<your_api_key>
       - CHILD_CHAIN_URL=http://samrong.omg.network
       - ETHEREUM_NETWORK=RINKEBY
       - RINKEBY_CONTRACT_ADDRESS=0x740ecec4c0ee99c285945de8b44e9f5bfb71eea7

--- a/docker-compose-watcher-non-mac.yml
+++ b/docker-compose-watcher-non-mac.yml
@@ -5,6 +5,7 @@ services:
     command: "full_local"
     environment:
       - ETHEREUM_RPC_URL=https://rinkeby.infura.io/v3/<your_api_key>
+      - ETHEREUM_WS_RPC_URL=wss://mainnet.infura.io/ws/v3/<your_api_key>
       - CHILD_CHAIN_URL=http://samrong.omg.network
       - ETHEREUM_NETWORK=RINKEBY
       - RINKEBY_CONTRACT_ADDRESS=0x740ecec4c0ee99c285945de8b44e9f5bfb71eea7

--- a/docker-compose-watcher-non-mac.yml
+++ b/docker-compose-watcher-non-mac.yml
@@ -5,7 +5,7 @@ services:
     command: "full_local"
     environment:
       - ETHEREUM_RPC_URL=https://rinkeby.infura.io/v3/<your_api_key>
-      - ETHEREUM_WS_RPC_URL=wss://mainnet.infura.io/ws/v3/<your_api_key>
+      - ETHEREUM_WS_RPC_URL=wss://rinkeby.infura.io/ws/v3/<your_api_key>
       - CHILD_CHAIN_URL=http://samrong.omg.network
       - ETHEREUM_NETWORK=RINKEBY
       - RINKEBY_CONTRACT_ADDRESS=0x740ecec4c0ee99c285945de8b44e9f5bfb71eea7

--- a/docs/run_local_watcher.md
+++ b/docs/run_local_watcher.md
@@ -14,7 +14,7 @@ The `docker-compose` tooling in the root of `elixir-omg` allows users to run the
 
 2) From the root of the `elixir-omg` execute:
 
-- `docker-compose -f docker-compose.yml -f docker-compose-watcher-mac.yml up` (Mac)
-- `docker-compose -f docker-compose.yml -f docker-compose-watcher-non-mac.yml up` (Linux/Windows)
+- `docker-compose -f docker-compose.yml -f docker-compose-watcher-mac.yml up watcher postgres` (Mac)
+- `docker-compose -f docker-compose.yml -f docker-compose-watcher-non-mac.yml up watcher postgres` (Linux/Windows)
 
 Modify the other environment variables for connecting to other networks.


### PR DESCRIPTION


## Overview

Statix was not picked up in a dependecy tree when building a release.
Watcher image missing WS env. variables

## Changes


- ...

## Testing


