### PR TITLE
fix: include Sentry on condition and remove unnecessary logging

### DIFF
--- a/apps/omg/lib/omg/ethereum_client_monitor.ex
+++ b/apps/omg/lib/omg/ethereum_client_monitor.ex
@@ -123,7 +123,7 @@ defmodule OMG.EthereumClientMonitor do
     case is_binary(value) do
       true ->
         ethereum_height = Encoding.int_from_hex(value)
-        _ = Logger.info("Ethereum client monitor got a newHeads event for new Ethereum height #{ethereum_height}.")
+        _ = Logger.debug("Ethereum client monitor got a newHeads event for new Ethereum height #{ethereum_height}.")
         {:noreply, %{state | ethereum_height: ethereum_height}}
 
       false ->

--- a/apps/omg/lib/omg/ethereum_height.ex
+++ b/apps/omg/lib/omg/ethereum_height.ex
@@ -51,7 +51,7 @@ defmodule OMG.EthereumHeight do
     case is_binary(value) do
       true ->
         ethereum_height = Encoding.int_from_hex(value)
-        _ = Logger.info("#{__MODULE__} got a newHeads event for new Ethereum height #{ethereum_height}.")
+        _ = Logger.debug("#{__MODULE__} got a newHeads event for new Ethereum height #{ethereum_height}.")
         {:noreply, ethereum_height}
 
       false ->

--- a/apps/omg_child_chain_rpc/lib/omg_child_chain_rpc/application.ex
+++ b/apps/omg_child_chain_rpc/lib/omg_child_chain_rpc/application.ex
@@ -13,9 +13,10 @@
 # limitations under the License.
 
 defmodule OMG.ChildChainRPC.Application do
-  # See https://hexdocs.pm/elixir/Application.html
-  # for more information on OTP Applications
   @moduledoc false
+
+  alias OMG.ChildChainRPC.Plugs.Health
+  alias OMG.ChildChainRPC.Web.Endpoint
 
   use Application
   require Logger
@@ -28,9 +29,11 @@ defmodule OMG.ChildChainRPC.Application do
     opts = [strategy: :one_for_one, name: OMG.ChildChainRPC.Supervisor]
 
     children = [
-      {OMG.ChildChainRPC.Plugs.Health, []},
-      {OMG.ChildChainRPC.Web.Endpoint, []}
+      {Health, []},
+      {Endpoint, []}
     ]
+
+    _ = Logger.warn("Is Sentry for OMG.ChildChainRPC.Web.Endpoint enabled: #{System.get_env("SENTRY_DSN") != nil}")
 
     Supervisor.start_link(children, opts)
   end

--- a/apps/omg_child_chain_rpc/lib/omg_child_chain_rpc/web/endpoint.ex
+++ b/apps/omg_child_chain_rpc/lib/omg_child_chain_rpc/web/endpoint.ex
@@ -14,7 +14,6 @@
 
 defmodule OMG.ChildChainRPC.Web.Endpoint do
   use Phoenix.Endpoint, otp_app: :omg_child_chain_rpc
-  use Appsignal.Phoenix
 
   ### we manually override call using https://github.com/getsentry/sentry-elixir/blob/master/lib/sentry/phoenix_endpoint.ex
   ### because we don't want to decide if we want to use Sentry or not at compile time

--- a/apps/omg_watcher_rpc/lib/application.ex
+++ b/apps/omg_watcher_rpc/lib/application.ex
@@ -17,6 +17,9 @@ defmodule OMG.WatcherRPC.Application do
   use Application
   use OMG.Utils.LoggerExt
 
+  alias OMG.WatcherRPC.BroadcastEvent
+  alias OMG.WatcherRPC.Web.Endpoint
+
   def start(_type, _args) do
     DeferredConfig.populate(:omg_watcher_rpc)
 
@@ -37,11 +40,11 @@ defmodule OMG.WatcherRPC.Application do
     # root supervisor must stop whenever any of its children supervisors goes down (children carry the load of restarts)
     children = [
       %{
-        id: OMG.WatcherRPC.Web.Endpoint,
-        start: {OMG.WatcherRPC.Web.Endpoint, :start_link, []},
+        id: Endpoint,
+        start: {Endpoint, :start_link, []},
         type: :supervisor
       },
-      {OMG.WatcherRPC.BroadcastEvent, []}
+      {BroadcastEvent, []}
     ]
 
     opts = [
@@ -49,6 +52,8 @@ defmodule OMG.WatcherRPC.Application do
       # whenever any of supervisor's children goes down, so it does
       name: OMG.WatcherRPC.RootSupervisor
     ]
+
+    _ = Logger.info("Is Sentry for OMG.WatcherRPC.Web.Endpoint enabled: #{System.get_env("SENTRY_DSN") != nil}")
 
     Supervisor.start_link(children, opts)
   end

--- a/apps/omg_watcher_rpc/lib/web/endpoint.ex
+++ b/apps/omg_watcher_rpc/lib/web/endpoint.ex
@@ -15,7 +15,38 @@
 defmodule OMG.WatcherRPC.Web.Endpoint do
   use Phoenix.Endpoint, otp_app: :omg_watcher_rpc
   use Appsignal.Phoenix
-  use Sentry.Phoenix.Endpoint
+
+  ### we manually override call using https://github.com/getsentry/sentry-elixir/blob/master/lib/sentry/phoenix_endpoint.ex
+  ### because we don't want to decide if we want to use Sentry or not at compile time
+  def call(conn, opts) do
+    super(conn, opts)
+  catch
+    kind, %Phoenix.Router.NoRouteError{} ->
+      :erlang.raise(kind, %Phoenix.Router.NoRouteError{}, __STACKTRACE__)
+
+    kind, reason ->
+      stacktrace = __STACKTRACE__
+
+      _ =
+        case System.get_env("SENTRY_DSN") do
+          nil ->
+            :ok
+
+          _ ->
+            request = Sentry.Plug.build_request_interface_data(conn, [])
+            exception = Exception.normalize(kind, reason, stacktrace)
+
+            Sentry.capture_exception(
+              exception,
+              stacktrace: stacktrace,
+              request: request,
+              event_source: :endpoint,
+              error_type: kind
+            )
+        end
+
+      :erlang.raise(kind, reason, stacktrace)
+  end
 
   # NOTE: one connects to `ws://host:port/socket/websocket` here (the transport is appended)
   socket("/socket", OMG.WatcherRPC.Web.Socket, websocket: true)

--- a/apps/omg_watcher_rpc/lib/web/endpoint.ex
+++ b/apps/omg_watcher_rpc/lib/web/endpoint.ex
@@ -14,7 +14,6 @@
 
 defmodule OMG.WatcherRPC.Web.Endpoint do
   use Phoenix.Endpoint, otp_app: :omg_watcher_rpc
-  use Appsignal.Phoenix
 
   ### we manually override call using https://github.com/getsentry/sentry-elixir/blob/master/lib/sentry/phoenix_endpoint.ex
   ### because we don't want to decide if we want to use Sentry or not at compile time


### PR DESCRIPTION
Sentry issue running on local watcher.
## Overview

Adjust reporting on Sentry issues, logs on compilation and in runtime.

## Changes
- left some comment in the code already 
## Testing

Tests should continue working.
