### PR TITLE
refactor: move the signed_tx_bytes entry from Signed to Recovered

### DIFF
--- a/apps/omg/lib/omg/block.ex
+++ b/apps/omg/lib/omg/block.ex
@@ -91,10 +91,7 @@ defmodule OMG.Block do
 
   # extracts the necessary data from a single transaction to include in a block and merkle hash
   # add more clauses to form blocks from other forms of transactions
-  defp get_data_per_tx(%Transaction.Recovered{
-         tx_hash: hash,
-         signed_tx: %Transaction.Signed{signed_tx_bytes: bytes}
-       }) do
+  defp get_data_per_tx(%Transaction.Recovered{tx_hash: hash, signed_tx_bytes: bytes}) do
     {bytes, hash}
   end
 

--- a/apps/omg/test/support/crypto.ex
+++ b/apps/omg/test/support/crypto.ex
@@ -48,9 +48,7 @@ defmodule OMG.DevCrypto do
   @spec sign(Transaction.t(), list(Crypto.priv_key_t())) :: Transaction.Signed.t()
   def sign(%Transaction{} = tx, private_keys) do
     sigs = Enum.map(private_keys, fn pk -> signature(tx, pk) end)
-
-    transaction = %Transaction.Signed{raw_tx: tx, sigs: sigs}
-    %{transaction | signed_tx_bytes: Transaction.Signed.encode(transaction)}
+    %Transaction.Signed{raw_tx: tx, sigs: sigs}
   end
 
   @doc """

--- a/apps/omg_watcher/lib/omg_watcher/db/transaction.ex
+++ b/apps/omg_watcher/lib/omg_watcher/db/transaction.ex
@@ -166,11 +166,8 @@ defmodule OMG.Watcher.DB.Transaction do
   @spec process(Transaction.Recovered.t(), pos_integer(), integer(), list()) :: [list()]
   defp process(
          %Transaction.Recovered{
-           signed_tx:
-             %Transaction.Signed{
-               signed_tx_bytes: signed_tx_bytes,
-               raw_tx: %Transaction{metadata: metadata}
-             } = tx
+           signed_tx: %Transaction.Signed{raw_tx: %Transaction{metadata: metadata}} = tx,
+           signed_tx_bytes: signed_tx_bytes
          },
          block_number,
          txindex,

--- a/apps/omg_watcher/lib/omg_watcher/exit_processor/in_flight_exit_info.ex
+++ b/apps/omg_watcher/lib/omg_watcher/exit_processor/in_flight_exit_info.ex
@@ -198,7 +198,6 @@ defmodule OMG.Watcher.ExitProcessor.InFlightExitInfo do
     {ife_hash, struct!(__MODULE__, ife_map)}
   end
 
-  # NOTE: the databases currently don't hold the `signed_tx_bytes` field, hence dropping this here and in the other fun.
   # NOTE: non-private because `CompetitorInfo` holds `Transaction.Signed` objects too
   def from_db_signed_tx(%{raw_tx: raw_tx_map, sigs: sigs}) when is_map(raw_tx_map) and is_list(sigs) do
     value = %{raw_tx: from_db_raw_tx(raw_tx_map), sigs: sigs}


### PR DESCRIPTION
This is just clean-up, but will be useful for #844 to have it done.

## Overview

As title. This is much tidier. `signed_tx_bytes` held there is useful only when we're operating on the `Transaction.Recovered` structure. Storing it in `Transaction.Signed` was awkward and confusing

## Changes

Move `:signed_tx_bytes` filed from `Transaction.Signed` to `Transaction.Recovered`

## Testing

Everything covered in tests as it was + no modifications to tests necessary :tada: 