### PR TITLE
test: fix race in catching log in block_getter_test

### DIFF
--- a/apps/omg_watcher/test/omg_watcher/integration/block_getter_test.exs
+++ b/apps/omg_watcher/test/omg_watcher/integration/block_getter_test.exs
@@ -36,7 +36,6 @@ defmodule OMG.Watcher.Integration.BlockGetterTest do
   alias Watcher.TestHelper
 
   require Utxo
-  import ExUnit.CaptureLog
 
   @moduletag :integration
   @moduletag :watcher
@@ -148,10 +147,9 @@ defmodule OMG.Watcher.Integration.BlockGetterTest do
       different_hash
     )
 
-    {:ok, _txhash} = Eth.RootChain.submit_block(different_hash, 1, 20_000_000_000)
-
     # checking if both machines and humans learn about the byzantine condition
-    assert capture_log(fn ->
+    assert TestHelper.capture_log(fn ->
+             {:ok, _txhash} = Eth.RootChain.submit_block(different_hash, 1, 20_000_000_000)
              IntegrationTest.wait_for_byzantine_events([%Event.InvalidBlock{}.name], @timeout)
            end) =~ inspect({:error, :incorrect_hash})
   end
@@ -172,10 +170,10 @@ defmodule OMG.Watcher.Integration.BlockGetterTest do
     )
 
     invalid_block_hash = block_with_incorrect_transaction.hash
-    {:ok, _txhash} = Eth.RootChain.submit_block(invalid_block_hash, 1, 20_000_000_000)
 
     # checking if both machines and humans learn about the byzantine condition
-    assert capture_log(fn ->
+    assert TestHelper.capture_log(fn ->
+             {:ok, _txhash} = Eth.RootChain.submit_block(invalid_block_hash, 1, 20_000_000_000)
              IntegrationTest.wait_for_byzantine_events([%Event.InvalidBlock{}.name], @timeout)
            end) =~ inspect(:tx_execution)
   end
@@ -217,11 +215,10 @@ defmodule OMG.Watcher.Integration.BlockGetterTest do
     exit_processor_sla_margin = Application.fetch_env!(:omg_watcher, :exit_processor_sla_margin)
     Eth.DevHelpers.wait_for_root_chain_block(eth_height + exit_processor_sla_margin, @timeout)
 
-    # Here we're manually submitting invalid block to the root chain
-    {:ok, _} = OMG.Eth.RootChain.submit_block(bad_block_hash, 2, 1)
-
     # checking if both machines and humans learn about the byzantine condition
-    assert capture_log(fn ->
+    assert TestHelper.capture_log(fn ->
+             # Here we're manually submitting invalid block to the root chain
+             {:ok, _} = OMG.Eth.RootChain.submit_block(bad_block_hash, 2, 1)
              IntegrationTest.wait_for_byzantine_events([%Event.UnchallengedExit{}.name], @timeout)
            end) =~ inspect(:unchallenged_exit)
 

--- a/apps/omg_watcher/test/support/test_helper.ex
+++ b/apps/omg_watcher/test/support/test_helper.ex
@@ -197,22 +197,22 @@ defmodule OMG.Watcher.TestHelper do
     ])
   end
 
-  def capture_log(function, max_waiting \\ 2_000) do
+  def capture_log(function, max_waiting_ms \\ 2_000) do
     CaptureLog.capture_log(fn ->
       logs = CaptureLog.capture_log(fn -> function.() end)
 
       case logs do
-        "" -> wait_for_log(max_waiting)
+        "" -> wait_for_log(max_waiting_ms)
         logs -> logs
       end
     end)
   end
 
-  defp wait_for_log(max_waiting) when is_number(max_waiting) do
-    steps = :erlang.ceil(max_waiting / 10)
+  defp wait_for_log(max_waiting_ms, sleep_time_ms \\ 20) do
+    steps = :erlang.ceil(max_waiting_ms / sleep_time_ms)
 
     Enum.reduce_while(1..steps, nil, fn _, _ ->
-      logs = CaptureLog.capture_log(fn -> Process.sleep(10) end)
+      logs = CaptureLog.capture_log(fn -> Process.sleep(sleep_time_ms) end)
 
       case logs do
         "" -> {:cont, ""}


### PR DESCRIPTION
## Overview
Sometimes the log is printed before the capture_log is enabled, and test fails.
```
  * test transaction which is using already spent utxo from exit and happened after margin of slow validator(m_sv) causes to emit unchallenged_exit event2019-07-22 10:23:53.074 [warn] module=OMG.Watcher.Application function=set_cookie/1 ⋅Cookie not applied.⋅
2019-07-22 10:24:25.204 [warn] module=OMG.Watcher.BlockGetter.Core function=consider_exits/2 ⋅Chain invalid when taking exits into account, because of {:error, :unchallenged_exit}⋅
2019-07-22 10:24:25.204 [warn] module=OMG.Watcher.BlockGetter function=do_producer/1 ⋅Chain invalid when trying to download blocks, because of {:error, []}, won't try again⋅
  * test transaction which is using already spent utxo from exit and happened after margin of slow validator(m_sv) causes to emit unchallenged_exit event (48032.4ms)

  1) test transaction which is using already spent utxo from exit and happened after margin of slow validator(m_sv) causes to emit unchallenged_exit event (OMG.Watcher.Integration.BlockGetterTest)
     test/omg_watcher/integration/block_getter_test.exs:184
     Assertion with =~ failed
     code:  assert capture_log(fn -> IntegrationTest.wait_for_byzantine_events([%Event.UnchallengedExit{}.name()], @timeout) end) =~ inspect(:unchallenged_exit)
     left:  ""
     right: ":unchallenged_exit"
     stacktrace:
       test/omg_watcher/integration/block_getter_test.exs:224: (test)
```

## Changes
moved function causes log into capture_log 

## Testing
mix test --only integration test/omg_watcher/integration/block_getter_test.exs
