### PR TITLE
fix: change fee_server not to crash on corrupted json

### DIFF
--- a/apps/omg/lib/omg/alert/alarm.ex
+++ b/apps/omg/lib/omg/alert/alarm.ex
@@ -21,13 +21,19 @@ defmodule OMG.Alert.Alarm do
   @typedoc """
   The raw alarm being used to `set` the Alarm
   """
-  @type raw_t :: {:boot_in_progress | :ethereum_client_connection, node(), module()}
+  @type raw_t ::
+          {:boot_in_progress
+           | :ethereum_client_connection
+           | :invalid_fee_file, node(), module()}
 
   def ethereum_client_connection_issue(node, reporter),
     do: {:ethereum_client_connection, %{node: node, reporter: reporter}}
 
   def boot_in_progress(node, reporter),
     do: {:boot_in_progress, %{node: node, reporter: reporter}}
+
+  def invalid_fee_file(node, reporter),
+    do: {:invalid_fee_file, %{node: node, reporter: reporter}}
 
   @spec set(raw_t()) :: :ok | :duplicate
   def set(raw_alarm = {_, node, reporter}) when is_atom(node) and is_atom(reporter) do
@@ -67,5 +73,9 @@ defmodule OMG.Alert.Alarm do
 
   defp make_alarm({:boot_in_progress, node, reporter}) do
     boot_in_progress(node, reporter)
+  end
+
+  defp make_alarm({:invalid_fee_file, node, reporter}) do
+    invalid_fee_file(node, reporter)
   end
 end

--- a/apps/omg/lib/omg/alert/alarm_handler.ex
+++ b/apps/omg/lib/omg/alert/alarm_handler.ex
@@ -25,7 +25,7 @@ defmodule OMG.Alert.AlarmHandler do
   end
 
   # subscribing to alarms of type
-  def alarm_types, do: [:ethereum_client_connection, :boot_in_progress]
+  def alarm_types, do: [:ethereum_client_connection, :boot_in_progress, :invalid_fee_file]
 
   def init(_args) do
     {:ok, %{alarms: []}}

--- a/apps/omg/lib/omg/fees.ex
+++ b/apps/omg/lib/omg/fees.ex
@@ -70,7 +70,9 @@ defmodule OMG.Fees do
         |> Enum.map(&parse_fee_spec/1)
         |> Enum.reduce({[], %{}, 1}, &spec_reducer/2)
 
-      {Enum.reverse(errors), token_fee_map}
+      errors
+      |> Enum.reverse()
+      |> (&{&1, token_fee_map}).()
       |> handle_parser_output()
     end
   end

--- a/apps/omg/lib/omg/fees.ex
+++ b/apps/omg/lib/omg/fees.ex
@@ -64,15 +64,15 @@ defmodule OMG.Fees do
   """
   @spec parse_file_content(binary()) :: {:ok, fee_t()} | {:error, list({:error, atom()})}
   def parse_file_content(file_content) do
-    {:ok, json} = Jason.decode(file_content)
+    with {:ok, json} <- Jason.decode(file_content) do
+      {errors, token_fee_map, _} =
+        json
+        |> Enum.map(&parse_fee_spec/1)
+        |> Enum.reduce({[], %{}, 1}, &spec_reducer/2)
 
-    {errors, token_fee_map, _} =
-      json
-      |> Enum.map(&parse_fee_spec/1)
-      |> Enum.reduce({[], %{}, 1}, &spec_reducer/2)
-
-    {Enum.reverse(errors), token_fee_map}
-    |> handle_parser_output()
+      {Enum.reverse(errors), token_fee_map}
+      |> handle_parser_output()
+    end
   end
 
   defp is_merge_transaction?(recovered_tx) do

--- a/apps/omg/test/support/test_helper.ex
+++ b/apps/omg/test/support/test_helper.ex
@@ -143,18 +143,24 @@ defmodule OMG.TestHelper do
   @doc """
   Always creates file in the priv/ folder of the application.
   """
-  @spec write_fee_file(%{Crypto.address_t() => non_neg_integer}) :: {:ok, binary, binary}
-  def write_fee_file(map) do
+  @spec write_fee_file(%{Crypto.address_t() => non_neg_integer} | binary(), binary() | nil) :: {:ok, binary, binary}
+  def write_fee_file(fee_map, file_name \\ nil)
+
+  def write_fee_file(map, file_name) when is_map(map) do
     {:ok, json} =
       map
       |> Enum.map(fn {"0x" <> _ = k, v} -> %{token: k, flat_fee: v} end)
       |> Jason.encode()
 
+    write_fee_file(json, file_name)
+  end
+
+  def write_fee_file(content, file_name) do
     priv_dir = :code.priv_dir(:omg_child_chain)
-    file = "omisego_operator_test_fees_file-#{DateTime.to_unix(DateTime.utc_now())}"
+    file = file_name || "omisego_operator_test_fees_file-#{DateTime.to_unix(DateTime.utc_now())}"
     full_path = "#{priv_dir}/#{file}"
 
-    :ok = File.write(full_path, json, [:write])
+    :ok = File.write(full_path, content, [:write])
     {:ok, full_path, file}
   end
 

--- a/apps/omg_child_chain/lib/omg_child_chain/fee_server.ex
+++ b/apps/omg_child_chain/lib/omg_child_chain/fee_server.ex
@@ -21,6 +21,7 @@ defmodule OMG.ChildChain.FeeServer do
   Fee's file parsing and rules of transaction's fee validation are in `OMG.Fees`
   """
 
+  alias OMG.Alert.Alarm
   alias OMG.Fees
 
   use GenServer
@@ -66,7 +67,11 @@ defmodule OMG.ChildChain.FeeServer do
       if Application.get_env(:omg_child_chain, :ignore_fees) do
         _ = Logger.warn("Fee specs from file are ignored. Updates takes no effect.")
       else
-        update_fee_spec()
+        alarm = {:invalid_fee_file, Node.self(), __MODULE__}
+        _ = Alarm.set(alarm)
+
+        with :ok <- update_fee_spec(),
+             do: _ = Alarm.clear(alarm)
       end
 
     {:noreply, state}

--- a/apps/omg_child_chain/lib/omg_child_chain/fee_server.ex
+++ b/apps/omg_child_chain/lib/omg_child_chain/fee_server.ex
@@ -68,17 +68,21 @@ defmodule OMG.ChildChain.FeeServer do
         _ = Logger.warn("Fee specs from file are ignored. Updates takes no effect.")
       else
         alarm = {:invalid_fee_file, Node.self(), __MODULE__}
-        _ = Alarm.set(alarm)
 
-        with :ok <- update_fee_spec(),
-             do: _ = Alarm.clear(alarm)
+        case update_fee_spec() do
+          :ok ->
+            Alarm.clear(alarm)
+
+          _ ->
+            Alarm.set(alarm)
+        end
       end
 
     {:noreply, state}
   end
 
   # Reads fee specification file if needed and updates :ets state with current fees information
-  @spec update_fee_spec() :: :ok
+  @spec update_fee_spec() :: :ok | {:error, atom() | [{:error, atom()}, ...]}
   defp update_fee_spec do
     path = get_fees()
 

--- a/apps/omg_child_chain/lib/omg_child_chain/fee_server.ex
+++ b/apps/omg_child_chain/lib/omg_child_chain/fee_server.ex
@@ -96,11 +96,6 @@ defmodule OMG.ChildChain.FeeServer do
       {:file_unchanged, _last_change_at} ->
         :ok
 
-      {:error, :enoent} ->
-        _ = Logger.error("The fee specification file #{inspect(path)} not found.")
-
-        {:error, :fee_spec_not_found}
-
       error ->
         _ = Logger.error("Unable to update fees from file. Reason: #{inspect(error)}")
         error

--- a/apps/omg_child_chain/lib/omg_child_chain/fee_server.ex
+++ b/apps/omg_child_chain/lib/omg_child_chain/fee_server.ex
@@ -62,7 +62,12 @@ defmodule OMG.ChildChain.FeeServer do
   end
 
   def handle_info(:update_fee_spec, state) do
-    _ = update_fee_spec()
+    _ =
+      if Application.get_env(:omg_child_chain, :ignore_fees) do
+        _ = Logger.warn("Fee specs from file are ignored. Updates takes no effect.")
+      else
+        update_fee_spec()
+      end
 
     {:noreply, state}
   end
@@ -77,7 +82,6 @@ defmodule OMG.ChildChain.FeeServer do
          {:ok, specs} <- Fees.parse_file_content(content) do
       :ok = save_fees(specs, changed_at)
       _ = Logger.info("Reloaded #{inspect(Enum.count(specs))} fee specs from file, changed at #{inspect(changed_at)}")
-
       :ok
     else
       {:file_unchanged, _last_change_at} ->

--- a/apps/omg_child_chain/test/omg_child_chain/integration/fee_server_test.exs
+++ b/apps/omg_child_chain/test/omg_child_chain/integration/fee_server_test.exs
@@ -1,0 +1,155 @@
+# Copyright 2019 OmiseGO Pte Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defmodule OMG.ChildChain.Integration.FeeServer do
+  @moduledoc """
+  Tests a simple happy path of all the pieces working together
+  """
+
+  use ExUnitFixtures
+  use ExUnit.Case, async: false
+  import ExUnit.CaptureLog
+
+  alias OMG.ChildChain.FeeServer
+  alias OMG.Eth
+  alias OMG.TestHelper
+
+  @moduletag :integration
+  @moduletag :child_chain
+
+  @eth Eth.zero_address()
+  @eth_hex Eth.Encoding.to_hex(@eth)
+  @fees %{@eth_hex => 0}
+
+  setup do
+    ignore_option = Application.fetch_env!(:omg_child_chain, :ignore_fees)
+    old_file_name = Application.fetch_env!(:omg_child_chain, :fee_specs_file_name)
+
+    {:ok, file_path, file_name} = TestHelper.write_fee_file(@fees)
+    Application.put_env(:omg_child_chain, :fee_specs_file_name, file_name)
+
+    on_exit(fn ->
+      File.rm(file_path)
+      Application.put_env(:omg_child_chain, :ignore_fees, ignore_option)
+      Application.put_env(:omg_child_chain, :fee_specs_file_name, old_file_name)
+
+      # without waiting tests interfere on :ets
+      Process.sleep(500)
+    end)
+
+    %{fee_file: file_name}
+  end
+
+  describe "fees in effect" do
+    test "corrupted file does not make server crash", %{fee_file: file_name} do
+      {:started, _log, exit_fn} = start_fee_server()
+
+      default_fees = %{@eth => 0}
+      new_fee = 5
+
+      assert {:ok, default_fees} == FeeServer.transaction_fees()
+
+      # corrupt file, refresh, check fees did not change
+      overwrite_fee_file(file_name, "[not a json]")
+      assert refresh_fees() =~ ~r/\[error\].*Unable to update fees/
+
+      assert {:ok, default_fees} == FeeServer.transaction_fees()
+      assert server_alive?()
+
+      # fix file, reload, check changes applied
+      overwrite_fee_file(file_name, %{@eth_hex => new_fee})
+      refresh_fees()
+
+      assert {:ok, %{@eth => new_fee}} == FeeServer.transaction_fees()
+      assert server_alive?()
+
+      exit_fn.()
+    end
+
+    test "starting with corrupted file makes server die", %{fee_file: file_name} do
+      overwrite_fee_file(file_name, "[not a json]")
+      {:died, log} = start_fee_server()
+
+      assert log =~ ~r/\[error\].*Unable to update fees/
+      assert false == server_alive?()
+    end
+  end
+
+  describe "fees ignored" do
+    setup do
+      Application.put_env(:omg_child_chain, :ignore_fees, true)
+      {:started, log, exit_fn} = start_fee_server()
+      assert log =~ "ignored"
+
+      on_exit(fn ->
+        exit_fn.()
+        Application.put_env(:omg_child_chain, :ignore_fees, false)
+      end)
+
+      :ok
+    end
+
+    test "fee server ignores file updates" do
+      assert {:ok, :ignore} == FeeServer.transaction_fees()
+
+      assert refresh_fees() =~ "Updates takes no effect"
+
+      assert {:ok, :ignore} == FeeServer.transaction_fees()
+      assert server_alive?()
+    end
+  end
+
+  defp start_fee_server do
+    log = capture_log(fn -> GenServer.start(FeeServer, [], name: TestFeeServer) end)
+
+    case GenServer.whereis(TestFeeServer) do
+      pid when is_pid(pid) ->
+        # switch of internal timer to don't interfere with tests
+        if tref = Keyword.get(:sys.get_state(TestFeeServer), :tref) do
+          {:ok, :cancel} = :timer.cancel(tref)
+        end
+
+        {:started, log, fn -> GenServer.stop(pid) end}
+
+      nil ->
+        {:died, log}
+    end
+  end
+
+  defp refresh_fees do
+    pid = GenServer.whereis(TestFeeServer)
+
+    capture_log(fn ->
+      Process.send(pid, :update_fee_spec, [])
+      # handle_info is async - we need to wait it executes to get message logged
+      Process.sleep(100)
+    end)
+  end
+
+  defp server_alive? do
+    case GenServer.whereis(TestFeeServer) do
+      pid when is_pid(pid) ->
+        Process.alive?(pid)
+
+      _ ->
+        false
+    end
+  end
+
+  defp overwrite_fee_file(file, content) do
+    # file modification date is in seconds
+    Process.sleep(1000)
+    {:ok, _, ^file} = TestHelper.write_fee_file(content, file)
+  end
+end


### PR DESCRIPTION
:clipboard: Fixes #815 

## Overview

Changes fee file handling to be more forgiving regarding user errors in the file structure.
Expected behavior is:
* if the child chain is starting and fee file is corrupted it should crash
* if the child chain is running and file was updated corrupting it, error message is logged, alarm raised and last valid fees are effective.

## Changes
* prevented `fee_server` process from crashing on json-serialization issues
* added alarms to raise issues with file parsing.

## Testing

Added integration test for fee_server that shows the expected behavior.
