### PR TITLE
fix: Statsd connection can drop and it shouldn't be attached to the a…

### DIFF
--- a/apps/omg/config/config.exs
+++ b/apps/omg/config/config.exs
@@ -7,8 +7,7 @@ config :omg,
   ethereum_events_check_interval_ms: 500,
   coordinator_eth_height_check_interval_ms: 6_000,
   client_monitor_interval_ms: 4500,
-  metrics_collection_interval: 60_000,
-  ws_url: {:system, "ETHEREUM_WS_RPC_URL", "ws://localhost:8546/ws"}
+  metrics_collection_interval: 60_000
 
 config :omg, :eip_712_domain,
   name: "OMG Network",

--- a/apps/omg/config/config.exs
+++ b/apps/omg/config/config.exs
@@ -8,7 +8,7 @@ config :omg,
   coordinator_eth_height_check_interval_ms: 6_000,
   client_monitor_interval_ms: 4500,
   metrics_collection_interval: 60_000,
-  ws_url: System.get_env("ETHEREUM_WS_RPC_URL") || "ws://localhost:8546/ws"
+  ws_url: {:system, "ETHEREUM_WS_RPC_URL", "ws://localhost:8546/ws"}
 
 config :omg, :eip_712_domain,
   name: "OMG Network",

--- a/apps/omg/config/config.exs
+++ b/apps/omg/config/config.exs
@@ -7,7 +7,8 @@ config :omg,
   ethereum_events_check_interval_ms: 500,
   coordinator_eth_height_check_interval_ms: 6_000,
   client_monitor_interval_ms: 4500,
-  metrics_collection_interval: 60_000
+  metrics_collection_interval: 60_000,
+  ws_url: System.get_env("ETHEREUM_WS_RPC_URL") || "ws://localhost:8546/ws"
 
 config :omg, :eip_712_domain,
   name: "OMG Network",

--- a/apps/omg/config/test.exs
+++ b/apps/omg/config/test.exs
@@ -8,5 +8,4 @@ config :omg,
   environment: :test,
   # an entry to fix a common reference path to the root directory of the umbrella project
   # this is useful because `mix test` and `mix coveralls --umbrella` have different views on the root dir when testing
-  umbrella_root_dir: Path.join(__DIR__, "../../.."),
-  ws_url: "ws://localhost:8546/ws"
+  umbrella_root_dir: Path.join(__DIR__, "../../..")

--- a/apps/omg/config/test.exs
+++ b/apps/omg/config/test.exs
@@ -8,4 +8,5 @@ config :omg,
   environment: :test,
   # an entry to fix a common reference path to the root directory of the umbrella project
   # this is useful because `mix test` and `mix coveralls --umbrella` have different views on the root dir when testing
-  umbrella_root_dir: Path.join(__DIR__, "../../..")
+  umbrella_root_dir: Path.join(__DIR__, "../../.."),
+  ws_url: "ws://localhost:8546/ws"

--- a/apps/omg/lib/omg/ethereum_client_monitor.ex
+++ b/apps/omg/lib/omg/ethereum_client_monitor.ex
@@ -60,7 +60,7 @@ defmodule OMG.EthereumClientMonitor do
     state = %__MODULE__{
       alarm_module: alarm_module,
       ethereum_height: ethereum_height,
-      ws_url: Keyword.get(opts, :ws_url)
+      ws_url: Keyword.get(opts, :ws_url, Application.get_env(:omg, :ws_url))
     }
 
     _ = raise_clear(alarm_module, state.raised, ethereum_height)

--- a/apps/omg/lib/omg/ethereum_client_monitor.ex
+++ b/apps/omg/lib/omg/ethereum_client_monitor.ex
@@ -42,7 +42,7 @@ defmodule OMG.EthereumClientMonitor do
   defstruct interval: @default_interval,
             tref: nil,
             alarm_module: nil,
-            raised: true,
+            raised: false,
             ethereum_height: :error,
             ws_url: nil
 
@@ -60,7 +60,7 @@ defmodule OMG.EthereumClientMonitor do
     state = %__MODULE__{
       alarm_module: alarm_module,
       ethereum_height: ethereum_height,
-      ws_url: Keyword.get(opts, :ws_url, Application.get_env(:omg, :ws_url))
+      ws_url: Keyword.get(opts, :ws_url)
     }
 
     _ = raise_clear(alarm_module, state.raised, ethereum_height)
@@ -75,9 +75,7 @@ defmodule OMG.EthereumClientMonitor do
   def handle_continue(:ws_connect, state) do
     _ = Logger.debug("Ethereum client monitor starting a WS newHeads subscription.")
 
-    params =
-      [listen_to: "newHeads", ws_url: state.ws_url]
-      |> Keyword.delete(:ws_url, nil)
+    params = [listen_to: "newHeads", ws_url: state.ws_url]
 
     _ = SubscriptionWorker.start_link([{:event_bus, OMG.InternalEventBus} | params])
     _ = raise_clear(state.alarm_module, state.raised, state.ethereum_height)

--- a/apps/omg/lib/omg/root_chain_coordinator/measure.ex
+++ b/apps/omg/lib/omg/root_chain_coordinator/measure.ex
@@ -26,6 +26,6 @@ defmodule OMG.RootChainCoordinator.Measure do
       |> Process.info(:message_queue_len)
       |> elem(1)
 
-    :ok = Datadog.gauge(name(state.service_name, :message_queue_len), value)
+    _ = Datadog.gauge(name(state.service_name, :message_queue_len), value)
   end
 end

--- a/apps/omg/lib/omg/state/measure.ex
+++ b/apps/omg/lib/omg/state/measure.ex
@@ -28,8 +28,8 @@ defmodule OMG.State.Measure do
 
   def handle_event([:process, OMG.State], _, %Core{} = state, _config) do
     Enum.each(MeasurementCalculation.calculate(state), fn
-      {key, value} -> :ok = Datadog.gauge(name(key), value)
-      {key, value, metadata} -> :ok = Datadog.gauge(name(key), value, tags: [metadata])
+      {key, value} -> _ = Datadog.gauge(name(key), value)
+      {key, value, metadata} -> _ = Datadog.gauge(name(key), value, tags: [metadata])
     end)
   end
 end

--- a/apps/omg/lib/omg/supervisor.ex
+++ b/apps/omg/lib/omg/supervisor.ex
@@ -27,7 +27,7 @@ defmodule OMG.Supervisor do
   def init(:ok) do
     children = [
       {OMG.InternalEventBus, []},
-      {OMG.EthereumClientMonitor, [alarm_module: Alarm]},
+      {OMG.EthereumClientMonitor, [alarm_module: Alarm, ws_url: Application.get_env(:omg, :ws_url)]},
       {OMG.EthereumHeight, []}
     ]
 

--- a/apps/omg/lib/omg/supervisor.ex
+++ b/apps/omg/lib/omg/supervisor.ex
@@ -29,7 +29,7 @@ defmodule OMG.Supervisor do
 
     children = [
       {OMG.InternalEventBus, []},
-      {OMG.EthereumClientMonitor, [alarm_module: Alarm, ws_url: Application.get_env(:omg, :ws_url)]},
+      {OMG.EthereumClientMonitor, [alarm_module: Alarm, ws_url: Application.get_env(:omg_eth, :ws_url)]},
       {OMG.EthereumHeight, []}
     ]
 

--- a/apps/omg/lib/omg/supervisor.ex
+++ b/apps/omg/lib/omg/supervisor.ex
@@ -25,6 +25,8 @@ defmodule OMG.Supervisor do
   end
 
   def init(:ok) do
+    DeferredConfig.populate(:omg)
+
     children = [
       {OMG.InternalEventBus, []},
       {OMG.EthereumClientMonitor, [alarm_module: Alarm, ws_url: Application.get_env(:omg, :ws_url)]},

--- a/apps/omg/test/omg/ethereum_client_monitor_test.exs
+++ b/apps/omg/test/omg/ethereum_client_monitor_test.exs
@@ -57,20 +57,36 @@ defmodule OMG.EthereumClientMonitorTest do
     %{server_ref: server_ref, websocket_url: websocket_url}
   end
 
-  test "that alarm gets raised if there's no ethereum client running", %{
-    server_ref: server_ref,
+  test "that alarms get raised when we kill the connection", %{
+    server_ref: _server_ref,
     websocket_url: _websocket_url
   } do
-    WebSockexServerMock.shutdown(server_ref)
-    true = is_pid(Process.whereis(EthereumClientMonitor))
+    pid = Process.whereis(EthereumClientMonitor)
+    %{raised: false} = :sys.get_state(EthereumClientMonitor)
+    {:links, links} = Process.info(pid, :links)
+    exclude_test_pid = self()
 
-    :ok =
-      pull_client_alarm(400, [
-        %{
-          details: %{node: Node.self(), reporter: EthereumClientMonitor},
-          id: :ethereum_client_connection
-        }
-      ])
+    [ws_connection] =
+      Enum.filter(links, fn
+        ^exclude_test_pid -> false
+        _ -> true
+      end)
+
+    true = Process.exit(ws_connection, :testkill)
+    :erlang.trace(pid, true, [:receive])
+    assert_receive {:trace, ^pid, :receive, {:EXIT, ^ws_connection, :testkill}}
+    assert_receive {:trace, ^pid, :receive, {:"$gen_cast", :set_alarm}}
+
+    alarm = %{
+      details: %{node: Node.self(), reporter: EthereumClientMonitor},
+      id: :ethereum_client_connection
+    }
+
+    [^alarm] = Alarm.all()
+
+    %{raised: true} = :sys.get_state(EthereumClientMonitor)
+    # eventually, the connection should recover
+    assert_receive {:trace, ^pid, :receive, {:"$gen_cast", :clear_alarm}}
   end
 
   test "that alarm gets raised if there's no ethereum client running and cleared when it's running", %{

--- a/apps/omg/test/omg/ethereum_client_monitor_test.exs
+++ b/apps/omg/test/omg/ethereum_client_monitor_test.exs
@@ -72,8 +72,8 @@ defmodule OMG.EthereumClientMonitorTest do
         _ -> true
       end)
 
-    true = Process.exit(ws_connection, :testkill)
     :erlang.trace(pid, true, [:receive])
+    true = Process.exit(ws_connection, :testkill)
     assert_receive {:trace, ^pid, :receive, {:EXIT, ^ws_connection, :testkill}}
     assert_receive {:trace, ^pid, :receive, {:"$gen_cast", :set_alarm}}
 

--- a/apps/omg/test/omg/integration/root_chain_coordinator_test.exs
+++ b/apps/omg/test/omg/integration/root_chain_coordinator_test.exs
@@ -43,7 +43,7 @@ defmodule OMG.RootChainCoordinatorTest do
       Supervisor.start_link(
         [
           {OMG.InternalEventBus, []},
-          {OMG.EthereumClientMonitor, [alarm_module: Alarm, ws_url: Application.get_env(:omg, :ws_url)]},
+          {OMG.EthereumClientMonitor, [alarm_module: Alarm, ws_url: Application.get_env(:omg_eth, :ws_url)]},
           {OMG.EthereumHeight, []},
           {OMG.RootChainCoordinator, coordinator_setup},
           OMG.EthereumEventListener.prepare_child(

--- a/apps/omg/test/omg/integration/root_chain_coordinator_test.exs
+++ b/apps/omg/test/omg/integration/root_chain_coordinator_test.exs
@@ -42,7 +42,7 @@ defmodule OMG.RootChainCoordinatorTest do
       Supervisor.start_link(
         [
           {OMG.InternalEventBus, []},
-          {OMG.EthereumClientMonitor, [alarm_module: Alarm]},
+          {OMG.EthereumClientMonitor, [alarm_module: Alarm, ws_url: Application.get_env(:omg, :ws_url)]},
           {OMG.EthereumHeight, []},
           {OMG.RootChainCoordinator, coordinator_setup},
           OMG.EthereumEventListener.prepare_child(

--- a/apps/omg/test/omg/integration/root_chain_coordinator_test.exs
+++ b/apps/omg/test/omg/integration/root_chain_coordinator_test.exs
@@ -34,6 +34,7 @@ defmodule OMG.RootChainCoordinatorTest do
   test "can do a simplest sync",
        %{alice: alice} do
     DeferredConfig.populate(:omg_eth)
+    DeferredConfig.populate(:omg)
     :ok = AlarmHandler.install()
     coordinator_setup = %{test: [finality_margin: 0]}
     test_process = self()

--- a/apps/omg_child_chain/lib/omg_child_chain/block_queue/measure.ex
+++ b/apps/omg_child_chain/lib/omg_child_chain/block_queue/measure.ex
@@ -14,7 +14,12 @@
 
 defmodule OMG.ChildChain.BlockQueue.Measure do
   @moduledoc """
-  Counting business metrics sent to Datadog
+  Counting business metrics sent to Datadog.
+  We don't want to pattern match on :ok to Datadog because the connection
+  towards the statsd client can be intermittent and sending would be unsuccessful and that
+  would trigger the removal of telemetry handler. But because we have monitors in place,
+  that eventually recover the connection to Statsd handlers wouldn't exist anymore and metrics
+  wouldn't be published.
   """
   alias OMG.Status.Metric.Datadog
   import OMG.Status.Metric.Event, only: [name: 2]
@@ -25,6 +30,6 @@ defmodule OMG.ChildChain.BlockQueue.Measure do
       |> Process.info(:message_queue_len)
       |> elem(1)
 
-    :ok = Datadog.gauge(name(state.service_name, :message_queue_len), value)
+    _ = Datadog.gauge(name(state.service_name, :message_queue_len), value)
   end
 end

--- a/apps/omg_child_chain_rpc/config/config.exs
+++ b/apps/omg_child_chain_rpc/config/config.exs
@@ -25,7 +25,7 @@ config :phoenix,
 config :omg_child_chain_rpc, OMG.ChildChainRPC.Tracer,
   service: :web,
   adapter: SpandexDatadog.Adapter,
-  disabled?: {:system, "METRICS", false},
+  disabled?: {:system, "DD_DISABLED", false, {String, :to_existing_atom}},
   env: {:system, "APP_ENV"},
   type: :web
 

--- a/apps/omg_db/lib/omg_db/measure.ex
+++ b/apps/omg_db/lib/omg_db/measure.ex
@@ -42,12 +42,12 @@ defmodule OMG.DB.Measure do
       |> Process.info(:message_queue_len)
       |> elem(1)
 
-    :ok = Datadog.gauge(name(:db_message_queue_len), value, tags: ["service_name:#{service_name}"])
+    _ = Datadog.gauge(name(:db_message_queue_len), value, tags: ["service_name:#{service_name}"])
 
     Enum.each(@keys, fn table_key ->
       case :ets.take(state.name, table_key) do
         [{key, value}] ->
-          :ok = Datadog.gauge(name(key), value)
+          _ = Datadog.gauge(name(key), value)
 
         _ ->
           # handling the case where the entry doesn't exist yet

--- a/apps/omg_db/mix.exs
+++ b/apps/omg_db/mix.exs
@@ -12,7 +12,7 @@ defmodule OMG.DB.MixProject do
       elixir: "~> 1.6",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,
-      deps: deps(),
+      deps: deps() ++ rocksdb(),
       test_coverage: [tool: ExCoveralls]
     ]
   end
@@ -31,7 +31,6 @@ defmodule OMG.DB.MixProject do
 
   defp deps do
     [
-      {:rocksdb, "~> 1.2"},
       {:exleveldb, "~> 0.11"},
       # NOTE: we only need in :dev and :test here, but we need in :prod too in performance
       #       then there's some unexpected behavior of mix that won't allow to mix these, see
@@ -43,5 +42,12 @@ defmodule OMG.DB.MixProject do
       {:omg_utils, in_umbrella: true},
       {:omg_status, in_umbrella: true}
     ]
+  end
+
+  defp rocksdb do
+    case System.get_env("EXCLUDE_ROCKSDB") do
+      nil -> [{:rocksdb, "~> 1.2"}]
+      _ -> []
+    end
   end
 end

--- a/apps/omg_eth/config/config.exs
+++ b/apps/omg_eth/config/config.exs
@@ -17,6 +17,7 @@ config :omg_eth,
   node_logging_in_debug: true,
   child_block_interval: 1000,
   exit_period_seconds: {:system, "EXIT_PERIOD_SECONDS", 7 * 24 * 60 * 60, {String, :to_integer}},
-  ethereum_client_warning_time_ms: ethereum_client_timeout_ms / 4
+  ethereum_client_warning_time_ms: ethereum_client_timeout_ms / 4,
+  ws_url: {:system, "ETHEREUM_WS_RPC_URL", "ws://localhost:8546/ws"}
 
 import_config "#{Mix.env()}.exs"

--- a/apps/omg_eth/config/config.exs
+++ b/apps/omg_eth/config/config.exs
@@ -17,7 +17,6 @@ config :omg_eth,
   node_logging_in_debug: true,
   child_block_interval: 1000,
   exit_period_seconds: {:system, "EXIT_PERIOD_SECONDS", 7 * 24 * 60 * 60, {String, :to_integer}},
-  ethereum_client_warning_time_ms: ethereum_client_timeout_ms / 4,
-  ws_url: System.get_env("ETHEREUM_WS_RPC_URL") || "ws://localhost:8546/ws"
+  ethereum_client_warning_time_ms: ethereum_client_timeout_ms / 4
 
 import_config "#{Mix.env()}.exs"

--- a/apps/omg_eth/config/test.exs
+++ b/apps/omg_eth/config/test.exs
@@ -8,4 +8,5 @@ config :omg_eth,
   exit_period_seconds: 22,
   # an entry to fix a common reference path to the root directory of the umbrella project
   # this is useful because `mix test` and `mix coveralls --umbrella` have different views on the root dir when testing
-  umbrella_root_dir: Path.join(__DIR__, "../../..")
+  umbrella_root_dir: Path.join(__DIR__, "../../.."),
+  ws_url: "ws://localhost:8546/ws"

--- a/apps/omg_eth/lib/omg_eth/subscription_worker.ex
+++ b/apps/omg_eth/lib/omg_eth/subscription_worker.ex
@@ -29,7 +29,7 @@ defmodule OMG.Eth.SubscriptionWorker do
   """
   @spec start_link(Keyword.t()) :: {:ok, pid()} | no_return()
   def start_link(opts) do
-    ws_url = Keyword.get(opts, :ws_url, Application.get_env(:omg, :ws_url))
+    ws_url = Keyword.get(opts, :ws_url)
 
     {:ok, pid} = WebSockex.start_link(ws_url, __MODULE__, opts, [])
     spawn(fn -> listen(pid, opts) end)

--- a/apps/omg_eth/lib/omg_eth/subscription_worker.ex
+++ b/apps/omg_eth/lib/omg_eth/subscription_worker.ex
@@ -29,7 +29,7 @@ defmodule OMG.Eth.SubscriptionWorker do
   """
   @spec start_link(Keyword.t()) :: {:ok, pid()} | no_return()
   def start_link(opts) do
-    ws_url = Keyword.get(opts, :ws_url, Application.get_env(:omg_eth, :ws_url))
+    ws_url = Keyword.get(opts, :ws_url, Application.get_env(:omg, :ws_url))
 
     {:ok, pid} = WebSockex.start_link(ws_url, __MODULE__, opts, [])
     spawn(fn -> listen(pid, opts) end)

--- a/apps/omg_eth/test/omg_eth/subscription_worker_test.exs
+++ b/apps/omg_eth/test/omg_eth/subscription_worker_test.exs
@@ -14,11 +14,11 @@
 
 defmodule OMG.Eth.SubscriptionWorkerTest do
   @moduledoc false
-  alias __MODULE__.WebSockex.ServerMock
   alias OMG.Eth.SubscriptionWorker
 
   use ExUnitFixtures
-  use ExUnit.Case, async: true
+  use ExUnit.Case, async: false
+  use OMG.Utils.LoggerExt
 
   @moduletag :wrappers
   @moduletag :common
@@ -37,12 +37,11 @@ defmodule OMG.Eth.SubscriptionWorkerTest do
   @tag fixtures: [:eth_node]
   test "that worker can subscribe to different events and receive events" do
     listen_to = ["newHeads", "newPendingTransactions"]
-    {:ok, {server_ref, websocket_url}} = ServerMock.start(self())
 
     Enum.each(
       listen_to,
       fn listen ->
-        params = [listen_to: listen, ws_url: websocket_url]
+        params = [listen_to: listen, ws_url: Application.get_env(:omg_eth, :ws_url)]
         _ = SubscriptionWorker.start_link([{:event_bus, OMG.InternalEventBus} | params])
         :ok = OMG.InternalEventBus.subscribe(listen, link: true)
         event = String.to_atom(listen)
@@ -53,85 +52,5 @@ defmodule OMG.Eth.SubscriptionWorkerTest do
         end
       end
     )
-
-    ServerMock.shutdown(server_ref)
-  end
-
-  test "that worker can subscribe to my own server via arguments" do
-    {:ok, {server_ref, websocket_url}} = ServerMock.start(self())
-    listen_to = ["newHeads", "newPendingTransactions"]
-
-    Enum.each(
-      listen_to,
-      fn listen ->
-        params = [listen_to: listen, ws_url: websocket_url]
-        _ = SubscriptionWorker.start_link([{:event_bus, OMG.InternalEventBus} | params])
-        :ok = OMG.InternalEventBus.subscribe(listen, link: true)
-        event = String.to_atom(listen)
-
-        receive do
-          {:internal_event_bus, ^event, _message} ->
-            assert true
-        end
-      end
-    )
-
-    ServerMock.shutdown(server_ref)
-  end
-
-  defmodule WebSockex.ServerMock do
-    use Plug.Router
-
-    plug(:match)
-    plug(:dispatch)
-
-    match _ do
-      send_resp(conn, 200, "Hello from plug")
-    end
-
-    def start(pid) when is_pid(pid) do
-      ref = make_ref()
-      port = Enum.random(60_000..63_000)
-
-      url = "ws://localhost:#{port}/ws"
-
-      opts = [dispatch: dispatch(), port: port, ref: ref]
-
-      {:ok, _} = Plug.Adapters.Cowboy.http(__MODULE__, [], opts)
-      {:ok, {ref, url}}
-    end
-
-    def shutdown(ref) do
-      Plug.Adapters.Cowboy.shutdown(ref)
-    end
-
-    defp dispatch do
-      [{:_, [{"/ws", WebSockex.MockTestSocket, []}]}]
-    end
-  end
-
-  defmodule WebSockex.MockTestSocket do
-    @behaviour :cowboy_websocket_handler
-
-    def init(_, _req, _) do
-      {:upgrade, :protocol, :cowboy_websocket}
-    end
-
-    def terminate(_, _, _), do: :ok
-
-    def websocket_init(_, req, _) do
-      {:ok, req, %{}}
-    end
-
-    def websocket_terminate(_, _, _) do
-      :ok
-    end
-
-    def websocket_handle({:text, _body}, req, state) do
-      response = Jason.encode!(%{"params" => %{"result" => %{"number" => "0x77be11", "hash" => "0x1234"}}})
-      {:reply, {:text, response}, req, state}
-    end
-
-    def websocket_info(_, req, state), do: {:ok, req, state}
   end
 end

--- a/apps/omg_eth/test/omg_eth/subscription_worker_test.exs
+++ b/apps/omg_eth/test/omg_eth/subscription_worker_test.exs
@@ -37,11 +37,12 @@ defmodule OMG.Eth.SubscriptionWorkerTest do
   @tag fixtures: [:eth_node]
   test "that worker can subscribe to different events and receive events" do
     listen_to = ["newHeads", "newPendingTransactions"]
+    {:ok, {server_ref, websocket_url}} = ServerMock.start(self())
 
     Enum.each(
       listen_to,
       fn listen ->
-        params = [listen_to: listen]
+        params = [listen_to: listen, ws_url: websocket_url]
         _ = SubscriptionWorker.start_link([{:event_bus, OMG.InternalEventBus} | params])
         :ok = OMG.InternalEventBus.subscribe(listen, link: true)
         event = String.to_atom(listen)
@@ -52,6 +53,8 @@ defmodule OMG.Eth.SubscriptionWorkerTest do
         end
       end
     )
+
+    ServerMock.shutdown(server_ref)
   end
 
   test "that worker can subscribe to my own server via arguments" do

--- a/apps/omg_status/config/config.exs
+++ b/apps/omg_status/config/config.exs
@@ -1,12 +1,12 @@
 use Mix.Config
 
 config :omg_status,
-  metrics: {:system, "METRICS", true}
+  client_monitor_interval_ms: 10_000
 
 config :omg_status, OMG.Status.Metric.Tracer,
   service: :omg_status,
   adapter: SpandexDatadog.Adapter,
-  disabled?: {:system, "METRICS", false},
+  disabled?: {:system, "DD_DISABLED", false, {String, :to_existing_atom}},
   env: {:system, "APP_ENV"},
   type: :backend
 

--- a/apps/omg_status/config/test.exs
+++ b/apps/omg_status/config/test.exs
@@ -2,6 +2,7 @@ use Mix.Config
 
 config :omg_status,
   metrics: false,
-  environment: :test
+  environment: :test,
+  client_monitor_interval_ms: 10
 
 config :omg_status, OMG.Status.Metric.Tracer, env: "test"

--- a/apps/omg_status/lib/omg_status/alert/alarm.ex
+++ b/apps/omg_status/lib/omg_status/alert/alarm.ex
@@ -21,7 +21,7 @@ defmodule OMG.Status.Alert.Alarm do
   @typedoc """
   The raw alarm being used to `set` the Alarm
   """
-  @type raw_t :: {atom(), list()} | {{atom(), binary()}, list} | {atom(), %{node: Node.t(), reporter: module()}}
+  @type raw_t :: {:statsd_client_connection, atom(), atom()}
 
   def statsd_client_connection(node, reporter),
     do: {:statsd_client_connection, %{node: node, reporter: reporter}}

--- a/apps/omg_status/lib/omg_status/alert/alarm.ex
+++ b/apps/omg_status/lib/omg_status/alert/alarm.ex
@@ -14,7 +14,7 @@
 
 defmodule OMG.Status.Alert.Alarm do
   @moduledoc """
-  Interface for raising and clearing alarms.
+  Interface for raising and clearing alarms related to OMG Status.
   """
   alias OMG.Status.Alert.AlarmHandler
 
@@ -23,6 +23,15 @@ defmodule OMG.Status.Alert.Alarm do
   """
   @type raw_t :: {atom(), list()} | {{atom(), binary()}, list} | {atom(), %{node: Node.t(), reporter: module()}}
 
+  def statsd_client_connection(node, reporter),
+    do: {:statsd_client_connection, %{node: node, reporter: reporter}}
+
+  @spec set(raw_t()) :: :ok | :duplicate
+  def set(raw_alarm), do: raw_alarm |> make_alarm() |> do_raise()
+
+  @spec clear(raw_t()) :: :ok | :not_raised
+  def clear(raw_alarm), do: raw_alarm |> make_alarm() |> do_clear()
+
   def clear_all do
     all_raw()
     |> Enum.each(&:alarm_handler.clear_alarm(&1))
@@ -30,5 +39,25 @@ defmodule OMG.Status.Alert.Alarm do
 
   def all, do: all_raw()
 
+  defp do_raise(alarm) do
+    if Enum.member?(all_raw(), alarm),
+      do: :duplicate,
+      else: :alarm_handler.set_alarm(alarm)
+  end
+
+  defp do_clear(alarm) do
+    if Enum.member?(all_raw(), alarm),
+      do: :alarm_handler.clear_alarm(alarm),
+      else: :not_raised
+  end
+
   defp all_raw, do: :gen_event.call(:alarm_handler, AlarmHandler, :get_alarms)
+
+  @spec make_alarm(raw_t()) :: {atom(), %{node: node(), reporter: module()}}
+  defp make_alarm(raw_alarm = {_, node, reporter}) when is_atom(node) and is_atom(reporter),
+    do: make_alarm_for(raw_alarm)
+
+  defp make_alarm_for({:statsd_client_connection, node, reporter}) do
+    statsd_client_connection(node, reporter)
+  end
 end

--- a/apps/omg_status/lib/omg_status/application.ex
+++ b/apps/omg_status/lib/omg_status/application.ex
@@ -17,8 +17,8 @@ defmodule OMG.Status.Application do
   Top level application module.
   """
   use Application
-  alias OMG.Status.Alert.AlarmHandler
   alias OMG.Status.Alert.Alarm
+  alias OMG.Status.Alert.AlarmHandler
   alias OMG.Status.Metric.Datadog
   alias OMG.Status.Metric.VmstatsSink
 
@@ -32,7 +32,8 @@ defmodule OMG.Status.Application do
 
     children =
       if datadog do
-        []
+        # spandex datadog api server is able to flush when disabled?: true
+        [{SpandexDatadog.ApiServer, spandex_datadog_options()}]
       else
         [
           {OMG.Status.Metric.StatsdMonitor, [alarm_module: Alarm, child_module: Datadog]},
@@ -60,7 +61,7 @@ defmodule OMG.Status.Application do
     end
   end
 
-  @spec is_disabled?() :: boolean() | nil
+  @spec is_disabled?() :: boolean()
   defp is_disabled?() do
     case System.get_env("DD_DISABLED") do
       "false" -> false

--- a/apps/omg_status/lib/omg_status/metric/datadog.ex
+++ b/apps/omg_status/lib/omg_status/metric/datadog.ex
@@ -27,7 +27,7 @@ defmodule OMG.Status.Metric.Datadog do
   use GenServer
   require Logger
 
-  def start(), do: GenServer.start(__MODULE__, [], [])
+  def start, do: GenServer.start(__MODULE__, [], [])
 
   def init(_opts) do
     _ = Logger.info("Starting #{inspect(__MODULE__)} and connecting to Datadog.")
@@ -37,7 +37,7 @@ defmodule OMG.Status.Metric.Datadog do
   end
 
   def handle_info({:EXIT, port, reason}, %Statix.Conn{sock: __MODULE__} = state) do
-    Logger.error("Port in #{inspect(__MODULE__)} #{inspect(port)} exited with reason #{reason}")
+    _ = Logger.error("Port in #{inspect(__MODULE__)} #{inspect(port)} exited with reason #{reason}")
     {:stop, :normal, state}
   end
 end

--- a/apps/omg_status/lib/omg_status/metric/datadog.ex
+++ b/apps/omg_status/lib/omg_status/metric/datadog.ex
@@ -23,4 +23,21 @@ defmodule OMG.Status.Metric.Datadog do
     :test -> use OMG.Status.Metric.Statix
     _ -> use Statix, runtime_config: true
   end
+
+  use GenServer
+  require Logger
+
+  def start(), do: GenServer.start(__MODULE__, [], [])
+
+  def init(_opts) do
+    _ = Logger.info("Starting #{inspect(__MODULE__)} and connecting to Datadog.")
+    Process.flag(:trap_exit, true)
+    connect()
+    {:ok, current_conn()}
+  end
+
+  def handle_info({:EXIT, port, reason}, %Statix.Conn{sock: __MODULE__} = state) do
+    Logger.error("Port in #{inspect(__MODULE__)} #{inspect(port)} exited with reason #{reason}")
+    {:stop, :normal, state}
+  end
 end

--- a/apps/omg_status/lib/omg_status/metric/statix.ex
+++ b/apps/omg_status/lib/omg_status/metric/statix.ex
@@ -34,6 +34,8 @@ defmodule OMG.Status.Metric.Statix do
       def measure(key, options \\ [], fun), do: :ok
 
       def set(key, val, options \\ []), do: :ok
+
+      def current_conn(), do: %Statix.Conn{sock: __MODULE__}
     end
   end
 end

--- a/apps/omg_status/lib/omg_status/metric/statix.ex
+++ b/apps/omg_status/lib/omg_status/metric/statix.ex
@@ -35,7 +35,7 @@ defmodule OMG.Status.Metric.Statix do
 
       def set(key, val, options \\ []), do: :ok
 
-      def current_conn(), do: %Statix.Conn{sock: __MODULE__}
+      def current_conn, do: %Statix.Conn{sock: __MODULE__}
     end
   end
 end

--- a/apps/omg_status/lib/omg_status/metric/statsd_monitor.ex
+++ b/apps/omg_status/lib/omg_status/metric/statsd_monitor.ex
@@ -1,0 +1,134 @@
+# Copyright 2019 OmiseGO Pte Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defmodule OMG.Status.Metric.StatsdMonitor do
+  @moduledoc """
+  This module is a custom implemented supervisor that monitors all it's chilldren
+
+  """
+  use GenServer
+
+  require Logger
+  @default_interval Application.get_env(:omg_status, :client_monitor_interval_ms)
+  @type t :: %__MODULE__{
+          alarm_module: module(),
+          child_module: module(),
+          interval: pos_integer(),
+          monitor: {pid(), reference()},
+          raised: boolean(),
+          tref: reference() | nil
+        }
+
+  defstruct alarm_module: nil,
+            child_module: nil,
+            interval: @default_interval,
+            monitor: nil,
+            raised: true,
+            tref: nil
+
+  def start_link(args) do
+    GenServer.start_link(__MODULE__, args, name: __MODULE__)
+  end
+
+  def init([_ | _] = opts) do
+    _ = Logger.info("Starting #{inspect(__MODULE__)}.")
+    install_alarm_handler()
+
+    alarm_module = Keyword.get(opts, :alarm_module)
+    child_module = Keyword.get(opts, :child_module)
+    false = Process.flag(:trap_exit, true)
+    {pid, _ref} = monitor = Kernel.spawn_monitor(child_module, :start, [])
+
+    state = %__MODULE__{
+      alarm_module: alarm_module,
+      child_module: child_module,
+      monitor: monitor
+    }
+
+    _ = raise_clear(alarm_module, state.raised, Process.alive?(pid))
+    {:ok, state}
+  end
+
+  # gen_event init
+  def init(_args) do
+    {:ok, %{}}
+  end
+
+  def handle_info({:DOWN, _ref, :process, _object, _reason}, state) do
+    _ = state.alarm_module.set({:statsd_client_connection, Node.self(), __MODULE__})
+    _ = :timer.cancel(state.tref)
+    {:ok, tref} = :timer.send_after(state.interval, :connect)
+    {:noreply, %{state | tref: tref}}
+  end
+
+  def handle_info(:connect, state) do
+    {pid, _ref} = monitor = Kernel.spawn_monitor(state.child_module, :start, [])
+    _ = raise_clear(state.alarm_module, state.raised, Process.alive?(pid))
+    {:noreply, %{state | monitor: monitor}}
+  end
+
+  def handle_cast(:clear_alarm, state) do
+    {:noreply, %{state | raised: false}}
+  end
+
+  def handle_cast(:set_alarm, state) do
+    {:noreply, %{state | raised: true}}
+  end
+
+  def terminate(_, _), do: :ok
+
+  #
+  # gen_event
+  #
+  def handle_call(_request, state), do: {:ok, :ok, state}
+
+  def handle_event({:clear_alarm, {:statsd_client_connection, %{reporter: __MODULE__}}}, state) do
+    _ = Logger.warn("Established connection to the client. :statsd_client_connection alarm clearead.")
+    :ok = GenServer.cast(__MODULE__, :clear_alarm)
+    {:ok, state}
+  end
+
+  def handle_event({:set_alarm, {:statsd_client_connection, %{reporter: __MODULE__}}}, state) do
+    _ = Logger.warn("Connection dropped raising :statsd_client_connection alarm.")
+    :ok = GenServer.cast(__MODULE__, :set_alarm)
+    {:ok, state}
+  end
+
+  # flush
+  def handle_event(event, state) do
+    _ = Logger.info("inspect(#{__MODULE__}) got event: #{inspect(event)}. Ignoring.")
+    {:ok, state}
+  end
+
+  # if an alarm is raised, we don't have to raise it again.
+  # if an alarm is cleared, we don't need to clear it again
+  # we want to avoid pushing events again
+  @spec raise_clear(module(), boolean(), boolean()) :: :ok | :duplicate
+  defp raise_clear(_alarm_module, true, false), do: :ok
+
+  defp raise_clear(alarm_module, false, false),
+    do: alarm_module.set({:statsd_client_connection, Node.self(), __MODULE__})
+
+  defp raise_clear(alarm_module, true, _),
+    do: alarm_module.clear({:statsd_client_connection, Node.self(), __MODULE__})
+
+  defp raise_clear(_alarm_module, false, _), do: :ok
+
+  defp install_alarm_handler do
+    case Enum.member?(:gen_event.which_handlers(:alarm_handler), __MODULE__) do
+      true -> :ok
+      _ -> :alarm_handler.add_alarm_handler(__MODULE__)
+    end
+  end
+end

--- a/apps/omg_status/lib/omg_status/metric/vmstats_sink.ex
+++ b/apps/omg_status/lib/omg_status/metric/vmstats_sink.ex
@@ -29,9 +29,9 @@ defmodule OMG.Status.Metric.VmstatsSink do
 
   defp base_key, do: Application.get_env(:vmstats, :base_key)
 
-  def collect(:counter, key, value), do: :ok = Datadog.set(key, value)
+  def collect(:counter, key, value), do: _ = Datadog.set(key, value)
 
-  def collect(:gauge, key, value), do: :ok = Datadog.gauge(key, value)
+  def collect(:gauge, key, value), do: _ = Datadog.gauge(key, value)
 
-  def collect(:timing, key, value), do: :ok = Datadog.timing(key, value)
+  def collect(:timing, key, value), do: _ = Datadog.timing(key, value)
 end

--- a/apps/omg_status/test/omg_status/metric/datadog_test.exs
+++ b/apps/omg_status/test/omg_status/metric/datadog_test.exs
@@ -1,0 +1,38 @@
+# Copyright 2019 OmiseGO Pte Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defmodule OMG.Status.Metric.DatadogTest do
+  use ExUnit.Case, async: true
+  alias OMG.Status.Metric.Datadog
+
+  setup do
+    %{datadog: Datadog.start()}
+  end
+
+  test "if exiting process/port sends an exit signal to the parent process", %{datadog: {:ok, datadog_pid}} do
+    :erlang.trace(datadog_pid, true, [:receive])
+
+    {:ok, _} =
+      Task.start(fn ->
+        port = Port.open({:spawn, "cat"}, [:binary])
+        true = Process.link(datadog_pid)
+        true = Process.exit(port, :portkill)
+        # we want to exit because the port forcefully closes
+        # so this sleep shouldn't happen
+        Process.sleep(10_000)
+      end)
+
+    assert_receive {:trace, ^datadog_pid, :receive, {:EXIT, port, :portkill}}
+  end
+end

--- a/apps/omg_status/test/omg_status/metric/statsd_monitor_test.exs
+++ b/apps/omg_status/test/omg_status/metric/statsd_monitor_test.exs
@@ -1,0 +1,92 @@
+# Copyright 2019 OmiseGO Pte Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defmodule OMG.Status.Metric.StatsdMonitorTest do
+  use ExUnit.Case, async: true
+  alias OMG.Status.Metric.StatsdMonitor
+
+  setup do
+    {:ok, alarm_process} = __MODULE__.Alarm.start(self())
+
+    {:ok, statsd_monitor} =
+      StatsdMonitor.start_link(alarm_module: __MODULE__.Alarm, child_module: __MODULE__.StasdWrapper)
+
+    on_exit(fn ->
+      Process.exit(alarm_process, :cleanup)
+      Process.exit(statsd_monitor, :cleanup)
+    end)
+
+    %{
+      alarm_process: alarm_process,
+      statsd_monitor: statsd_monitor
+    }
+  end
+
+  test "if exiting process/port sends an exit signal to the parent process", %{alarm_process: alarm_process} do
+    :erlang.trace(alarm_process, true, [:receive])
+    assert_receive :got_raise_alarm
+  end
+
+  test "if exiting process/port sends an exit signal to the parent process 2", %{
+    alarm_process: alarm_process,
+    statsd_monitor: _statsd_monitor
+  } do
+    :erlang.trace(alarm_process, true, [:receive])
+    {:ok, statsd_wrapper} = __MODULE__.StasdWrapper.start()
+    assert_receive :got_clear_alarm
+    true = Process.exit(statsd_wrapper, :testkill)
+    assert_receive :got_raise_alarm
+    assert_receive :got_clear_alarm
+  end
+
+  defmodule Alarm do
+    use GenServer
+
+    def start(parent) do
+      GenServer.start(__MODULE__, [parent], name: __MODULE__)
+    end
+
+    def init([parent]) do
+      {:ok, %{parent: parent}}
+    end
+
+    def set({:statsd_client_connection, _node, OMG.Status.Metric.StatsdMonitor}) do
+      GenServer.call(__MODULE__, :got_raise_alarm)
+    end
+
+    def clear({:statsd_client_connection, _, OMG.Status.Metric.StatsdMonitor}) do
+      GenServer.call(__MODULE__, :got_clear_alarm)
+    end
+
+    def handle_call(:got_raise_alarm, _, state) do
+      {:reply, send(state.parent, :got_raise_alarm), state}
+    end
+
+    def handle_call(:got_clear_alarm, _, state) do
+      {:reply, send(state.parent, :got_clear_alarm), state}
+    end
+  end
+
+  defmodule StasdWrapper do
+    use GenServer
+
+    def start do
+      GenServer.start(__MODULE__, [], [])
+    end
+
+    def init(_) do
+      {:ok, %{}}
+    end
+  end
+end

--- a/apps/omg_watcher/config/config.exs
+++ b/apps/omg_watcher/config/config.exs
@@ -34,7 +34,7 @@ config :omg_watcher, OMG.Watcher.DB.Repo,
 config :omg_watcher, OMG.Watcher.Tracer,
   service: :db,
   adapter: SpandexDatadog.Adapter,
-  disabled?: {:system, "METRICS", false},
+  disabled?: {:system, "DD_DISABLED", false, {String, :to_existing_atom}},
   env: {:system, "APP_ENV"},
   type: :db
 

--- a/apps/omg_watcher/lib/omg_watcher/block_getter/measure.ex
+++ b/apps/omg_watcher/lib/omg_watcher/block_getter/measure.ex
@@ -29,6 +29,6 @@ defmodule OMG.Watcher.BlockGetter.Measure do
       |> Process.info(:message_queue_len)
       |> elem(1)
 
-    :ok = Datadog.gauge(name(:block_getter_message_queue_len), value)
+    _ = Datadog.gauge(name(:block_getter_message_queue_len), value)
   end
 end

--- a/apps/omg_watcher/lib/omg_watcher/eventer/measure.ex
+++ b/apps/omg_watcher/lib/omg_watcher/eventer/measure.ex
@@ -29,6 +29,6 @@ defmodule OMG.Watcher.Eventer.Measure do
       |> Process.info(:message_queue_len)
       |> elem(1)
 
-    :ok = Datadog.gauge(name(:eventer_message_queue_len), value)
+    _ = Datadog.gauge(name(:eventer_message_queue_len), value)
   end
 end

--- a/apps/omg_watcher/lib/omg_watcher/exit_processor/measure.ex
+++ b/apps/omg_watcher/lib/omg_watcher/exit_processor/measure.ex
@@ -26,6 +26,6 @@ defmodule OMG.Watcher.ExitProcessor.Measure do
       |> Process.info(:message_queue_len)
       |> elem(1)
 
-    :ok = Datadog.gauge(name(:watcher_exit_processor_message_queue_len), value)
+    _ = Datadog.gauge(name(:watcher_exit_processor_message_queue_len), value)
   end
 end

--- a/apps/omg_watcher/test/omg_watcher/api/alarm_test.exs
+++ b/apps/omg_watcher/test/omg_watcher/api/alarm_test.exs
@@ -21,17 +21,11 @@ defmodule OMG.Watcher.API.AlarmTest do
     system_alarm = {:system_memory_high_watermark, []}
     system_disk_alarm = {{:disk_almost_full, "/dev/null"}, []}
     app_alarm = {:ethereum_client_connection, %{node: Node.self(), reporter: __MODULE__}}
-
-    on_exit(fn ->
-      :alarm_handler.clear_alarm(app_alarm)
-      :alarm_handler.clear_alarm(system_alarm)
-      :alarm_handler.clear_alarm(system_disk_alarm)
-    end)
-
     %{system_alarm: system_alarm, system_disk_alarm: system_disk_alarm, app_alarm: app_alarm}
   end
 
   test "if alarms are returned when there are no alarms raised", _ do
+    _ = OMG.Status.Alert.Alarm.clear_all()
     {:ok, []} = Alarm.get_alarms()
   end
 
@@ -40,6 +34,7 @@ defmodule OMG.Watcher.API.AlarmTest do
     system_disk_alarm: system_disk_alarm,
     app_alarm: app_alarm
   } do
+    _ = OMG.Status.Alert.Alarm.clear_all()
     :alarm_handler.set_alarm(system_alarm)
     :alarm_handler.set_alarm(app_alarm)
     :alarm_handler.set_alarm(system_disk_alarm)

--- a/apps/omg_watcher_rpc/config/config.exs
+++ b/apps/omg_watcher_rpc/config/config.exs
@@ -15,7 +15,7 @@ config :omg_watcher_rpc, OMG.WatcherRPC.Web.Endpoint,
 config :omg_watcher_rpc, OMG.WatcherRPC.Tracer,
   service: :web,
   adapter: SpandexDatadog.Adapter,
-  disabled?: {:system, "METRICS", false},
+  disabled?: {:system, "DD_DISABLED", false, {String, :to_existing_atom}},
   env: {:system, "APP_ENV"},
   type: :web
 

--- a/apps/omg_watcher_rpc/test/omg_watcher_rpc/web/controllers/alarm_test.exs
+++ b/apps/omg_watcher_rpc/test/omg_watcher_rpc/web/controllers/alarm_test.exs
@@ -14,16 +14,28 @@
 
 defmodule OMG.WatcherRPC.Web.Controller.AlarmTest do
   use ExUnitFixtures
-  use ExUnit.Case, async: false
+  use ExUnit.Case, async: true
 
   use OMG.Fixtures
   use OMG.Watcher.Fixtures
   alias OMG.Watcher.TestHelper
 
+  setup do
+    Enum.each(
+      :gen_event.which_handlers(:alarm_handler),
+      fn handler ->
+        Enum.each(
+          :gen_event.call(:alarm_handler, handler, :get_alarms),
+          fn alarm -> :alarm_handler.clear_alarm(alarm) end
+        )
+      end
+    )
+  end
+
   ### a very basic test of empty alarms should be sufficient, alarms encoding is
   ### covered in OMG.Utils.HttpRPC.ResponseTest
   @tag fixtures: [:phoenix_ecto_sandbox, :db_initialized]
-  test "if the controller returns the correct result when there's no alarms raised" do
+  test "if the controller returns the correct result when there's no alarms raised", _ do
     assert [] == TestHelper.success?("alarm.get")
   end
 end

--- a/apps/omg_watcher_rpc/test/omg_watcher_rpc/web/controllers/alarm_test.exs
+++ b/apps/omg_watcher_rpc/test/omg_watcher_rpc/web/controllers/alarm_test.exs
@@ -22,13 +22,8 @@ defmodule OMG.WatcherRPC.Web.Controller.AlarmTest do
 
   setup do
     Enum.each(
-      :gen_event.which_handlers(:alarm_handler),
-      fn handler ->
-        Enum.each(
-          :gen_event.call(:alarm_handler, handler, :get_alarms),
-          fn alarm -> :alarm_handler.clear_alarm(alarm) end
-        )
-      end
+      :gen_event.call(:alarm_handler, OMG.Status.Alert.AlarmHandler, :get_alarms),
+      fn alarm -> :alarm_handler.clear_alarm(alarm) end
     )
   end
 

--- a/docker-compose-watcher.yml
+++ b/docker-compose-watcher.yml
@@ -28,6 +28,8 @@ services:
       - RINKEBY_AUTHORITY_ADDRESS=0x41863dafbdf8cfc2a33fc38c0b525b6343d857b3
       - DATABASE_URL=postgres://omisego_dev:omisego_dev@postgres:5432/omisego_dev
       - NODE_HOST=127.0.0.1
+      - DD_DISABLED=true
+      - APP_ENV=localwatcher
     ports:
       - "7434:7434"
     healthcheck:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -63,6 +63,7 @@ services:
       - ERL_CC_COOKIE=develop
       - APP_ENV=local_development_child_chain
       - DD_HOSTNAME=datadog
+      - DD_DISABLED=true
     restart: always
     ports:
       - "9656:9656"
@@ -94,6 +95,7 @@ services:
       - ERL_W_COOKIE=develop
       - APP_ENV=local_development_watcher
       - DD_HOSTNAME=datadog
+      - DD_DISABLED=true
     restart: always
     ports:
       - "7434:7434"


### PR DESCRIPTION
Statsd connection can drop and it shouldn't be attached to the application process. If it drops it'll take the application with it.

## Overview

## Changes

Describe your changes and implementation choices. More details make PRs easier to review.

- Process monitoring with alarm raising
- excluding Datadog when `DD_DISABLED=true`
- flag to optionally include ROCKSDB 

## Testing

Describe how to test your new feature/bug fix and if possible, a step by step guide on how to demo this.
