### PR TITLE
Unifies usage of Hex encoders

### DIFF
--- a/apps/omg/config/config.exs
+++ b/apps/omg/config/config.exs
@@ -12,6 +12,6 @@ config :omg,
 config :omg, :eip_712_domain,
   name: "OMG Network",
   version: "1",
-  salt: "fad5c7f626d80f9256ef01929f3beb96e058b8b4b0e3fe52d84f054c0e2a7a83"
+  salt: "0xfad5c7f626d80f9256ef01929f3beb96e058b8b4b0e3fe52d84f054c0e2a7a83"
 
 import_config "#{Mix.env()}.exs"

--- a/apps/omg/lib/omg/crypto.ex
+++ b/apps/omg/lib/omg/crypto.ex
@@ -70,21 +70,6 @@ defmodule OMG.Crypto do
     {:ok, address}
   end
 
-  @doc """
-  Turns hex representation of an address to a binary
-  """
-  @spec decode_address(String.t()) :: {:ok, address_t} | {:error, :bad_address_encoding}
-  def decode_address("0x" <> address) when byte_size(address) == 40, do: Base.decode16(address, case: :lower)
-  def decode_address(raw) when byte_size(raw) == 20, do: {:ok, raw}
-  def decode_address(_), do: {:error, :bad_address_encoding}
-
-  @doc """
-  Returns hex representation of binary address
-  """
-  @spec encode_address(any) :: {:ok, String.t()} | {:error, :invalid_address}
-  def encode_address(address) when byte_size(address) == 20, do: {:ok, "0x" <> Base.encode16(address, case: :lower)}
-  def encode_address(_), do: {:error, :invalid_address}
-
   # private
 
   # Unpack 65-bytes binary signature into {v,r,s} tuple.

--- a/apps/omg/lib/omg/fees.ex
+++ b/apps/omg/lib/omg/fees.ex
@@ -17,7 +17,6 @@ defmodule OMG.Fees do
   Transaction's fee validation functions
   """
 
-  alias OMG.Crypto
   alias OMG.State.Transaction
   alias OMG.Utxo
 
@@ -114,7 +113,7 @@ defmodule OMG.Fees do
   defp parse_fee_spec(%{"flat_fee" => fee, "token" => token}) do
     # defensive code against user input
     with {:ok, fee} <- validate_fee(fee),
-         {:ok, addr} <- Crypto.decode_address(token) do
+         {:ok, addr} <- decode_address(token) do
       %{token: addr, flat_fee: fee}
     end
   end
@@ -148,5 +147,17 @@ defmodule OMG.Fees do
     end)
 
     {:error, errors}
+  end
+
+  defp decode_address("0x" <> data), do: decode_address(data)
+
+  defp decode_address(data) do
+    case Base.decode16(data, case: :mixed) do
+      {:ok, address} when byte_size(address) == 20 ->
+        {:ok, address}
+
+      _ ->
+        {:error, :bad_address_encoding}
+    end
   end
 end

--- a/apps/omg/lib/omg/typed_data_hash/config.ex
+++ b/apps/omg/lib/omg/typed_data_hash/config.ex
@@ -18,10 +18,11 @@ defmodule OMG.TypedDataHash.Config do
   attribute, so it doesn't need to compute every time structure data is hashed.
   """
 
+  alias OMG.Eth.Encoding
   alias OMG.TypedDataHash.Tools
 
   # Needed for test only to have value of address when `:contract_address` is not set
-  @fallback_ari_network_address "44de0ec539b8c4a4b530c78620fe8320167f2f74"
+  @fallback_ari_network_address "0x44de0ec539b8c4a4b530c78620fe8320167f2f74"
 
   @doc """
   Returns EIP-712 domain based on values from configuration in a format `signTypedData` expects.
@@ -32,8 +33,8 @@ defmodule OMG.TypedDataHash.Config do
 
     Application.fetch_env!(:omg, :eip_712_domain)
     |> Map.new()
-    |> Map.put_new(:verifyingContract, decode16!(contract_addr))
-    |> Map.update!(:salt, &decode16!/1)
+    |> Map.put_new(:verifyingContract, Encoding.from_hex(contract_addr))
+    |> Map.update!(:salt, &Encoding.from_hex/1)
   end
 
   @doc """
@@ -45,7 +46,4 @@ defmodule OMG.TypedDataHash.Config do
     domain_data_from_config()
     |> Tools.domain_separator()
   end
-
-  defp decode16!("0x" <> data), do: decode16!(data)
-  defp decode16!(data), do: Base.decode16!(data, case: :mixed)
 end

--- a/apps/omg/test/omg/crypto_test.exs
+++ b/apps/omg/test/omg/crypto_test.exs
@@ -79,6 +79,7 @@ defmodule OMG.CryptoTest do
              |> (&match?({:ok, ^address}, &1)).()
   end
 
+  # FIXME: remove this?
   test "checking decode_address function for diffrent agruments" do
     assert {:error, :bad_address_encoding} = Crypto.decode_address("0x0123456789abCdeF")
     assert {:error, :bad_address_encoding} = Crypto.decode_address("this is not HEX")

--- a/apps/omg/test/omg/crypto_test.exs
+++ b/apps/omg/test/omg/crypto_test.exs
@@ -78,30 +78,4 @@ defmodule OMG.CryptoTest do
              |> Crypto.recover_address(signature)
              |> (&match?({:ok, ^address}, &1)).()
   end
-
-  # FIXME: remove this?
-  test "checking decode_address function for diffrent agruments" do
-    assert {:error, :bad_address_encoding} = Crypto.decode_address("0x0123456789abCdeF")
-    assert {:error, :bad_address_encoding} = Crypto.decode_address("this is not HEX")
-
-    assert {:ok, <<0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0>>} =
-             Crypto.decode_address("0x0000000000000000000000000000000000000000")
-
-    assert {:ok, <<65, 86, 211, 52, 45, 92, 56, 90, 135, 210, 100, 249, 6, 83, 115, 53, 146, 0, 5, 129>>} =
-             Crypto.decode_address("0x4156d3342d5c385a87d264f90653733592000581")
-  end
-
-  test "checking encode_address function for diffrent agruments" do
-    assert {:error, :invalid_address} = Crypto.encode_address(<<>>)
-    assert {:error, :invalid_address} = Crypto.encode_address("this is not address")
-    assert {:error, :invalid_address} = Crypto.encode_address(<<5, 86, 211, 52, 45, 92, 56, 90, 135>>)
-
-    assert {:ok, "0x0000000000000000000000000000000000000000"} =
-             Crypto.encode_address(<<0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0>>)
-
-    assert {:ok, "0x4156d3342d5c385a87d264f90653733592000581"} =
-             Crypto.encode_address(
-               <<65, 86, 211, 52, 45, 92, 56, 90, 135, 210, 100, 249, 6, 83, 115, 53, 146, 0, 5, 129>>
-             )
-  end
 end

--- a/apps/omg/test/omg/dependency_conformance/signature_test.exs
+++ b/apps/omg/test/omg/dependency_conformance/signature_test.exs
@@ -41,7 +41,7 @@ defmodule OMG.DependencyConformance.SignatureTest do
     {:ok, [addr | _]} = Ethereumex.HttpClient.eth_accounts()
     {:ok, _, signtest_addr} = Eth.Deployer.create_new(OMG.Eth.Eip712, root_path, Eth.Encoding.from_hex(addr))
 
-    :ok = Application.put_env(:omg_eth, :contract_addr, Base.encode16(signtest_addr))
+    :ok = Application.put_env(:omg_eth, :contract_addr, Eth.Encoding.to_hex(signtest_addr))
 
     on_exit(exit_fn)
     [contract: signtest_addr]

--- a/apps/omg/test/omg/state/transaction_test.exs
+++ b/apps/omg/test/omg/state/transaction_test.exs
@@ -54,10 +54,8 @@ defmodule OMG.State.TransactionTest do
     end
 
     test "raw transaction hash is invariant" do
-      {:ok, hash_value} =
-        Base.decode16("09645ee9736332be55eaccf9d08ff572a6fa23e2f6dc2aac42dbf09832d8f60e", case: :lower)
-
-      assert Transaction.raw_txhash(@transaction) == hash_value
+      assert Transaction.raw_txhash(@transaction) ==
+               Base.decode16!("09645ee9736332be55eaccf9d08ff572a6fa23e2f6dc2aac42dbf09832d8f60e", case: :lower)
     end
   end
 

--- a/apps/omg/test/omg/typed_data_hash_test.exs
+++ b/apps/omg/test/omg/typed_data_hash_test.exs
@@ -46,8 +46,8 @@ defmodule OMG.TypedDataHashTest do
 
   setup_all do
     null_addr = <<0::160>>
-    owner = "2258a5279850f6fb78888a7e45ea2a5eb1b3c436" |> Base.decode16!(case: :lower)
-    token = "0123456789abcdef000000000000000000000000" |> Base.decode16!(case: :lower)
+    owner = "2258a5279850f6fb78888a7e45ea2a5eb1b3c436" |> Base.decode16!(case: :mixed)
+    token = "0123456789abcdef000000000000000000000000" |> Base.decode16!(case: :mixed)
 
     {:ok,
      %{
@@ -62,7 +62,7 @@ defmodule OMG.TypedDataHashTest do
          {owner, token, 1337},
          {null_addr, null_addr, 0}
        ],
-       metadata: "853a8d8af99c93405a791b97d57e819e538b06ffaa32ad70da2582500bc18d43" |> Base.decode16!(case: :lower)
+       metadata: "853a8d8af99c93405a791b97d57e819e538b06ffaa32ad70da2582500bc18d43" |> Base.decode16!(case: :mixed)
      }}
   end
 

--- a/apps/omg_child_chain/lib/omg_child_chain/block_queue.ex
+++ b/apps/omg_child_chain/lib/omg_child_chain/block_queue.ex
@@ -151,7 +151,7 @@ defmodule OMG.ChildChain.BlockQueue do
         ) do
       {:ok, parent_height} = EthereumHeight.get()
       state1 = Core.enqueue_block(state, block_hash, block_number, parent_height)
-      _ = Logger.info("Enqueuing block num '#{inspect(block_number)}', hash '#{inspect(Base.encode16(block_hash))}'")
+      _ = Logger.info("Enqueuing block num '#{inspect(block_number)}', hash '#{inspect(Encoding.to_hex(block_hash))}'")
 
       FreshBlocks.push(block)
       submit_blocks(state1)

--- a/apps/omg_child_chain/lib/omg_child_chain/block_queue.ex
+++ b/apps/omg_child_chain/lib/omg_child_chain/block_queue.ex
@@ -42,6 +42,7 @@ defmodule OMG.ChildChain.BlockQueue do
     use OMG.Utils.LoggerExt
     use OMG.Utils.Metrics
     alias OMG.Eth
+    alias OMG.Eth.Encoding
     alias OMG.EthereumHeight
 
     def start_link(_args) do
@@ -75,7 +76,7 @@ defmodule OMG.ChildChain.BlockQueue do
 
       {:ok, known_hashes} = OMG.DB.block_hashes(range)
       {:ok, {top_mined_hash, _}} = Eth.RootChain.get_child_chain(mined_num)
-      _ = Logger.info("Starting BlockQueue, top_mined_hash: #{inspect(Eth.Encoding.to_hex(top_mined_hash))}")
+      _ = Logger.info("Starting BlockQueue, top_mined_hash: #{inspect(Encoding.to_hex(top_mined_hash))}")
 
       {:ok, state} =
         with {:ok, _state} = result <-
@@ -186,7 +187,7 @@ defmodule OMG.ChildChain.BlockQueue do
 
     defp log_init_error(fields) do
       config = Eth.Diagnostics.get_child_chain_config()
-      fields = Keyword.update!(fields, :known_hashes, fn hashes -> Enum.map(hashes, &Eth.Encoding.to_hex/1) end)
+      fields = Keyword.update!(fields, :known_hashes, fn hashes -> Enum.map(hashes, &Encoding.to_hex/1) end)
       diagnostic = fields |> Enum.into(%{config: config})
 
       _ =

--- a/apps/omg_eth/lib/omg_eth/defaults.ex
+++ b/apps/omg_eth/lib/omg_eth/defaults.ex
@@ -19,7 +19,7 @@ defmodule OMG.Eth.Defaults do
   Don't ever use this for `OMG.Eth.RootChain.submit_block/5` or any other production related code.
   """
 
-  import OMG.Eth.Encoding
+  alias OMG.Eth.Encoding
 
   # safe, reasonable amount, equal to the testnet block gas limit
   @lots_of_gas 5_712_388
@@ -27,6 +27,6 @@ defmodule OMG.Eth.Defaults do
 
   def tx_defaults do
     [value: 0, gasPrice: @gas_price, gas: @lots_of_gas]
-    |> Enum.map(fn {k, v} -> {k, to_hex(v)} end)
+    |> Enum.map(fn {k, v} -> {k, Encoding.to_hex(v)} end)
   end
 end

--- a/apps/omg_eth/lib/omg_eth/wait_for.ex
+++ b/apps/omg_eth/lib/omg_eth/wait_for.ex
@@ -17,7 +17,6 @@ defmodule OMG.Eth.WaitFor do
   Generic wait_for_* utils, styled after web3 counterparts
   """
 
-  alias OMG.Eth
   alias OMG.Eth.Encoding
 
   def eth_rpc do

--- a/apps/omg_eth/lib/omg_eth/wait_for.ex
+++ b/apps/omg_eth/lib/omg_eth/wait_for.ex
@@ -18,8 +18,7 @@ defmodule OMG.Eth.WaitFor do
   """
 
   alias OMG.Eth
-
-  import Eth.Encoding
+  alias OMG.Eth.Encoding
 
   def eth_rpc do
     f = fn ->
@@ -43,7 +42,7 @@ defmodule OMG.Eth.WaitFor do
   def eth_receipt(txhash, timeout \\ 15_000) do
     f = fn ->
       txhash
-      |> to_hex()
+      |> Encoding.to_hex()
       |> Ethereumex.HttpClient.eth_get_transaction_receipt()
       |> case do
         {:ok, receipt} when receipt != nil -> {:ok, receipt}

--- a/apps/omg_eth/test/fixtures.exs
+++ b/apps/omg_eth/test/fixtures.exs
@@ -19,8 +19,7 @@ defmodule OMG.Eth.Fixtures do
   use ExUnitFixtures.FixtureModule
 
   alias OMG.Eth
-
-  import Eth.Encoding
+  alias OMG.Eth.Encoding
 
   deffixture eth_node do
     DeferredConfig.populate(:omg_eth)
@@ -42,7 +41,7 @@ defmodule OMG.Eth.Fixtures do
     {:ok, [addr | _]} = Ethereumex.HttpClient.eth_accounts()
 
     DeferredConfig.populate(:omg_eth)
-    {:ok, _, token_addr} = Eth.Deployer.create_new(OMG.Eth.Token, root_path, from_hex(addr))
+    {:ok, _, token_addr} = Eth.Deployer.create_new(OMG.Eth.Token, root_path, Encoding.from_hex(addr))
 
     # ensuring that the root chain contract handles token_addr
     {:ok, false} = Eth.RootChainHelper.has_token(token_addr)
@@ -54,9 +53,9 @@ defmodule OMG.Eth.Fixtures do
 
   deffixture root_chain_contract_config(contract) do
     DeferredConfig.populate(:omg_eth)
-    Application.put_env(:omg_eth, :contract_addr, to_hex(contract.contract_addr), persistent: true)
-    Application.put_env(:omg_eth, :authority_addr, to_hex(contract.authority_addr), persistent: true)
-    Application.put_env(:omg_eth, :txhash_contract, to_hex(contract.txhash_contract), persistent: true)
+    Application.put_env(:omg_eth, :contract_addr, Encoding.to_hex(contract.contract_addr), persistent: true)
+    Application.put_env(:omg_eth, :authority_addr, Encoding.to_hex(contract.authority_addr), persistent: true)
+    Application.put_env(:omg_eth, :txhash_contract, Encoding.to_hex(contract.txhash_contract), persistent: true)
 
     {:ok, started_apps} = Application.ensure_all_started(:omg_eth)
 

--- a/apps/omg_eth/test/support/dev_helpers.ex
+++ b/apps/omg_eth/test/support/dev_helpers.ex
@@ -129,8 +129,7 @@ defmodule OMG.Eth.DevHelpers do
   end
 
   def create_account_from_secret(:parity, secret, passphrase) when byte_size(secret) == 64 do
-    secret = secret |> Base.decode16!(case: :upper) |> Base.encode16(case: :lower)
-    secret = "0x" <> secret
+    secret = secret |> Base.decode16!(case: :upper) |> Eth.Encoding.to_hex()
     {:ok, _} = Ethereumex.HttpClient.request("parity_newAccountFromSecret", [secret, passphrase], [])
   end
 

--- a/apps/omg_eth/test/support/dev_mining_helper.ex
+++ b/apps/omg_eth/test/support/dev_mining_helper.ex
@@ -17,6 +17,9 @@ defmodule OMG.Eth.DevMiningHelper do
   Sends small tx every second, causing Ethereum node in `--dev` mode to create new blocks.
   Basically helps to simulate behavior of `geth --dev --dev.period 1`. Useful with parity.
   """
+
+  alias OMG.Eth.Encoding
+
   @devperiod_ms 1000
 
   use GenServer
@@ -41,7 +44,7 @@ defmodule OMG.Eth.DevMiningHelper do
   end
 
   defp mine(addr, passphrase) do
-    %{from: addr, to: addr, value: OMG.Eth.Encoding.to_hex(1)}
+    %{from: addr, to: addr, value: Encoding.to_hex(1)}
     |> OMG.Eth.send_transaction(passphrase: passphrase)
     |> OMG.Eth.DevHelpers.transact_sync!()
   end
@@ -55,7 +58,7 @@ defmodule OMG.Eth.DevMiningHelper do
 
     {:ok, [faucet | _]} = Ethereumex.HttpClient.eth_accounts()
 
-    %{from: faucet, to: addr, value: OMG.Eth.Encoding.to_hex(1_000_000 * trunc(:math.pow(10, 9 + 5)))}
+    %{from: faucet, to: addr, value: Encoding.to_hex(1_000_000 * trunc(:math.pow(10, 9 + 5)))}
     |> OMG.Eth.send_transaction(passphrase: "")
     |> OMG.Eth.DevHelpers.transact_sync!()
 

--- a/apps/omg_eth/test/support/librarian.ex
+++ b/apps/omg_eth/test/support/librarian.ex
@@ -18,8 +18,7 @@ defmodule OMG.Eth.Librarian do
   """
 
   alias OMG.Eth
-
-  import Eth.Encoding
+  alias OMG.Eth.Encoding
 
   @tx_defaults Eth.Defaults.tx_defaults()
 
@@ -62,7 +61,7 @@ defmodule OMG.Eth.Librarian do
 
     libs_arg =
       libs
-      |> Enum.map(fn {lib_name, lib_addr} -> "#{lib_name}.sol:#{lib_name}:#{to_hex(lib_addr)}" end)
+      |> Enum.map(fn {lib_name, lib_addr} -> "#{lib_name}.sol:#{lib_name}:#{Encoding.to_hex(lib_addr)}" end)
       |> Enum.join(" ")
 
     [] =

--- a/apps/omg_eth/test/support/token.ex
+++ b/apps/omg_eth/test/support/token.ex
@@ -18,8 +18,7 @@ defmodule OMG.Eth.Token do
   """
 
   alias OMG.Eth
-
-  import Eth.Encoding
+  alias OMG.Eth.Encoding
 
   @tx_defaults Eth.Defaults.tx_defaults()
 
@@ -33,7 +32,7 @@ defmodule OMG.Eth.Token do
     opts = @tx_defaults |> Keyword.put(:gas, @gas_token_ops) |> Keyword.merge(opts)
 
     {:ok, [from | _]} = Ethereumex.HttpClient.eth_accounts()
-    Eth.contract_transact(from_hex(from), token, "mint(address,uint256)", [owner, amount], opts)
+    Eth.contract_transact(Encoding.from_hex(from), token, "mint(address,uint256)", [owner, amount], opts)
   end
 
   def transfer(from, owner, amount, token, opts \\ []) do

--- a/apps/omg_performance/lib/performance.ex
+++ b/apps/omg_performance/lib/performance.ex
@@ -184,8 +184,7 @@ defmodule OMG.Performance do
     Application.put_env(:ethereumex, :http_options, recv_timeout: :infinity)
     Application.put_env(:ethereumex, :url, opts[:geth])
 
-    {:ok, contract_addr_enc} = Crypto.encode_address(contract_addr)
-    Application.put_env(:omg_eth, :contract_addr, contract_addr_enc)
+    Application.put_env(:omg_eth, :contract_addr, OMG.Eth.Encoding.to_hex(contract_addr))
 
     {:ok, started_apps}
   end

--- a/apps/omg_watcher/lib/omg_watcher/eventer/core.ex
+++ b/apps/omg_watcher/lib/omg_watcher/eventer/core.ex
@@ -17,8 +17,8 @@ defmodule OMG.Watcher.Eventer.Core do
   Functional core of eventer
   """
 
-  alias OMG.Crypto
   alias OMG.State.Transaction
+  alias OMG.Utils.HttpRPC.Encoding
   alias OMG.Utxo
   alias OMG.Watcher.Event
 
@@ -95,13 +95,11 @@ defmodule OMG.Watcher.Eventer.Core do
   end
 
   defp create_transfer_subtopic(address) do
-    {:ok, encoded_address} = Crypto.encode_address(address)
-    create_subtopic(@transfer_topic, encoded_address)
+    create_subtopic(@transfer_topic, Encoding.to_hex(address))
   end
 
   defp create_exit_subtopic(address) do
-    {:ok, encoded_address} = Crypto.encode_address(address)
-    create_subtopic(@exit_topic, encoded_address)
+    create_subtopic(@exit_topic, Encoding.to_hex(address))
   end
 
   defp create_subtopic(main_topic, subtopic), do: main_topic <> ":" <> subtopic

--- a/apps/omg_watcher/test/omg_watcher/eventer/core_test.exs
+++ b/apps/omg_watcher/test/omg_watcher/eventer/core_test.exs
@@ -19,7 +19,7 @@ defmodule OMG.Watcher.Eventer.CoreTest do
   use ExUnit.Case, async: true
   use OMG.Fixtures
 
-  alias OMG.Crypto
+  alias OMG.Utils.HttpRPC.Encoding
   alias OMG.Utxo
   alias OMG.Watcher.Event
   alias OMG.Watcher.Eventer
@@ -37,10 +37,8 @@ defmodule OMG.Watcher.Eventer.CoreTest do
         {bob, 5}
       ])
 
-    {:ok, encoded_alice_address} = Crypto.encode_address(alice.addr)
-    {:ok, encoded_bob_address} = Crypto.encode_address(bob.addr)
-    topic_alice = TestHelper.create_topic("transfer", encoded_alice_address)
-    topic_bob = TestHelper.create_topic("transfer", encoded_bob_address)
+    topic_alice = TestHelper.create_topic("transfer", Encoding.to_hex(alice.addr))
+    topic_bob = TestHelper.create_topic("transfer", Encoding.to_hex(bob.addr))
 
     event_1 = {topic_alice, "address_received", %Event.AddressReceived{tx: recovered_tx}}
 
@@ -57,8 +55,7 @@ defmodule OMG.Watcher.Eventer.CoreTest do
   test "prepare_events function generates 1 proper address_received events", %{alice: alice} do
     recovered_tx = OMG.TestHelper.create_recovered([{1, 0, 0, alice}], @zero_address, [{alice, 100}])
 
-    {:ok, encoded_alice_address} = Crypto.encode_address(alice.addr)
-    topic = TestHelper.create_topic("transfer", encoded_alice_address)
+    topic = TestHelper.create_topic("transfer", Encoding.to_hex(alice.addr))
 
     event_1 = {topic, "address_received", %Event.AddressReceived{tx: recovered_tx}}
 
@@ -73,9 +70,7 @@ defmodule OMG.Watcher.Eventer.CoreTest do
       exit_finalized: %{owner: alice.addr, currency: @zero_address, amount: 7, utxo_pos: Utxo.position(1, 0, 0)}
     }
 
-    {:ok, encoded_alice_address} = Crypto.encode_address(alice.addr)
-
-    topic = TestHelper.create_topic("exit", encoded_alice_address)
+    topic = TestHelper.create_topic("exit", Encoding.to_hex(alice.addr))
 
     event =
       {topic, "exit_finalized",

--- a/apps/omg_watcher/test/omg_watcher/integration/block_getter_test.exs
+++ b/apps/omg_watcher/test/omg_watcher/integration/block_getter_test.exs
@@ -26,7 +26,6 @@ defmodule OMG.Watcher.Integration.BlockGetterTest do
   use Plug.Test
   use Phoenix.ChannelTest
 
-  alias OMG.Crypto
   alias OMG.Eth
   alias OMG.Utils.HttpRPC.Encoding
   alias OMG.Utxo
@@ -55,9 +54,7 @@ defmodule OMG.Watcher.Integration.BlockGetterTest do
     token: token,
     alice_deposits: {deposit_blknum, token_deposit_blknum}
   } do
-    {:ok, alice_address} = Crypto.encode_address(alice.addr)
-
-    token_addr = token |> Encoding.to_hex()
+    token_addr = Encoding.to_hex(token)
 
     # utxo from deposit should be available
     assert [%{"blknum" => ^deposit_blknum}, %{"blknum" => ^token_deposit_blknum, "currency" => ^token_addr}] =
@@ -68,7 +65,7 @@ defmodule OMG.Watcher.Integration.BlockGetterTest do
       subscribe_and_join(
         socket(OMG.WatcherRPC.Web.Socket),
         Channel.Transfer,
-        TestHelper.create_topic("transfer", alice_address)
+        TestHelper.create_topic("transfer", Encoding.to_hex(alice.addr))
       )
 
     tx = OMG.TestHelper.create_encoded([{deposit_blknum, 0, 0, alice}], @eth, [{alice, 7}, {bob, 3}])

--- a/apps/omg_watcher/test/omg_watcher/integration/standard_exit_test.exs
+++ b/apps/omg_watcher/test/omg_watcher/integration/standard_exit_test.exs
@@ -47,7 +47,7 @@ defmodule OMG.Watcher.Integration.StandardExitTest do
       subscribe_and_join(
         socket(OMG.WatcherRPC.Web.Socket),
         OMG.WatcherRPC.Web.Channel.Exit,
-        TestHelper.create_topic("exit", Encoding.to_hex(alice.addr))
+        TestHelper.create_topic("exit", Eth.Encoding.to_hex(alice.addr))
       )
 
     exit_finality_margin = Application.fetch_env!(:omg_watcher, :exit_finality_margin)

--- a/apps/omg_watcher/test/omg_watcher/integration/standard_exit_test.exs
+++ b/apps/omg_watcher/test/omg_watcher/integration/standard_exit_test.exs
@@ -20,7 +20,6 @@ defmodule OMG.Watcher.Integration.StandardExitTest do
   use Plug.Test
   use Phoenix.ChannelTest
 
-  alias OMG.Crypto
   alias OMG.Eth
   alias OMG.Utils.HttpRPC.Response
   alias OMG.Utxo
@@ -44,13 +43,11 @@ defmodule OMG.Watcher.Integration.StandardExitTest do
     stable_alice: alice,
     stable_alice_deposits: {deposit_blknum, _}
   } do
-    {:ok, encoded_alice_address} = Crypto.encode_address(alice.addr)
-
     {:ok, _, _socket} =
       subscribe_and_join(
         socket(OMG.WatcherRPC.Web.Socket),
         OMG.WatcherRPC.Web.Channel.Exit,
-        TestHelper.create_topic("exit", encoded_alice_address)
+        TestHelper.create_topic("exit", Encoding.to_hex(alice.addr))
       )
 
     exit_finality_margin = Application.fetch_env!(:omg_watcher, :exit_finality_margin)

--- a/apps/omg_watcher/test/omg_watcher/integration/transaction_submit_test.exs
+++ b/apps/omg_watcher/test/omg_watcher/integration/transaction_submit_test.exs
@@ -32,7 +32,7 @@ defmodule OMG.Watcher.Integration.TransactionSubmitTest do
 
   alias OMG.DevCrypto
   alias OMG.Eth
-  alias OMG.Eth.Encoding
+  alias OMG.Utils.HttpRPC.Encoding
   alias OMG.Watcher.Integration.TestHelper, as: IntegrationTest
   alias OMG.Watcher.TestHelper
 

--- a/apps/omg_watcher_rpc/test/omg_watcher_rpc/web/controllers/account_test.exs
+++ b/apps/omg_watcher_rpc/test/omg_watcher_rpc/web/controllers/account_test.exs
@@ -18,7 +18,6 @@ defmodule OMG.WatcherRPC.Web.Controller.AccountTest do
   use OMG.Fixtures
   use OMG.Watcher.Fixtures
 
-  alias OMG.Crypto
   alias OMG.Utils.HttpRPC.Encoding
   alias OMG.Utxo
   alias OMG.Watcher.DB
@@ -60,8 +59,7 @@ defmodule OMG.WatcherRPC.Web.Controller.AccountTest do
   end
 
   defp body_for(%{addr: address}) do
-    {:ok, address_encode} = Crypto.encode_address(address)
-    %{"address" => address_encode}
+    %{"address" => Encoding.to_hex(address)}
   end
 
   @tag fixtures: [:initial_blocks, :alice]
@@ -69,9 +67,9 @@ defmodule OMG.WatcherRPC.Web.Controller.AccountTest do
     alice: alice
   } do
     # refer to `/transaction.all` tests for more thorough cases, this is the same
-    {:ok, address} = Crypto.encode_address(alice.addr)
+    alice_addr = Encoding.to_hex(alice.addr)
 
-    assert [_] = TestHelper.success?("account.get_transactions", %{"address" => address, "limit" => 1})
+    assert [_] = TestHelper.success?("account.get_transactions", %{"address" => alice_addr, "limit" => 1})
   end
 
   @tag fixtures: [:phoenix_ecto_sandbox]

--- a/apps/omg_watcher_rpc/test/omg_watcher_rpc/web/validators/typed_data_signed_test.exs
+++ b/apps/omg_watcher_rpc/test/omg_watcher_rpc/web/validators/typed_data_signed_test.exs
@@ -30,6 +30,7 @@ defmodule OMG.WatcherRPC.Web.Validators.TypedDataSignedTest do
   @token_hex Encoding.to_hex(@other_token)
   @alice TestHelper.generate_entity()
   @bob TestHelper.generate_entity()
+  # FIXME: don't decode16
   @ari_network_address "44DE0EC539B8C4A4B530C78620FE8320167F2F74" |> Base.decode16!()
   @eip_domain %{
     name: "OMG Network",

--- a/apps/omg_watcher_rpc/test/omg_watcher_rpc/web/validators/typed_data_signed_test.exs
+++ b/apps/omg_watcher_rpc/test/omg_watcher_rpc/web/validators/typed_data_signed_test.exs
@@ -30,7 +30,6 @@ defmodule OMG.WatcherRPC.Web.Validators.TypedDataSignedTest do
   @token_hex Encoding.to_hex(@other_token)
   @alice TestHelper.generate_entity()
   @bob TestHelper.generate_entity()
-  # FIXME: don't decode16
   @ari_network_address "44DE0EC539B8C4A4B530C78620FE8320167F2F74" |> Base.decode16!()
   @eip_domain %{
     name: "OMG Network",

--- a/docs/demo_01.md
+++ b/docs/demo_01.md
@@ -12,7 +12,6 @@ Run a developer's Child chain server and start IEx REPL with code and config loa
 {:ok, _} = Application.ensure_all_started(:ethereumex)
 
 alias OMG.Eth
-alias OMG.Crypto
 alias OMG.DevCrypto
 alias OMG.State.Transaction
 alias OMG.TestHelper

--- a/docs/demo_02.md
+++ b/docs/demo_02.md
@@ -16,7 +16,6 @@ Run a developer's Child chain server, Watcher and start IEx REPL with code and c
 {:ok, _} = Application.ensure_all_started(:ethereumex)
 
 alias OMG.Eth
-alias OMG.Crypto
 alias OMG.DevCrypto
 alias OMG.State.Transaction
 alias OMG.TestHelper
@@ -29,8 +28,7 @@ alice = TestHelper.generate_entity()
 bob = TestHelper.generate_entity()
 eth = Eth.RootChain.eth_pseudo_address()
 
-{:ok, alice_enc} = Crypto.encode_address(alice.addr)
-{:ok, bob_enc} = Crypto.encode_address(bob.addr)
+bob_enc = Encoding.to_hex(bob.addr)
 
 {:ok, _} = Eth.DevHelpers.import_unlock_fund(alice)
 {:ok, _} = Eth.DevHelpers.import_unlock_fund(bob)
@@ -142,7 +140,7 @@ tx3 =
   Transaction.new([{bob_deposit_blknum, 0, 0}], [{bob.addr, eth, 7}, {alice.addr, eth, 3}]) |>
   DevCrypto.sign([bob.priv, <<>>]) |>
   Transaction.Signed.encode() |>
-  OMG.Utils.HttpRPC.Encoding.to_hex()
+  Encoding.to_hex()
 
 %{"success" => true} =
   ~c(echo '{"transaction": "#{tx3}"}' | http POST #{child_chain_url}/transaction.submit) |>
@@ -177,7 +175,7 @@ tx4 =
   Transaction.new([{spend_blknum, 0, 0}], [{bob.addr, eth, 7}]) |>
   DevCrypto.sign([bob.priv, <<>>]) |>
   Transaction.Signed.encode() |>
-  OMG.Utils.HttpRPC.Encoding.to_hex()
+  Encoding.to_hex()
 
 # and send using httpie
 ~c(echo '{"transaction": "#{tx4}"}' | http POST #{child_chain_url}/transaction.submit) |>

--- a/docs/demo_02.md
+++ b/docs/demo_02.md
@@ -166,7 +166,7 @@ r(OMG.State.Core)
 
 # grab an utxo that bob can spend
 %{"data" => [_bobs_deposit, %{"blknum" => spend_blknum, "txindex" => 0, "oindex" => 0}]} =
-  ~c(echo '{"address": "#{bob_enc}"}' | http POST #{watcher_url}/utxo.get) |>
+  ~c(echo '{"address": "#{bob_enc}"}' | http POST #{watcher_url}/account.get_utxos) |>
   to_charlist() |>
   :os.cmd() |>
   Jason.decode!()

--- a/docs/demo_03.md
+++ b/docs/demo_03.md
@@ -25,13 +25,11 @@ Run `iex -S mix run --no-start --config ~/config.exs` and inside REPL do:
 {:ok, _} = Application.ensure_all_started(:ethereumex)
 
 alias OMG.Eth
-alias OMG.Crypto
-alias OMG.DevCrypto
 alias OMG.TestHelper
 
 DeferredConfig.populate(:omg_eth)
 
-{:ok, contract_addr} = Application.fetch_env!(:omg_eth, :contract_addr) |> Crypto.decode_address()
+contract_addr = Application.fetch_env!(:omg_eth, :contract_addr) |> Eth.Encoding.from_hex()
 
 # defaults
 opts = [initial_funds: trunc(:math.pow(10, 18)) * 1]


### PR DESCRIPTION
:clipboard: Fixes #816

## Overview
Unifies usage of Hex encoders

## Changes

Removed Crypto.(de|en)code_address, limited usage to Eth.Encoding & Utils.HttpRPC.Encoding.
In code try to use Eth.Encoding except the cases RPC is used.
In test use whatever fits (including Base.decode16)

## Testing

Cleaning work, existing test should suffice.
