### PR TITLE
Refactor child chain transaction processing to accomodate transaction types

### DIFF
--- a/apps/omg/lib/omg/state/measurement_calculation.ex
+++ b/apps/omg/lib/omg/state/measurement_calculation.ex
@@ -18,6 +18,8 @@ defmodule OMG.State.MeasurementCalculation do
   alias OMG.Eth.Encoding
   alias OMG.State.Core
 
+  # TODO: functions here reach uncleanly into the UtxoSet (not going through `OMG.State.UtxoSet`) - is this bad?
+
   def calculate(%Core{utxos: utxos}) do
     balance =
       Enum.map(

--- a/apps/omg/lib/omg/state/transaction/markers.ex
+++ b/apps/omg/lib/omg/state/transaction/markers.ex
@@ -1,0 +1,20 @@
+# Copyright 2019 OmiseGO Pte Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defmodule OMG.State.Transaction.Markers do
+  @moduledoc """
+  Collection of binary markers to decode the transaction type
+  """
+  def payment, do: <<188, 97, 78>>
+end

--- a/apps/omg/lib/omg/state/transaction/output_predicate_protocol.ex
+++ b/apps/omg/lib/omg/state/transaction/output_predicate_protocol.ex
@@ -1,0 +1,28 @@
+# Copyright 2019 OmiseGO Pte Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defmodule OMG.State.Transaction.OutputPredicateProtocol do
+  @moduledoc """
+  Code allowing outputs being spent by txs to be unlocked.
+
+  Intended to be called in stateful validation
+  """
+
+  @doc """
+  True if a particular witness can unlock a particular output to be spent, given being put in a particular transaction
+  """
+  def can_spend?(witness, output_spent, _raw_tx) when is_binary(witness) do
+    output_spent.owner == witness
+  end
+end

--- a/apps/omg/lib/omg/state/transaction/payment.ex
+++ b/apps/omg/lib/omg/state/transaction/payment.ex
@@ -1,0 +1,330 @@
+# Copyright 2019 OmiseGO Pte Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defmodule OMG.State.Transaction.Payment do
+  @moduledoc """
+      Internal representation of a payment transaction done on Plasma chain.
+
+      This module holds the representation of a "raw" transaction, i.e. without signatures nor recovered input spenders
+  """
+  alias OMG.Crypto
+  alias OMG.State.Transaction
+  alias OMG.Utxo
+
+  require Transaction
+  require Utxo
+
+  @default_metadata nil
+
+  @zero_address OMG.Eth.zero_address()
+
+  defstruct [:inputs, :outputs, metadata: @default_metadata]
+
+  @type t() :: %__MODULE__{
+          inputs: list(input()),
+          outputs: list(output()),
+          metadata: Transaction.metadata()
+        }
+
+  @type input() :: %{
+          blknum: non_neg_integer(),
+          txindex: non_neg_integer(),
+          oindex: non_neg_integer()
+        }
+
+  @type output() :: %{
+          owner: Crypto.address_t(),
+          currency: currency(),
+          amount: non_neg_integer()
+        }
+  @type currency() :: Crypto.address_t()
+
+  @max_inputs 4
+  @max_outputs 4
+
+  defmacro is_metadata(metadata) do
+    quote do
+      unquote(metadata) == nil or (is_binary(unquote(metadata)) and byte_size(unquote(metadata)) == 32)
+    end
+  end
+
+  defmacro max_inputs do
+    quote do
+      unquote(@max_inputs)
+    end
+  end
+
+  defmacro max_outputs do
+    quote do
+      unquote(@max_outputs)
+    end
+  end
+
+  @doc """
+  Creates a new transaction from a list of inputs and a list of outputs.
+  Adds empty (zeroes) inputs and/or outputs to reach the expected size
+  of `@max_inputs` inputs and `@max_outputs` outputs.
+
+  assumptions:
+  ```
+    length(inputs) <= @max_inputs
+    length(outputs) <= @max_outputs
+  ```
+  """
+  @spec new(
+          list({pos_integer, pos_integer, 0..3}),
+          list({Crypto.address_t(), currency(), pos_integer}),
+          Transaction.metadata()
+        ) :: t()
+  def new(inputs, outputs, metadata \\ @default_metadata)
+
+  def new(inputs, outputs, metadata)
+      when is_metadata(metadata) and length(inputs) <= @max_inputs and length(outputs) <= @max_outputs do
+    inputs =
+      inputs
+      |> Enum.map(fn {blknum, txindex, oindex} -> %{blknum: blknum, txindex: txindex, oindex: oindex} end)
+
+    inputs = inputs ++ List.duplicate(%{blknum: 0, txindex: 0, oindex: 0}, @max_inputs - Kernel.length(inputs))
+
+    outputs =
+      outputs
+      |> Enum.map(fn {owner, currency, amount} -> %{owner: owner, currency: currency, amount: amount} end)
+
+    outputs =
+      outputs ++
+        List.duplicate(
+          %{owner: @zero_address, currency: @zero_address, amount: 0},
+          @max_outputs - Kernel.length(outputs)
+        )
+
+    %__MODULE__{inputs: inputs, outputs: outputs, metadata: metadata}
+  end
+
+  @doc """
+  Transaform the structure of RLP items after a successful RLP decode of a raw transaction, into a structure instance
+  """
+  def reconstruct([inputs_rlp, outputs_rlp | rest_rlp])
+      when rest_rlp == [] or length(rest_rlp) == 1 do
+    with {:ok, inputs} <- reconstruct_inputs(inputs_rlp),
+         {:ok, outputs} <- reconstruct_outputs(outputs_rlp),
+         {:ok, metadata} <- reconstruct_metadata(rest_rlp),
+         do: {:ok, %__MODULE__{inputs: inputs, outputs: outputs, metadata: metadata}}
+  end
+
+  def reconstruct(_), do: {:error, :malformed_transaction}
+
+  defp reconstruct_inputs(inputs_rlp) do
+    Enum.map(inputs_rlp, fn [blknum, txindex, oindex] ->
+      %{blknum: parse_int(blknum), txindex: parse_int(txindex), oindex: parse_int(oindex)}
+    end)
+    |> inputs_without_gaps()
+  rescue
+    _ -> {:error, :malformed_inputs}
+  end
+
+  defp reconstruct_outputs(outputs_rlp) do
+    outputs =
+      Enum.map(outputs_rlp, fn [owner, currency, amount] ->
+        with {:ok, cur12} <- parse_address(currency),
+             {:ok, owner} <- parse_address(owner) do
+          %{owner: owner, currency: cur12, amount: parse_int(amount)}
+        end
+      end)
+
+    if(error = Enum.find(outputs, &match?({:error, _}, &1)),
+      do: error,
+      else: outputs
+    )
+    |> outputs_without_gaps()
+  rescue
+    _ -> {:error, :malformed_outputs}
+  end
+
+  defp reconstruct_metadata([]), do: {:ok, nil}
+  defp reconstruct_metadata([metadata]) when Transaction.is_metadata(metadata), do: {:ok, metadata}
+  defp reconstruct_metadata([_]), do: {:error, :malformed_metadata}
+
+  defp parse_int(binary), do: :binary.decode_unsigned(binary, :big)
+
+  # necessary, because RLP handles empty string equally to integer 0
+  @spec parse_address(<<>> | Crypto.address_t()) :: {:ok, Crypto.address_t()} | {:error, :malformed_address}
+  defp parse_address(binary)
+  defp parse_address(""), do: {:ok, <<0::160>>}
+  defp parse_address(<<_::160>> = address_bytes), do: {:ok, address_bytes}
+  defp parse_address(_), do: {:error, :malformed_address}
+
+  defp inputs_without_gaps(inputs),
+    do: check_for_gaps(inputs, %{blknum: 0, txindex: 0, oindex: 0}, {:error, :inputs_contain_gaps})
+
+  defp outputs_without_gaps({:error, _} = error), do: error
+
+  defp outputs_without_gaps(outputs),
+    do:
+      check_for_gaps(
+        outputs,
+        %{owner: @zero_address, currency: @zero_address, amount: 0},
+        {:error, :outputs_contain_gaps}
+      )
+
+  # Check if any consecutive pair of elements contains empty followed by non-empty element
+  # which means there is a gap
+  defp check_for_gaps(items, empty, error) do
+    items
+    # discard - discards last unpaired element from a comparison
+    |> Stream.chunk_every(2, 1, :discard)
+    |> Enum.any?(fn
+      [^empty, elt] when elt != empty -> true
+      _ -> false
+    end)
+    |> if(do: error, else: {:ok, items})
+  end
+end
+
+defimpl OMG.State.Transaction.Protocol, for: OMG.State.Transaction.Payment do
+  alias OMG.State.Transaction
+  alias OMG.Utxo
+
+  require Transaction
+  require Utxo
+  require Transaction.Payment
+
+  @zero_address OMG.Eth.zero_address()
+  @empty_signature <<0::size(520)>>
+
+  # TODO: commented code for the tx markers handling
+  # @payment_marker Transaction.Markers.payment()
+  #
+  # end commented code
+
+  @doc """
+  Turns a structure instance into a structure of RLP items, ready to be RLP encoded, for a raw transaction
+  """
+  def get_data_for_rlp(%Transaction.Payment{inputs: inputs, outputs: outputs, metadata: metadata})
+      when Transaction.Payment.is_metadata(metadata),
+      do:
+        [
+          # TODO: commented code for the tx markers handling
+          # @payment_marker,
+          # contract expects 4 inputs and outputs
+          Enum.map(inputs, fn %{blknum: blknum, txindex: txindex, oindex: oindex} -> [blknum, txindex, oindex] end) ++
+            List.duplicate([0, 0, 0], 4 - length(inputs)),
+          Enum.map(outputs, fn %{owner: owner, currency: currency, amount: amount} -> [owner, currency, amount] end) ++
+            List.duplicate([@zero_address, @zero_address, 0], 4 - length(outputs))
+        ] ++ if(metadata, do: [metadata], else: [])
+
+  def get_outputs(%Transaction.Payment{outputs: outputs}) do
+    outputs
+    |> Enum.reject(&match?(%{owner: @zero_address, currency: @zero_address, amount: 0}, &1))
+  end
+
+  def get_inputs(%Transaction.Payment{inputs: inputs}) do
+    inputs
+    |> Enum.map(fn %{blknum: blknum, txindex: txindex, oindex: oindex} -> Utxo.position(blknum, txindex, oindex) end)
+    |> Enum.filter(&Utxo.Position.non_zero?/1)
+  end
+
+  @doc """
+  True if the witnessses provided follow some extra custom validation.
+
+  Currently this covers the requirement for all the inputs to be signed on predetermined positions
+  """
+  def valid?(%Transaction.Payment{}, %Transaction.Signed{sigs: sigs} = tx) do
+    tx
+    |> Transaction.get_inputs()
+    |> all_inputs_signed?(sigs)
+  end
+
+  @doc """
+  True if a payment can be applied, given a set of input UTXOs is present in the ledger.
+  Involves the checking of balancing of inputs and outputs for currencies
+
+  Returns the fees that this transaction is paying, mapped by currency
+  """
+  @spec can_apply?(Transaction.Payment.t(), list(Utxo.t())) :: {:ok, map()} | {:error, :amounts_do_not_add_up}
+  def can_apply?(%Transaction.Payment{} = tx, input_utxos) do
+    outputs = Transaction.get_outputs(tx)
+
+    input_amounts_by_currency = get_amounts_by_currency(input_utxos)
+    output_amounts_by_currency = get_amounts_by_currency(outputs)
+
+    with :ok <- amounts_add_up?(input_amounts_by_currency, output_amounts_by_currency),
+         do: {:ok, fees_paid(input_amounts_by_currency, output_amounts_by_currency)}
+  end
+
+  @doc """
+  Effects of a payment transaction - spends all inputs and creates all outputs
+  """
+  def get_effects(%Transaction.Payment{} = tx, blknum, tx_index) do
+    new_utxos_map = tx |> non_zero_utxos_from(blknum, tx_index) |> Map.new()
+    spent_input_pointers = Transaction.get_inputs(tx)
+    {spent_input_pointers, new_utxos_map}
+  end
+
+  defp all_inputs_signed?(non_zero_inputs, sigs) do
+    count_non_zero_signatures = Enum.count(sigs, &(&1 != @empty_signature))
+    count_non_zero_inputs = length(non_zero_inputs)
+
+    cond do
+      count_non_zero_signatures > count_non_zero_inputs -> {:error, :superfluous_signature}
+      count_non_zero_signatures < count_non_zero_inputs -> {:error, :missing_signature}
+      true -> true
+    end
+  end
+
+  defp non_zero_utxos_from(tx, blknum, tx_index) do
+    tx
+    |> utxos_from(blknum, tx_index)
+    |> Enum.filter(fn {_key, value} -> is_non_zero_amount?(value) end)
+  end
+
+  defp utxos_from(tx, blknum, tx_index) do
+    hash = Transaction.raw_txhash(tx)
+
+    tx
+    |> Transaction.get_outputs()
+    |> Enum.with_index()
+    |> Enum.map(fn {%{owner: owner, currency: currency, amount: amount}, oindex} ->
+      {Utxo.position(blknum, tx_index, oindex),
+       %Utxo{owner: owner, currency: currency, amount: amount, creating_txhash: hash}}
+    end)
+  end
+
+  defp is_non_zero_amount?(%{amount: 0}), do: false
+  defp is_non_zero_amount?(%{amount: _}), do: true
+
+  defp fees_paid(input_amounts_by_currency, output_amounts_by_currency) do
+    input_amounts_by_currency
+    |> Enum.into(%{}, fn {input_currency, input_amount} ->
+      # fee is implicit - it's the difference between funds owned and spend
+      implicit_paid_fee = input_amount - Map.get(output_amounts_by_currency, input_currency, 0)
+      {input_currency, implicit_paid_fee}
+    end)
+  end
+
+  defp get_amounts_by_currency(utxos) do
+    utxos
+    |> Enum.group_by(fn %{currency: currency} -> currency end, fn %{amount: amount} -> amount end)
+    |> Enum.map(fn {currency, amounts} -> {currency, Enum.sum(amounts)} end)
+    |> Map.new()
+  end
+
+  defp amounts_add_up?(input_amounts, output_amounts) do
+    for {output_currency, output_amount} <- Map.to_list(output_amounts) do
+      input_amount = Map.get(input_amounts, output_currency, 0)
+      input_amount >= output_amount
+    end
+    |> Enum.all?()
+    |> if(do: :ok, else: {:error, :amounts_do_not_add_up})
+  end
+end

--- a/apps/omg/lib/omg/state/transaction/protocol.ex
+++ b/apps/omg/lib/omg/state/transaction/protocol.ex
@@ -1,0 +1,61 @@
+# Copyright 2019 OmiseGO Pte Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defprotocol OMG.State.Transaction.Protocol do
+  @moduledoc """
+  Should be implemented for any type of transaction processed in the system
+  """
+
+  alias OMG.State.Transaction
+
+  @doc """
+  Transforms structured data into RLP-structured (encodable) list of fields
+  """
+  @spec get_data_for_rlp(t()) :: list(any())
+  def get_data_for_rlp(tx)
+
+  @doc """
+  List of input pointers (e.g. of which one implementation is `utxo_pos`) this transaction is intending to spend
+  """
+  @spec get_inputs(t()) :: list(any())
+  def get_inputs(tx)
+
+  @doc """
+  List of outputs this transaction intends to create
+  """
+  @spec get_outputs(t()) :: list(any())
+  def get_outputs(tx)
+
+  @doc """
+  Custom validation of the transaction with respect to its witnesses. Part of stateless validation routine
+  """
+  @spec valid?(t(), Transaction.Signed.t()) :: true | {:error, atom}
+  def valid?(tx, signed_tx)
+
+  @doc """
+  Custom stateful validity, based on pre-fetched subset of input UTXOs
+
+  Should also return the fees that this transaction is paying, mapped by currency; for fee validation
+  """
+  @spec can_apply?(t(), list()) :: {:ok, map()} | {:error, atom}
+  def can_apply?(tx, input_utxos)
+
+  @doc """
+  Effects of transaction application
+
+  Should return a tuple consisting of input pointers to be spent and new UTXOs to create
+  """
+  @spec get_effects(t(), non_neg_integer(), non_neg_integer()) :: {list(), map()}
+  def get_effects(tx, blknum, tx_index)
+end

--- a/apps/omg/lib/omg/state/transaction/signed.ex
+++ b/apps/omg/lib/omg/state/transaction/signed.ex
@@ -21,16 +21,16 @@ defmodule OMG.State.Transaction.Signed do
 
   alias OMG.Crypto
   alias OMG.State.Transaction
+  alias OMG.State.Transaction.Witness
   alias OMG.TypedDataHash
 
-  @signature_length 65
-  @empty_signature <<0::size(520)>>
   @type tx_bytes() :: binary()
+  @empty_signature <<0::size(520)>>
 
   defstruct [:raw_tx, :sigs]
 
   @type t() :: %__MODULE__{
-          raw_tx: Transaction.t(),
+          raw_tx: Transaction.Protocol.t(),
           sigs: [Crypto.sig_t()]
         }
 
@@ -38,11 +38,8 @@ defmodule OMG.State.Transaction.Signed do
   Produce a binary form of a signed transaction - coerces into RLP-encodeable structure and RLP encodes
   """
   @spec encode(t()) :: tx_bytes()
-  def encode(%__MODULE__{
-        raw_tx: raw_tx,
-        sigs: sigs
-      }) do
-    [sigs | Transaction.get_data_for_rlp(raw_tx)]
+  def encode(%__MODULE__{raw_tx: %{} = raw_tx, sigs: sigs}) do
+    [sigs | Transaction.Protocol.get_data_for_rlp(raw_tx)]
     |> ExRLP.encode()
   end
 
@@ -52,8 +49,8 @@ defmodule OMG.State.Transaction.Signed do
   """
   @spec decode(tx_bytes()) :: {:ok, t()} | {:error, atom}
   def decode(signed_tx_bytes) do
-    with {:ok, raw_tx_rlp_decoded_chunks} <- try_exrlp_decode(signed_tx_bytes),
-         do: reconstruct(raw_tx_rlp_decoded_chunks)
+    with {:ok, tx_rlp_decoded_chunks} <- generic_decode(signed_tx_bytes),
+         do: reconstruct(tx_rlp_decoded_chunks)
   end
 
   @doc """
@@ -66,49 +63,49 @@ defmodule OMG.State.Transaction.Signed do
   end
 
   @doc """
-  Recovers the spenders for non-empty signatures, in the order they appear in transaction's signatures
+  Recovers the witnesses for non-empty signatures, in the order they appear in transaction's signatures
   """
-  @spec get_spenders(t()) :: {:ok, list(Crypto.address_t())} | {:error, atom}
-  def get_spenders(%Transaction.Signed{raw_tx: raw_tx, sigs: sigs}) do
-    hash_without_sigs = TypedDataHash.hash_struct(raw_tx)
+  @spec get_witnesses(Transaction.Signed.t()) :: {:ok, list(Crypto.address_t())} | {:error, atom}
+  def get_witnesses(%Transaction.Signed{raw_tx: raw_tx, sigs: raw_witnesses}) do
+    raw_txhash = TypedDataHash.hash_struct(raw_tx)
 
-    with {:ok, reversed_spenders} <- get_reversed_spenders(hash_without_sigs, sigs),
-         do: {:ok, Enum.reverse(reversed_spenders)}
+    with {:ok, reversed_witnesses} <- get_reversed_witnesses(raw_txhash, raw_tx, raw_witnesses),
+         do:
+           {:ok,
+            reversed_witnesses
+            |> Enum.reverse()
+            |> Enum.with_index()
+            |> Enum.into(%{}, fn {witness, idx} -> {idx, witness} end)}
   end
 
-  defp get_reversed_spenders(hash_without_sigs, sigs) do
-    sigs
-    |> Enum.filter(fn sig -> sig != @empty_signature end)
-    |> Enum.reduce_while({:ok, []}, fn sig, acc -> get_spender(hash_without_sigs, sig, acc) end)
+  defp get_reversed_witnesses(raw_txhash, raw_tx, raw_witnesses) do
+    raw_witnesses
+    # TODO: move this check out of here and make generic?
+    #       (or remove altogether - this covers the padding using empty signatures, which might be going away)
+    |> Enum.filter(fn raw_witness -> raw_witness != @empty_signature end)
+    |> Enum.reduce_while({:ok, []}, fn raw_witness, acc -> get_witness(raw_txhash, raw_tx, raw_witness, acc) end)
   end
 
-  defp get_spender(hash_without_sigs, sig, {:ok, spenders}) do
-    Crypto.recover_address(hash_without_sigs, sig)
+  defp get_witness(raw_txhash, raw_tx, raw_witness, {:ok, witnesses}) do
+    Witness.recover(raw_witness, raw_txhash, raw_tx)
     |> case do
-      {:ok, spender} -> {:cont, {:ok, [spender | spenders]}}
+      {:ok, witness} -> {:cont, {:ok, [witness | witnesses]}}
       error -> {:halt, error}
     end
   end
 
-  defp try_exrlp_decode(signed_tx_bytes) do
+  defp generic_decode(signed_tx_bytes) do
     {:ok, ExRLP.decode(signed_tx_bytes)}
   rescue
     _ -> {:error, :malformed_transaction_rlp}
   end
 
-  defp reconstruct([sigs | raw_tx_rlp_decoded_chunks]) do
-    with true <- is_list(sigs),
-         true <- Enum.all?(sigs, &signature_length?/1),
-         {:ok, raw_tx} <- Transaction.reconstruct(raw_tx_rlp_decoded_chunks) do
-      {:ok, %__MODULE__{raw_tx: raw_tx, sigs: sigs}}
-    else
-      false -> {:error, :malformed_signatures}
-      err -> err
-    end
+  def reconstruct([raw_witnesses | typed_tx_rlp_decoded_chunks]) do
+    with true <- is_list(raw_witnesses) || {:error, :malformed_witnesses},
+         true <- Enum.all?(raw_witnesses, &Witness.valid?/1) || {:error, :malformed_witnesses},
+         {:ok, raw_tx} <- Transaction.dispatching_reconstruct(typed_tx_rlp_decoded_chunks),
+         do: {:ok, %Transaction.Signed{raw_tx: raw_tx, sigs: raw_witnesses}}
   end
 
-  defp reconstruct(_), do: {:error, :malformed_transaction}
-
-  defp signature_length?(sig) when byte_size(sig) == @signature_length, do: true
-  defp signature_length?(_sig), do: false
+  def reconstruct(_), do: {:error, :malformed_transaction}
 end

--- a/apps/omg/lib/omg/state/transaction/witness.ex
+++ b/apps/omg/lib/omg/state/transaction/witness.ex
@@ -1,0 +1,39 @@
+# Copyright 2019 OmiseGO Pte Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defmodule OMG.State.Transaction.Witness do
+  @moduledoc """
+  Code required to validate and recover raw witnesses (e.g. signatures) goes here.
+
+  These should be called by the stateless validation, in order to put load off stateful validation (i.e. sig recovery)
+  """
+  alias OMG.Crypto
+  @signature_length 65
+
+  @type t :: Crypto.address_t()
+
+  @doc """
+  Pre-check done after decoding to quickly assert whether the witness has one of valid forms
+  """
+  def valid?(witness) when is_binary(witness), do: signature_length?(witness)
+
+  @doc """
+  Prepares the witness to be quickly used in stateful validation
+  """
+  def recover(raw_witness, raw_txhash, _raw_tx) when is_binary(raw_witness),
+    do: Crypto.recover_address(raw_txhash, raw_witness)
+
+  defp signature_length?(sig) when byte_size(sig) == @signature_length, do: true
+  defp signature_length?(_sig), do: false
+end

--- a/apps/omg/lib/omg/state/utxo_set.ex
+++ b/apps/omg/lib/omg/state/utxo_set.ex
@@ -1,0 +1,89 @@
+# Copyright 2019 OmiseGO Pte Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defmodule OMG.State.UtxoSet do
+  @moduledoc """
+  Handles all the operations done on the UTXOs held in the ledger
+
+  It will provide the requested UTXOs by a collection of inputs, trade in transaction effects (new utxos, utxos to delete).
+
+  It also translates the modifications to it into DB updates, and is able to interpret the UTXO query result from DB
+  """
+
+  alias OMG.Utxo
+
+  require Utxo
+
+  def init(utxos_query_result) do
+    Enum.into(utxos_query_result, %{}, fn {db_position, db_utxo} ->
+      {Utxo.Position.from_db_key(db_position), Utxo.from_db_value(db_utxo)}
+    end)
+  end
+
+  @doc """
+  Provides the outputs that are pointed by `inputs` provided
+  """
+  def get_by_inputs(utxos, inputs) do
+    inputs
+    |> Enum.reduce_while({:ok, []}, fn input, acc -> get_utxo(utxos, input, acc) end)
+    |> reverse()
+  end
+
+  @doc """
+  Updates itself given a list of spent input pointers and a map of UTXOs created upon a transaction
+  """
+  def apply_effects(utxos, spent_input_pointers, new_utxos_map) do
+    utxos |> Map.drop(spent_input_pointers) |> Map.merge(new_utxos_map)
+  end
+
+  @doc """
+  Returns the DB updates required given a list of spent input pointers and a map of UTXOs created upon a transaction
+  """
+  @spec db_updates(list(Utxo.Position.t()), %{Utxo.Position.t() => Utxo.t()}) ::
+          list({:put, :utxo, {Utxo.Position.db_t(), Utxo.t()}} | {:delete, :utxo, Utxo.Position.db_t()})
+  def db_updates(spent_input_pointers, new_utxos_map) do
+    db_updates_new_utxos = new_utxos_map |> Enum.map(&utxo_to_db_put/1)
+    db_updates_spent_utxos = spent_input_pointers |> Enum.map(&utxo_to_db_delete/1)
+    Enum.concat(db_updates_new_utxos, db_updates_spent_utxos)
+  end
+
+  def exists?(utxos, input_pointer),
+    do: Map.has_key?(utxos, input_pointer)
+
+  @doc """
+  Searches the UTXO set for a particular UTXO created with a `tx_hash` on `oindex` position.
+
+  Current implementation is **expensive**
+  """
+  def scan_for_matching_utxo(utxos, tx_hash, oindex) do
+    Enum.find(utxos, &match?({Utxo.position(_, _, ^oindex), %Utxo{creating_txhash: ^tx_hash}}, &1))
+  end
+
+  defp get_utxo(utxos, position, {:ok, acc}) do
+    case Map.get(utxos, position) do
+      nil -> {:halt, {:error, :utxo_not_found}}
+      found -> {:cont, {:ok, [found | acc]}}
+    end
+  end
+
+  defp utxo_to_db_put({utxo_pos, utxo}),
+    do: {:put, :utxo, {Utxo.Position.to_db_key(utxo_pos), Utxo.to_db_value(utxo)}}
+
+  defp utxo_to_db_delete(utxo_pos),
+    do: {:delete, :utxo, Utxo.Position.to_db_key(utxo_pos)}
+
+  @spec reverse({:ok, any()} | {:error, :utxo_not_found}) :: {:ok, list(any())} | {:error, :utxo_not_found}
+  defp reverse({:ok, input_utxos}), do: {:ok, Enum.reverse(input_utxos)}
+  defp reverse({:error, :utxo_not_found} = result), do: result
+end

--- a/apps/omg/lib/omg/typed_data_hash.ex
+++ b/apps/omg/lib/omg/typed_data_hash.ex
@@ -38,14 +38,14 @@ defmodule OMG.TypedDataHash do
   @doc """
   Computes a hash of encoded transaction as defined in EIP-712
   """
-  @spec hash_struct(Transaction.t(), Crypto.domain_separator_t()) :: Crypto.hash_t()
-  def hash_struct(raw_tx, domain_separator \\ nil) do
+  @spec hash_struct(Transaction.Payment.t(), Crypto.domain_separator_t()) :: Crypto.hash_t()
+  def hash_struct(%Transaction.Payment{} = raw_tx, domain_separator \\ nil) do
     domain_separator = domain_separator || __MODULE__.Config.domain_separator_from_config()
     Crypto.hash(@eip_191_prefix <> domain_separator <> hash_transaction(raw_tx))
   end
 
-  @spec hash_transaction(Transaction.t()) :: Crypto.hash_t()
-  def hash_transaction(raw_tx) do
+  @spec hash_transaction(Transaction.Payment.t()) :: Crypto.hash_t()
+  def hash_transaction(%Transaction.Payment{} = raw_tx) do
     __MODULE__.Tools.hash_transaction(
       Transaction.get_inputs(raw_tx),
       Transaction.get_outputs(raw_tx),

--- a/apps/omg/lib/omg/typed_data_hash/tools.ex
+++ b/apps/omg/lib/omg/typed_data_hash/tools.ex
@@ -70,25 +70,25 @@ defmodule OMG.TypedDataHash.Tools do
 
   @spec hash_transaction(
           list(Utxo.Position.t()),
-          list(Transaction.output()),
+          list(Transaction.Payment.output()),
           Transaction.metadata(),
           Crypto.hash_t(),
           Crypto.hash_t()
         ) :: Crypto.hash_t()
   def hash_transaction(inputs, outputs, metadata, empty_input_hash, empty_output_hash) do
-    require Transaction
+    require Transaction.Payment
 
     input_hashes =
       inputs
       |> Stream.map(&hash_input/1)
       |> Stream.concat(Stream.cycle([empty_input_hash]))
-      |> Enum.take(Transaction.max_inputs())
+      |> Enum.take(Transaction.Payment.max_inputs())
 
     output_hashes =
       outputs
       |> Stream.map(&hash_output/1)
       |> Stream.concat(Stream.cycle([empty_output_hash]))
-      |> Enum.take(Transaction.max_outputs())
+      |> Enum.take(Transaction.Payment.max_outputs())
 
     [
       @transaction_type_hash,
@@ -113,7 +113,7 @@ defmodule OMG.TypedDataHash.Tools do
     |> Crypto.hash()
   end
 
-  @spec hash_output(Transaction.output()) :: Crypto.hash_t()
+  @spec hash_output(Transaction.Payment.output()) :: Crypto.hash_t()
   def hash_output(%{owner: owner, currency: currency, amount: amount}) do
     [
       @output_type_hash,

--- a/apps/omg/test/omg/crypto_test.exs
+++ b/apps/omg/test/omg/crypto_test.exs
@@ -62,7 +62,7 @@ defmodule OMG.CryptoTest do
     {:ok, pub} = DevCrypto.generate_public_key(priv)
     {:ok, address} = Crypto.generate_address(pub)
 
-    raw_tx = Transaction.new([{1000, 1, 0}], [])
+    raw_tx = Transaction.Payment.new([{1000, 1, 0}], [])
     signature = DevCrypto.signature(raw_tx, priv)
     assert byte_size(signature) == 65
 
@@ -73,7 +73,7 @@ defmodule OMG.CryptoTest do
              |> (&match?({:ok, ^address}, &1)).()
 
     assert false ==
-             Transaction.new([{1000, 0, 1}], [])
+             Transaction.Payment.new([{1000, 0, 1}], [])
              |> TypedDataHash.hash_struct()
              |> Crypto.recover_address(signature)
              |> (&match?({:ok, ^address}, &1)).()

--- a/apps/omg/test/omg/dependency_conformance/signature_test.exs
+++ b/apps/omg/test/omg/dependency_conformance/signature_test.exs
@@ -49,7 +49,7 @@ defmodule OMG.DependencyConformance.SignatureTest do
 
   test "signature test empty transaction", context do
     contract = context[:contract]
-    tx = Transaction.new([], []) |> DevCrypto.sign([@alice.priv])
+    tx = Transaction.Payment.new([], []) |> DevCrypto.sign([@alice.priv])
     sig = tx.sigs |> Enum.at(0)
 
     verify(contract, tx, sig)

--- a/apps/omg/test/omg/fees_test.exs
+++ b/apps/omg/test/omg/fees_test.exs
@@ -30,19 +30,20 @@ defmodule OMG.FeesTest do
     @not_eth => 3
   }
 
+  # TODO: brittle test? why not test via public API (State.Core)?
   @tag fixtures: [:alice, :bob]
   test "Transactions covers the fee only in one currency accepted by the operator", %{alice: alice, bob: bob} do
     fees =
       create_recovered([{1, 0, 0, alice}], @eth, [{bob, 6}, {alice, 3}])
       |> for_tx(@fees)
 
-    assert covered?(%{@eth => 10}, %{@eth => 9}, fees)
+    assert covered?(%{@eth => 1}, fees)
 
     fees =
       create_recovered([{1, 0, 0, alice}], @not_eth, [{bob, 4}, {alice, 3}])
       |> for_tx(@fees)
 
-    assert covered?(%{@not_eth => 10}, %{@not_eth => 7}, fees)
+    assert covered?(%{@not_eth => 3}, fees)
 
     fees =
       create_recovered(
@@ -51,11 +52,7 @@ defmodule OMG.FeesTest do
       )
       |> for_tx(@fees)
 
-    assert covered?(
-             %{@eth => 5, @not_eth => 13},
-             %{@eth => 5, @not_eth => 10},
-             fees
-           )
+    assert covered?(%{@eth => 0, @not_eth => 3}, fees)
   end
 
   @tag fixtures: [:alice, :bob]
@@ -66,7 +63,7 @@ defmodule OMG.FeesTest do
       create_recovered([{1, 0, 0, alice}], other_token, [{bob, 5}, {alice, 3}])
       |> for_tx(@fees)
 
-    assert false == covered?(%{other_token => 10}, %{other_token => 7}, fees)
+    assert false == covered?(%{other_token => 3}, fees)
   end
 
   @tag fixtures: [:alice, :bob]
@@ -78,7 +75,7 @@ defmodule OMG.FeesTest do
       create_recovered([{1, 0, 0, alice}, {2, 0, 0, alice}], [{bob, other_token, 5}, {alice, other_token, 5}])
       |> for_tx(@fees)
 
-    assert covered?(%{@not_eth => 5, other_token => 10}, %{other_token => 10}, fees)
+    assert covered?(%{@not_eth => 5, other_token => 0}, fees)
   end
 
   describe "Merge transactions are free of cost" do
@@ -88,7 +85,7 @@ defmodule OMG.FeesTest do
         create_recovered([{1, 0, 0, alice}, {2, 0, 0, alice}], @not_eth, [{alice, 10}])
         |> for_tx(@fees)
 
-      assert covered?(%{@not_eth => 10}, %{@not_eth => 10}, fees)
+      assert covered?(%{@not_eth => 0}, fees)
     end
 
     @tag fixtures: [:alice]
@@ -100,11 +97,7 @@ defmodule OMG.FeesTest do
         )
         |> for_tx(@fees)
 
-      assert not covered?(
-               %{@eth => 10, @not_eth => 10},
-               %{@eth => 10, @not_eth => 10},
-               fees
-             )
+      assert not covered?(%{@eth => 0}, fees)
     end
 
     @tag fixtures: [:alice, :bob]
@@ -117,7 +110,7 @@ defmodule OMG.FeesTest do
         )
         |> for_tx(@fees)
 
-      assert not covered?(%{@eth => 10}, %{@eth => 10}, fees)
+      assert not covered?(%{@eth => 0}, fees)
     end
   end
 end

--- a/apps/omg/test/omg/state/core_test.exs
+++ b/apps/omg/test/omg/state/core_test.exs
@@ -284,6 +284,26 @@ defmodule OMG.State.CoreTest do
   end
 
   @tag fixtures: [:alice, :bob, :state_alice_deposit]
+  test "all inputs must be authorized to be spent", %{alice: alice, bob: bob, state_alice_deposit: state} do
+    state =
+      state
+      |> Core.exec(create_recovered([{1, 0, 0, alice}], @eth, [{bob, 7}, {alice, 3}]), :ignore)
+      |> success?()
+
+    state
+    |> Core.exec(create_recovered([{@blknum1, 0, 0, bob}, {@blknum1, 0, 1, bob}], @eth, []), :ignore)
+    |> fail?(:unauthorized_spent)
+    |> same?(state)
+    |> Core.exec(create_recovered([{@blknum1, 0, 0, alice}, {@blknum1, 0, 1, alice}], @eth, []), :ignore)
+    |> fail?(:unauthorized_spent)
+    |> same?(state)
+
+    state
+    |> Core.exec(create_recovered([{@blknum1, 0, 0, bob}, {@blknum1, 0, 1, alice}], @eth, []), :ignore)
+    |> success?()
+  end
+
+  @tag fixtures: [:alice, :bob, :state_alice_deposit]
   test "can't spend spent", %{alice: alice, bob: bob, state_alice_deposit: state} do
     transactions = [
       create_recovered([{1, 0, 0, alice}], @eth, [{bob, 7}, {alice, 3}]),

--- a/apps/omg/test/omg/state/core_test.exs
+++ b/apps/omg/test/omg/state/core_test.exs
@@ -236,7 +236,8 @@ defmodule OMG.State.CoreTest do
   end
 
   @tag fixtures: [:alice, :bob, :state_empty]
-  test "can't spend when signature order does not match input order", %{alice: alice, bob: bob, state_empty: state} do
+  test "can't spend when signature order does not match input order (restrictive spender checks)",
+       %{alice: alice, bob: bob, state_empty: state} do
     state
     |> do_deposit(alice, %{amount: 10, currency: @eth, blknum: 1})
     |> do_deposit(bob, %{amount: 20, currency: @eth, blknum: 2})
@@ -473,8 +474,9 @@ defmodule OMG.State.CoreTest do
              }, _, _}, _} = form_block_check(state)
 
     # precomputed fixed hash to check compliance with hashing algo
-    assert block_hash |> Base.encode16(case: :lower) ==
-             "ee44e104950e8784c17495e423493c54026fa554180bbbca057c1176bc4e1ded"
+    assert block_hash ==
+             <<238, 68, 225, 4, 149, 14, 135, 132, 193, 116, 149, 228, 35, 73, 60, 84, 2, 111, 165, 84, 24, 11, 187,
+               202, 5, 124, 17, 118, 188, 78, 29, 237>>
 
     # Check that contents of the block can be recovered again to original txs
     assert {:ok, ^recovered_tx_1} = Transaction.Recovered.recover_from(block_tx1)

--- a/apps/omg/test/omg/typed_data_hash_test.exs
+++ b/apps/omg/test/omg/typed_data_hash_test.exs
@@ -149,27 +149,28 @@ defmodule OMG.TypedDataHashTest do
 
     test "Transaction is hashed correctly", %{inputs: inputs, outputs: outputs, metadata: metadata} do
       assert "86b1c850f5221d40683097c9257dd13ee50964089ed3080ebd7ddc0a733adff3" ==
-               TypedDataHash.hash_transaction(Transaction.new([], [])) |> Base.encode16(case: :lower)
+               TypedDataHash.hash_transaction(Transaction.Payment.new([], [])) |> Base.encode16(case: :lower)
 
       assert "444ec233a0a80d7a40aff0bc53462543994aa088b2d0a3e635acc57176076ef8" ==
-               TypedDataHash.hash_transaction(Transaction.new(inputs, outputs))
+               TypedDataHash.hash_transaction(Transaction.Payment.new(inputs, outputs))
                |> Base.encode16(case: :lower)
 
       assert "636491ffc56c65f51760e1149da96e1f1605815ba21efe4ffa4c9a18ce7a0560" ==
-               TypedDataHash.hash_transaction(Transaction.new(inputs, outputs, metadata))
+               TypedDataHash.hash_transaction(Transaction.Payment.new(inputs, outputs, metadata))
                |> Base.encode16(case: :lower)
     end
 
     test "Structured hash is computed correctly", %{inputs: inputs, outputs: outputs, metadata: metadata} do
       assert "992ac0f45bff7d9fb74636623e5d8b111b49b818cadcf3a91c035735a84d154f" ==
-               TypedDataHash.hash_struct(Transaction.new([], []), @test_domain_separator) |> Base.encode16(case: :lower)
+               TypedDataHash.hash_struct(Transaction.Payment.new([], []), @test_domain_separator)
+               |> Base.encode16(case: :lower)
 
       assert "b42dc40570279af9faa05e64d62f54db0fd2b768a4a69646efba068cf88eb7a2" ==
-               TypedDataHash.hash_struct(Transaction.new(inputs, outputs), @test_domain_separator)
+               TypedDataHash.hash_struct(Transaction.Payment.new(inputs, outputs), @test_domain_separator)
                |> Base.encode16(case: :lower)
 
       assert "5f9adeaaba8d2fa17de40f45eb12136c7e7f26ea56567226274314d0a563e81d" ==
-               TypedDataHash.hash_struct(Transaction.new(inputs, outputs, metadata), @test_domain_separator)
+               TypedDataHash.hash_struct(Transaction.Payment.new(inputs, outputs, metadata), @test_domain_separator)
                |> Base.encode16(case: :lower)
     end
   end
@@ -183,7 +184,7 @@ defmodule OMG.TypedDataHashTest do
         "55d95900e5bffef27e6225c6ff4cbe1d18cbc28281583a24402ceec80aa924db337f9f663a6a80ca153497cd328e2a0b49d896b66d640e785f59eb76a37cb9aa1b"
         |> Base.decode16!(case: :lower)
 
-      raw_tx = Transaction.new([], [])
+      raw_tx = Transaction.Payment.new([], [])
 
       assert true ==
                raw_tx
@@ -197,7 +198,7 @@ defmodule OMG.TypedDataHashTest do
         "836c4c3726674a93e9d034a60152a64c7de0b55670bbed0c228647ca3797d5b043fea4325452eec47e644dd9124e46d7334b22997dbbbb3cf7b81f2a02a81ccd1c"
         |> Base.decode16!(case: :lower)
 
-      raw_tx = Transaction.new(inputs, outputs)
+      raw_tx = Transaction.Payment.new(inputs, outputs)
 
       assert true ==
                raw_tx
@@ -211,7 +212,7 @@ defmodule OMG.TypedDataHashTest do
         "7b0c9abe27135205c82571b9e4fcbf0641ba9db05d4d8256db3b8f0680a3a55729058aabb15b0f9a101325d60ec1730ae6dd907efd86dcb98cad88616d64a92d1c"
         |> Base.decode16!(case: :lower)
 
-      raw_tx = Transaction.new(inputs, outputs, metadata)
+      raw_tx = Transaction.Payment.new(inputs, outputs, metadata)
 
       assert true ==
                raw_tx

--- a/apps/omg/test/support/crypto.ex
+++ b/apps/omg/test/support/crypto.ex
@@ -45,8 +45,8 @@ defmodule OMG.DevCrypto do
     ```<<54, 43, 207, 67, 140, 160, 190, 135, 18, 162, 70, 120, 36, 245, 106, 165, 5, 101, 183,
       55, 11, 117, 126, 135, 49, 50, 12, 228, 173, 219, 183, 175>>```
   """
-  @spec sign(Transaction.t(), list(Crypto.priv_key_t())) :: Transaction.Signed.t()
-  def sign(%Transaction{} = tx, private_keys) do
+  @spec sign(Transaction.Protocol.t(), list(Crypto.priv_key_t())) :: Transaction.Signed.t()
+  def sign(%{} = tx, private_keys) do
     sigs = Enum.map(private_keys, fn pk -> signature(tx, pk) end)
     %Transaction.Signed{raw_tx: tx, sigs: sigs}
   end
@@ -63,11 +63,11 @@ defmodule OMG.DevCrypto do
   @doc """
   Produces a stand-alone, 65 bytes long, signature for a given transaction.
   """
-  @spec signature(Transaction.t(), Crypto.priv_key_t()) :: Crypto.sig_t()
+  @spec signature(Transaction.Protocol.t(), Crypto.priv_key_t()) :: Crypto.sig_t()
   def signature(_tx, <<>>), do: <<0::size(520)>>
   def signature(tx, priv), do: do_signature(tx, priv)
 
-  defp do_signature(%Transaction{} = tx, priv) do
+  defp do_signature(%{} = tx, priv) do
     tx
     |> TypedDataHash.hash_struct()
     |> signature_digest(priv)

--- a/apps/omg/test/support/integration/deposit_helper.ex
+++ b/apps/omg/test/support/integration/deposit_helper.ex
@@ -26,7 +26,7 @@ defmodule OMG.Integration.DepositHelper do
 
   def deposit_to_child_chain(to, value, @eth) do
     {:ok, receipt} =
-      Transaction.new([], [{to, @eth, value}])
+      Transaction.Payment.new([], [{to, @eth, value}])
       |> Transaction.raw_txbytes()
       |> Eth.RootChainHelper.deposit(value, to)
       |> Eth.DevHelpers.transact_sync!()
@@ -40,7 +40,7 @@ defmodule OMG.Integration.DepositHelper do
     {:ok, _} = Eth.Token.approve(to, contract_addr, value, token_addr) |> Eth.DevHelpers.transact_sync!()
 
     {:ok, receipt} =
-      Transaction.new([], [{to, token_addr, value}])
+      Transaction.Payment.new([], [{to, token_addr, value}])
       |> Transaction.raw_txbytes()
       |> Eth.RootChainHelper.deposit_from(to)
       |> Eth.DevHelpers.transact_sync!()

--- a/apps/omg/test/support/prop_test/helper.ex
+++ b/apps/omg/test/support/prop_test/helper.ex
@@ -25,7 +25,8 @@ defmodule OMG.PropTest.Helper do
   @doc """
   Collapse of the recover transaction into a short form use in OMG.PropTest
   """
-  def format_transaction(%Transaction.Recovered{spenders: [spender1, spender2]} = tx) do
+  def format_transaction(%Transaction.Recovered{witnesses: witnesses} = tx) do
+    [spender1, spender2] = Map.values(witnesses)
     inputs = Transaction.get_inputs(tx)
     outputs = Transaction.get_outputs(tx)
 

--- a/apps/omg/test/support/test_helper.ex
+++ b/apps/omg/test/support/test_helper.ex
@@ -77,7 +77,7 @@ defmodule OMG.TestHelper do
   """
   @spec create_recovered(
           list({pos_integer, non_neg_integer, 0 | 1, map}),
-          Transaction.currency(),
+          Transaction.Payment.currency(),
           list({map, pos_integer}),
           Transaction.metadata()
         ) :: Transaction.Recovered.t()
@@ -87,7 +87,7 @@ defmodule OMG.TestHelper do
 
   @spec create_recovered(
           list({pos_integer, non_neg_integer, 0 | 1, map}),
-          list({map, Transaction.currency(), pos_integer})
+          list({map, Transaction.Payment.currency(), pos_integer})
         ) :: Transaction.Recovered.t()
   def create_recovered(inputs, outputs), do: create_encoded(inputs, outputs) |> Transaction.Recovered.recover_from!()
 
@@ -104,13 +104,13 @@ defmodule OMG.TestHelper do
   """
   @spec create_signed(
           list({pos_integer, non_neg_integer, 0 | 1, map}),
-          Transaction.currency(),
+          Transaction.Payment.currency(),
           list({map, pos_integer}),
           Transaction.metadata()
         ) :: Transaction.Signed.t()
   def create_signed(inputs, currency, outputs, metadata \\ nil) do
     raw_tx =
-      Transaction.new(
+      Transaction.Payment.new(
         inputs |> Enum.map(fn {blknum, txindex, oindex, _} -> {blknum, txindex, oindex} end),
         outputs |> Enum.map(fn {owner, amount} -> {owner.addr, currency, amount} end),
         metadata
@@ -122,11 +122,11 @@ defmodule OMG.TestHelper do
 
   @spec create_signed(
           list({pos_integer, non_neg_integer, 0 | 1, map}),
-          list({map, Transaction.currency(), pos_integer})
+          list({map, Transaction.Payment.currency(), pos_integer})
         ) :: Transaction.Signed.t()
   def create_signed(inputs, outputs) do
     raw_tx =
-      Transaction.new(
+      Transaction.Payment.new(
         inputs |> Enum.map(fn {blknum, txindex, oindex, _} -> {blknum, txindex, oindex} end),
         outputs |> Enum.map(fn {owner, currency, amount} -> {owner.addr, currency, amount} end)
       )
@@ -135,9 +135,9 @@ defmodule OMG.TestHelper do
     DevCrypto.sign(raw_tx, privs)
   end
 
-  def sign_encode(%Transaction{} = tx, priv_keys), do: tx |> DevCrypto.sign(priv_keys) |> Transaction.Signed.encode()
+  def sign_encode(%{} = tx, priv_keys), do: tx |> DevCrypto.sign(priv_keys) |> Transaction.Signed.encode()
 
-  def sign_recover!(%Transaction{} = tx, priv_keys),
+  def sign_recover!(%{} = tx, priv_keys),
     do: tx |> sign_encode(priv_keys) |> Transaction.Recovered.recover_from!()
 
   @doc """

--- a/apps/omg_performance/lib/omg_performance/sender_server.ex
+++ b/apps/omg_performance/lib/omg_performance/sender_server.ex
@@ -122,7 +122,7 @@ defmodule OMG.Performance.SenderServer do
 
     # create and return signed transaction
     [{last_tx.blknum, last_tx.txindex, last_tx.oindex}]
-    |> Transaction.new([{spender.addr, @eth, newamount}, {recipient.addr, @eth, to_spend}])
+    |> Transaction.Payment.new([{spender.addr, @eth, newamount}, {recipient.addr, @eth, to_spend}])
     |> DevCrypto.sign([spender.priv, <<>>])
   end
 

--- a/apps/omg_watcher/lib/omg_watcher/db/transaction.ex
+++ b/apps/omg_watcher/lib/omg_watcher/db/transaction.ex
@@ -166,7 +166,7 @@ defmodule OMG.Watcher.DB.Transaction do
   @spec process(Transaction.Recovered.t(), pos_integer(), integer(), list()) :: [list()]
   defp process(
          %Transaction.Recovered{
-           signed_tx: %Transaction.Signed{raw_tx: %Transaction{metadata: metadata}} = tx,
+           signed_tx: %Transaction.Signed{raw_tx: %Transaction.Payment{metadata: metadata}} = tx,
            signed_tx_bytes: signed_tx_bytes
          },
          block_number,

--- a/apps/omg_watcher/lib/omg_watcher/eventer/core.ex
+++ b/apps/omg_watcher/lib/omg_watcher/eventer/core.ex
@@ -69,8 +69,10 @@ defmodule OMG.Watcher.Eventer.Core do
     get_address_received_events(event_trigger) ++ get_address_spent_events(event_trigger)
   end
 
-  defp get_address_spent_events(%{tx: %Transaction.Recovered{spenders: spenders}} = event_trigger) do
-    spenders
+  defp get_address_spent_events(%{tx: %Transaction.Recovered{witnesses: witnesses}} = event_trigger) do
+    witnesses
+    |> Map.values()
+    # makes sure only spender witnesses are used here. This should fail&crash when other kinds of witnesses go through
     |> Enum.filter(&account_address?/1)
     |> Enum.map(&create_address_spent_event(event_trigger, &1))
     |> Enum.uniq()
@@ -92,7 +94,6 @@ defmodule OMG.Watcher.Eventer.Core do
 
   defp account_address?(@zero_address), do: false
   defp account_address?(address) when is_binary(address) and byte_size(address) == 20, do: true
-  defp account_address?(_), do: false
 
   defp create_address_received_event(event_trigger, address) do
     subtopic = create_transfer_subtopic(address)

--- a/apps/omg_watcher/lib/omg_watcher/exit_processor/canonicity.ex
+++ b/apps/omg_watcher/lib/omg_watcher/exit_processor/canonicity.ex
@@ -135,9 +135,8 @@ defmodule OMG.Watcher.ExitProcessor.Canonicity do
          signed_ife_tx,
          blocks
        ) do
-    {:ok, input_owners} = Transaction.Signed.get_spenders(signed_ife_tx)
-
-    owner = Enum.at(input_owners, in_flight_input_index)
+    {:ok, input_witnesses} = Transaction.Signed.get_witnesses(signed_ife_tx)
+    owner = input_witnesses[in_flight_input_index]
 
     %{
       in_flight_txbytes: signed_ife_tx |> Transaction.raw_txbytes(),

--- a/apps/omg_watcher/lib/omg_watcher/exit_processor/competitor_info.ex
+++ b/apps/omg_watcher/lib/omg_watcher/exit_processor/competitor_info.ex
@@ -76,7 +76,7 @@ defmodule OMG.Watcher.ExitProcessor.CompetitorInfo do
     do: do_new(tx_bytes, index, sig)
 
   defp do_new(tx_bytes, competing_input_index, competing_input_signature) do
-    with {:ok, %Transaction{} = raw_tx} <- Transaction.decode(tx_bytes) do
+    with {:ok, %Transaction.Payment{} = raw_tx} <- Transaction.decode(tx_bytes) do
       {Transaction.raw_txhash(raw_tx),
        %__MODULE__{
          tx: %Transaction.Signed{

--- a/apps/omg_watcher/lib/omg_watcher/exit_processor/core.ex
+++ b/apps/omg_watcher/lib/omg_watcher/exit_processor/core.ex
@@ -449,14 +449,12 @@ defmodule OMG.Watcher.ExitProcessor.Core do
   @spec prepare_available_piggyback(InFlightExitInfo.t()) :: list(Event.PiggybackAvailable.t())
   defp prepare_available_piggyback(%InFlightExitInfo{tx: signed_tx} = ife) do
     outputs = Transaction.get_outputs(signed_tx)
-    {:ok, input_owners} = Transaction.Signed.get_spenders(signed_tx)
+    {:ok, input_witnesses} = Transaction.Signed.get_witnesses(signed_tx)
 
     available_inputs =
-      input_owners
-      |> Enum.filter(&zero_address?/1)
-      |> Enum.with_index()
-      |> Enum.filter(fn {_, index} -> not InFlightExitInfo.is_input_piggybacked?(ife, index) end)
-      |> Enum.map(fn {owner, index} -> %{index: index, address: owner} end)
+      input_witnesses
+      |> Enum.filter(fn {index, _} -> not InFlightExitInfo.is_input_piggybacked?(ife, index) end)
+      |> Enum.map(fn {index, owner} -> %{index: index, address: owner} end)
 
     available_outputs =
       outputs

--- a/apps/omg_watcher/lib/omg_watcher/exit_processor/in_flight_exit_info.ex
+++ b/apps/omg_watcher/lib/omg_watcher/exit_processor/in_flight_exit_info.ex
@@ -24,8 +24,9 @@ defmodule OMG.Watcher.ExitProcessor.InFlightExitInfo do
 
   require Utxo
   require Transaction
+  require Transaction.Payment
 
-  @max_inputs Transaction.max_inputs()
+  @max_inputs Transaction.Payment.max_inputs()
 
   # TODO: divide into inputs and outputs: prevent contract's implementation from leaking into watcher
   # https://github.com/omisego/elixir-omg/pull/361#discussion_r247926222
@@ -207,14 +208,14 @@ defmodule OMG.Watcher.ExitProcessor.InFlightExitInfo do
   def from_db_raw_tx(%{inputs: inputs, outputs: outputs, metadata: metadata})
       when is_list(inputs) and is_list(outputs) and Transaction.is_metadata(metadata) do
     value = %{inputs: inputs, outputs: outputs, metadata: metadata}
-    struct!(Transaction, value)
+    struct!(Transaction.Payment, value)
   end
 
   def to_db_value(%Transaction.Signed{raw_tx: raw_tx, sigs: sigs}) when is_list(sigs) do
     %{raw_tx: to_db_value(raw_tx), sigs: sigs}
   end
 
-  def to_db_value(%Transaction{inputs: inputs, outputs: outputs, metadata: metadata})
+  def to_db_value(%Transaction.Payment{inputs: inputs, outputs: outputs, metadata: metadata})
       when is_list(inputs) and is_list(outputs) and Transaction.is_metadata(metadata) do
     %{inputs: inputs, outputs: outputs, metadata: metadata}
   end

--- a/apps/omg_watcher/lib/omg_watcher/exit_processor/piggyback.ex
+++ b/apps/omg_watcher/lib/omg_watcher/exit_processor/piggyback.ex
@@ -40,7 +40,7 @@ defmodule OMG.Watcher.ExitProcessor.Piggyback do
 
   import OMG.Watcher.ExitProcessor.Tools
 
-  require Transaction
+  require Transaction.Payment
 
   use OMG.Utils.LoggerExt
 
@@ -70,14 +70,14 @@ defmodule OMG.Watcher.ExitProcessor.Piggyback do
           | :no_double_spend_on_particular_piggyback
 
   def get_input_challenge_data(request, state, txbytes, input_index) do
-    case input_index in 0..(Transaction.max_inputs() - 1) do
+    case input_index in 0..(Transaction.Payment.max_inputs() - 1) do
       true -> get_piggyback_challenge_data(request, state, txbytes, {:input, input_index})
       false -> {:error, :piggybacked_index_out_of_range}
     end
   end
 
   def get_output_challenge_data(request, state, txbytes, output_index) do
-    case output_index in 0..(Transaction.max_outputs() - 1) do
+    case output_index in 0..(Transaction.Payment.max_outputs() - 1) do
       true -> get_piggyback_challenge_data(request, state, txbytes, {:output, output_index})
       false -> {:error, :piggybacked_index_out_of_range}
     end

--- a/apps/omg_watcher/lib/omg_watcher/exit_processor/tools.ex
+++ b/apps/omg_watcher/lib/omg_watcher/exit_processor/tools.ex
@@ -31,7 +31,7 @@ defmodule OMG.Watcher.ExitProcessor.Tools do
   def double_spends_from_known_tx(inputs, %KnownTx{signed_tx: signed} = known_tx) when is_list(inputs) do
     known_spent_inputs = signed |> Transaction.get_inputs() |> Enum.with_index()
 
-    # NOTE: possibly ineffective if Transaction.max_inputs >> 4, BUT we're calling it seldom so no biggie
+    # NOTE: possibly ineffective if Transaction.Payment.max_inputs >> 4, BUT we're calling it seldom so no biggie
     for {left, left_index} <- inputs,
         {right, right_index} <- known_spent_inputs,
         left == right,

--- a/apps/omg_watcher/lib/omg_watcher/utxo_exit/core.ex
+++ b/apps/omg_watcher/lib/omg_watcher/utxo_exit/core.ex
@@ -44,7 +44,7 @@ defmodule OMG.Watcher.UtxoExit.Core do
 
   def compose_output_exit(sorted_tx_bytes, Utxo.position(_blknum, txindex, _) = utxo_pos) do
     if signed_tx = Enum.at(sorted_tx_bytes, txindex) do
-      {:ok, %Transaction.Signed{sigs: sigs} = tx} = Transaction.Signed.decode(signed_tx)
+      %Transaction.Signed{sigs: sigs} = tx = Transaction.Signed.decode!(signed_tx)
 
       {:ok,
        %{
@@ -58,8 +58,8 @@ defmodule OMG.Watcher.UtxoExit.Core do
     end
   end
 
-  @spec get_deposit_utxo({:ok, list({OMG.DB.utxo_pos_db_t(), Transaction.output()})}, Utxo.Position.t()) ::
-          nil | Transaction.output()
+  @spec get_deposit_utxo({:ok, list({OMG.DB.utxo_pos_db_t(), Transaction.Payment.output()})}, Utxo.Position.t()) ::
+          nil | Transaction.Payment.output()
   def get_deposit_utxo({:ok, utxos}, Utxo.position(blknum, _, _)) do
     case Enum.find(utxos, fn {{blk, _, _}, _} -> blk == blknum end) do
       {_, utxo} -> utxo
@@ -67,7 +67,7 @@ defmodule OMG.Watcher.UtxoExit.Core do
     end
   end
 
-  @spec compose_deposit_exit(Transaction.output() | any(), Utxo.Position.t()) ::
+  @spec compose_deposit_exit(Transaction.Payment.output() | any(), Utxo.Position.t()) ::
           {:error, :no_deposit_for_given_blknum}
           | {:ok,
              %{
@@ -76,7 +76,7 @@ defmodule OMG.Watcher.UtxoExit.Core do
                proof: binary
              }}
   def compose_deposit_exit(%{amount: amount, currency: currency, owner: owner}, utxo_pos) do
-    tx = Transaction.new([], [{owner, currency, amount}])
+    tx = Transaction.Payment.new([], [{owner, currency, amount}])
     txs = [Transaction.Signed.encode(%Transaction.Signed{raw_tx: tx, sigs: []})]
 
     {:ok,

--- a/apps/omg_watcher/test/omg_watcher/exit_processor/canonicity_test.exs
+++ b/apps/omg_watcher/test/omg_watcher/exit_processor/canonicity_test.exs
@@ -379,14 +379,14 @@ defmodule OMG.Watcher.ExitProcessor.CanonicityTest do
       other_input3 = {112, 2, 1}
 
       comps = [
-        Transaction.new([input_spent_in_idx0], []),
-        Transaction.new([other_input1, input_spent_in_idx0], []),
-        Transaction.new([other_input1, other_input2, input_spent_in_idx0], []),
-        Transaction.new([other_input1, other_input2, other_input3, input_spent_in_idx0], []),
-        Transaction.new([input_spent_in_idx1], []),
-        Transaction.new([other_input1, input_spent_in_idx1], []),
-        Transaction.new([other_input1, other_input2, input_spent_in_idx1], []),
-        Transaction.new([other_input1, other_input2, other_input3, input_spent_in_idx1], [])
+        Transaction.Payment.new([input_spent_in_idx0], []),
+        Transaction.Payment.new([other_input1, input_spent_in_idx0], []),
+        Transaction.Payment.new([other_input1, other_input2, input_spent_in_idx0], []),
+        Transaction.Payment.new([other_input1, other_input2, other_input3, input_spent_in_idx0], []),
+        Transaction.Payment.new([input_spent_in_idx1], []),
+        Transaction.Payment.new([other_input1, input_spent_in_idx1], []),
+        Transaction.Payment.new([other_input1, other_input2, input_spent_in_idx1], []),
+        Transaction.Payment.new([other_input1, other_input2, other_input3, input_spent_in_idx1], [])
       ]
 
       expected_input_ids = [{0, 0}, {1, 0}, {2, 0}, {3, 0}, {0, 1}, {1, 1}, {2, 1}, {3, 1}]

--- a/apps/omg_watcher/test/omg_watcher/exit_processor/persistence_test.exs
+++ b/apps/omg_watcher/test/omg_watcher/exit_processor/persistence_test.exs
@@ -49,8 +49,8 @@ defmodule OMG.Watcher.ExitProcessor.PersistenceTest do
     {:ok, processor_empty} = Core.init([], [], [])
 
     transactions = [
-      Transaction.new([{1, 0, 0}, {1, 2, 1}], [{alice.addr, @eth, 1}, {carol.addr, @eth, 2}]),
-      Transaction.new([{2, 1, 0}, {2, 2, 1}], [{alice.addr, @eth, 1}, {carol.addr, @eth, 2}])
+      Transaction.Payment.new([{1, 0, 0}, {1, 2, 1}], [{alice.addr, @eth, 1}, {carol.addr, @eth, 2}]),
+      Transaction.Payment.new([{2, 1, 0}, {2, 2, 1}], [{alice.addr, @eth, 1}, {carol.addr, @eth, 2}])
     ]
 
     [txbytes1, txbytes2] = transactions |> Enum.map(&Transaction.raw_txbytes/1)
@@ -116,8 +116,8 @@ defmodule OMG.Watcher.ExitProcessor.PersistenceTest do
   test "persist started ifes regardless of status",
        %{processor_empty: processor, alice: alice, carol: carol, db_pid: db_pid} do
     txs = [
-      Transaction.new([{1, 0, 0}, {1, 2, 1}], [{alice.addr, @eth, 1}]),
-      Transaction.new([{2, 1, 0}, {2, 2, 1}], [{alice.addr, @eth, 1}, {carol.addr, @eth, 2}])
+      Transaction.Payment.new([{1, 0, 0}, {1, 2, 1}], [{alice.addr, @eth, 1}]),
+      Transaction.Payment.new([{2, 1, 0}, {2, 2, 1}], [{alice.addr, @eth, 1}, {carol.addr, @eth, 2}])
     ]
 
     contract_statuses = [{1, @non_zero_exit_id}, {0, @zero_exit_id}]
@@ -128,9 +128,9 @@ defmodule OMG.Watcher.ExitProcessor.PersistenceTest do
 
   test "persist new challenges, responses and piggybacks",
        %{processor_empty: processor, alice: alice, db_pid: db_pid} do
-    tx = Transaction.new([{2, 1, 0}], [{alice.addr, @eth, 1}, {alice.addr, @eth, 2}])
+    tx = Transaction.Payment.new([{2, 1, 0}], [{alice.addr, @eth, 1}, {alice.addr, @eth, 2}])
     hash = Transaction.raw_txhash(tx)
-    competing_tx = Transaction.new([{2, 1, 0}, {1, 0, 0}], [{alice.addr, @eth, 2}, {alice.addr, @eth, 1}])
+    competing_tx = Transaction.Payment.new([{2, 1, 0}, {1, 0, 0}], [{alice.addr, @eth, 2}, {alice.addr, @eth, 1}])
 
     challenge = %{
       tx_hash: hash,
@@ -157,7 +157,7 @@ defmodule OMG.Watcher.ExitProcessor.PersistenceTest do
 
   test "persist ife finalizations",
        %{processor_empty: processor, alice: alice, db_pid: db_pid} do
-    tx = Transaction.new([{2, 1, 0}], [{alice.addr, @eth, 1}, {alice.addr, @eth, 2}])
+    tx = Transaction.Payment.new([{2, 1, 0}], [{alice.addr, @eth, 1}, {alice.addr, @eth, 2}])
     hash = Transaction.raw_txhash(tx)
 
     piggybacks1 = [%{tx_hash: hash, output_index: 0}, %{tx_hash: hash, output_index: 4}]

--- a/apps/omg_watcher/test/omg_watcher/exit_processor/piggyback_test.exs
+++ b/apps/omg_watcher/test/omg_watcher/exit_processor/piggyback_test.exs
@@ -115,7 +115,7 @@ defmodule OMG.Watcher.ExitProcessor.PiggybackTest do
          %{processor_empty: processor, alice: alice} do
       # there is leeway in the contract, that allows IFE transactions to hold non-zero signatures for zero-inputs
       # we want to be sure that this doesn't crash the `ExitProcessor`
-      tx = Transaction.new([{1, 0, 0}], [])
+      tx = Transaction.Payment.new([{1, 0, 0}], [])
       txbytes = txbytes(tx)
       # superfluous signatures
       %{sigs: sigs} = signed_tx = OMG.DevCrypto.sign(tx, [alice.priv, alice.priv, alice.priv])

--- a/apps/omg_watcher/test/omg_watcher/exit_processor/standard_exit_test.exs
+++ b/apps/omg_watcher/test/omg_watcher/exit_processor/standard_exit_test.exs
@@ -106,7 +106,7 @@ defmodule OMG.Watcher.ExitProcessor.StandardExitTest do
   describe "Core.determine_exit_txbytes" do
     test "produces valid exit txbytes for exits from deposits",
          %{alice: alice, processor_empty: processor} do
-      tx = Transaction.new([], [{alice.addr, @eth, 10}])
+      tx = Transaction.Payment.new([], [{alice.addr, @eth, 10}])
       deposit_txbytes = Transaction.raw_txbytes(tx)
       processor = processor |> start_se_from(tx, @utxo_pos_deposit)
 
@@ -248,8 +248,8 @@ defmodule OMG.Watcher.ExitProcessor.StandardExitTest do
 
     test "creates challenge: tx utxo double spent signed_by different signers",
          %{alice: alice, bob: bob, processor_empty: processor} do
-      tx1 = Transaction.new([@deposit_input2], [{alice.addr, @eth, 10}])
-      tx2 = Transaction.new([@deposit_input2], [{bob.addr, @eth, 10}])
+      tx1 = Transaction.Payment.new([@deposit_input2], [{alice.addr, @eth, 10}])
+      tx2 = Transaction.Payment.new([@deposit_input2], [{bob.addr, @eth, 10}])
       processor1 = processor |> start_se_from(tx1, @utxo_pos_tx)
       processor2 = processor |> start_se_from(tx2, @utxo_pos_tx)
 
@@ -275,7 +275,7 @@ defmodule OMG.Watcher.ExitProcessor.StandardExitTest do
 
     test "creates challenge: both utxos spent don't interfere",
          %{alice: alice, processor_empty: processor} do
-      tx = Transaction.new([@deposit_input2], [{alice.addr, @eth, 10}, {alice.addr, @eth, 10}])
+      tx = Transaction.Payment.new([@deposit_input2], [{alice.addr, @eth, 10}, {alice.addr, @eth, 10}])
       processor = processor |> start_se_from(tx, @utxo_pos_tx)
 
       recovered_spend = TestHelper.create_recovered([{@blknum, 0, 0, alice}], @eth, [{alice, 10}])

--- a/apps/omg_watcher/test/omg_watcher/utxo_exit/core_test.exs
+++ b/apps/omg_watcher/test/omg_watcher/utxo_exit/core_test.exs
@@ -57,7 +57,7 @@ defmodule OMG.Watcher.UtxoExit.CoreTest do
     end
 
     tx_exit = tx_encode.(30)
-    tx_exit_raw_tx_bytes = Transaction.Signed.decode(tx_exit) |> elem(1) |> Transaction.raw_txbytes()
+    tx_exit_raw_tx_bytes = Transaction.Signed.decode!(tx_exit) |> Transaction.raw_txbytes()
 
     position = Utxo.position(3, 0, 1)
     encode_utxo = position |> Utxo.Position.encode()

--- a/apps/omg_watcher_rpc/lib/web/validators/order.ex
+++ b/apps/omg_watcher_rpc/lib/web/validators/order.ex
@@ -43,11 +43,11 @@ defmodule OMG.WatcherRPC.Web.Validator.Order do
 
   defp fills_in_outputs?(payments) do
     alias OMG.State.Transaction
-    require Transaction
+    require Transaction.Payment
 
-    if length(payments) <= Transaction.max_outputs(),
+    if length(payments) <= Transaction.Payment.max_outputs(),
       do: {:ok, payments},
-      else: error("payments", {:too_many_payments, Transaction.max_outputs()})
+      else: error("payments", {:too_many_payments, Transaction.Payment.max_outputs()})
   end
 
   defp parse_payment(raw_payment) do

--- a/apps/omg_watcher_rpc/lib/web/validators/typed_data_signed.ex
+++ b/apps/omg_watcher_rpc/lib/web/validators/typed_data_signed.ex
@@ -37,7 +37,7 @@ defmodule OMG.WatcherRPC.Web.Validator.TypedDataSigned do
     end
   end
 
-  @spec parse_transaction(map()) :: {:ok, Transaction.t()} | {:error, any}
+  @spec parse_transaction(map()) :: {:ok, Transaction.Payment.t()} | {:error, any}
   def parse_transaction(params) do
     with {:ok, msg} <- expect(params, "message", :map),
          inputs when is_list(inputs) <- parse_inputs(msg),
@@ -45,7 +45,7 @@ defmodule OMG.WatcherRPC.Web.Validator.TypedDataSigned do
          {:ok, metadata} <- expect(msg, "metadata", :hash) do
       metadata = if metadata == @empty_metadata, do: nil, else: metadata
 
-      {:ok, Transaction.new(inputs, outputs, metadata)}
+      {:ok, Transaction.Payment.new(inputs, outputs, metadata)}
     end
   end
 
@@ -84,9 +84,9 @@ defmodule OMG.WatcherRPC.Web.Validator.TypedDataSigned do
 
   @spec parse_inputs(map()) :: [{integer(), integer(), integer()}] | {:error, any()}
   defp parse_inputs(message) do
-    require Transaction
+    require Transaction.Payment
 
-    0..(Transaction.max_inputs() - 1)
+    0..(Transaction.Payment.max_inputs() - 1)
     |> Enum.map(fn i -> expect(message, "input#{i}", map: &parse_input/1) end)
     |> all_success_or_error()
   end
@@ -102,9 +102,9 @@ defmodule OMG.WatcherRPC.Web.Validator.TypedDataSigned do
 
   @spec parse_outputs(map()) :: [{OMG.Crypto.address_t(), OMG.Crypto.address_t(), integer()}] | {:error, any()}
   defp parse_outputs(message) do
-    require Transaction
+    require Transaction.Payment
 
-    0..(Transaction.max_outputs() - 1)
+    0..(Transaction.Payment.max_outputs() - 1)
     |> Enum.map(fn i -> expect(message, "output#{i}", map: &parse_output/1) end)
     |> all_success_or_error()
   end

--- a/apps/omg_watcher_rpc/test/omg_watcher_rpc/web/controllers/in_flight_exit_test.exs
+++ b/apps/omg_watcher_rpc/test/omg_watcher_rpc/web/controllers/in_flight_exit_test.exs
@@ -77,12 +77,12 @@ defmodule OMG.WatcherRPC.Web.Controller.InFlightExitTest do
       )
 
       test_in_flight_exit_data.([{3000, 1, 0, alice}], [
-        OMG.State.Transaction.new([{1000, 1, 1}], [{bob.addr, @eth, 150}, {alice.addr, @eth, 50}])
+        Transaction.Payment.new([{1000, 1, 1}], [{bob.addr, @eth, 150}, {alice.addr, @eth, 50}])
       ])
 
       test_in_flight_exit_data.([{3000, 1, 0, alice}, {2000, 0, 1, alice}], [
-        OMG.State.Transaction.new([{1000, 1, 1}], [{bob.addr, @eth, 150}, {alice.addr, @eth, 50}]),
-        OMG.State.Transaction.new([{1000, 1, 0}], [{bob.addr, @eth, 99}, {alice.addr, @eth, 1}], <<1322::256>>)
+        Transaction.Payment.new([{1000, 1, 1}], [{bob.addr, @eth, 150}, {alice.addr, @eth, 50}]),
+        Transaction.Payment.new([{1000, 1, 0}], [{bob.addr, @eth, 99}, {alice.addr, @eth, 1}], <<1322::256>>)
       ])
     end
 

--- a/dialyzer.ignore-warnings
+++ b/dialyzer.ignore-warnings
@@ -11,3 +11,22 @@ lib/phoenix/router.ex:316: The pattern 'error' can never match the type {#{'conn
 lib/phoenix/router.ex:316: The pattern 'error' can never match the type {#{'conn':='nil', 'log':='debug', 'path_params':=map(), 'pipe_through':=[any(),...], 'plug':='Elixir.OMG.WatcherRPC.Web.Controller.Account' | 'Elixir.OMG.WatcherRPC.Web.Controller.Alarm' | 'Elixir.OMG.WatcherRPC.Web.Controller.Challenge' | 'Elixir.OMG.WatcherRPC.Web.Controller.Fallback' | 'Elixir.OMG.WatcherRPC.Web.Controller.InFlightExit' | 'Elixir.OMG.WatcherRPC.Web.Controller.Status' | 'Elixir.OMG.WatcherRPC.Web.Controller.Transaction' | 'Elixir.OMG.WatcherRPC.Web.Controller.Utxo', 'plug_opts':=atom(), 'route':=<<_:48,_:_*8>>},fun((_,map()) -> any()),fun((_) -> map()),{'Elixir.OMG.WatcherRPC.Web.Controller.Account' | 'Elixir.OMG.WatcherRPC.Web.Controller.Alarm' | 'Elixir.OMG.WatcherRPC.Web.Controller.Challenge' | 'Elixir.OMG.WatcherRPC.Web.Controller.Fallback' | 'Elixir.OMG.WatcherRPC.Web.Controller.InFlightExit' | 'Elixir.OMG.WatcherRPC.Web.Controller.Status' | 'Elixir.OMG.WatcherRPC.Web.Controller.Transaction' | 'Elixir.OMG.WatcherRPC.Web.Controller.Utxo',atom()}}
 lib/websockex.ex:19: Function handle_cast/2 only terminates with explicit exception
 lib/websockex.ex:297: Expression produces a value of type 'ok' | {'error',_}, but this value is unmatched
+####
+#
+# Protocol-related problems, these ignores workaround the problem reported
+# here: https://github.com/elixir-lang/elixir/issues/7708 and here https://github.com/jeremyjh/dialyxir/issues/221
+# fixed in https://github.com/jeremyjh/dialyxir/commit/3d0a13f17a46649bca2413d57cef45bb278d1474, not yet released in `dialyxir`
+# undo once we use the `dialyxir` release that includes this (presumably >1.0.0-rc.6)
+:0: Unknown function 'Elixir.OMG.State.Transaction.Protocol.Atom':'__impl__'/1
+:0: Unknown function 'Elixir.OMG.State.Transaction.Protocol.BitString':'__impl__'/1
+:0: Unknown function 'Elixir.OMG.State.Transaction.Protocol.Float':'__impl__'/1
+:0: Unknown function 'Elixir.OMG.State.Transaction.Protocol.Function':'__impl__'/1
+:0: Unknown function 'Elixir.OMG.State.Transaction.Protocol.Integer':'__impl__'/1
+:0: Unknown function 'Elixir.OMG.State.Transaction.Protocol.List':'__impl__'/1
+:0: Unknown function 'Elixir.OMG.State.Transaction.Protocol.Map':'__impl__'/1
+:0: Unknown function 'Elixir.OMG.State.Transaction.Protocol.PID':'__impl__'/1
+:0: Unknown function 'Elixir.OMG.State.Transaction.Protocol.Port':'__impl__'/1
+:0: Unknown function 'Elixir.OMG.State.Transaction.Protocol.Reference':'__impl__'/1
+:0: Unknown function 'Elixir.OMG.State.Transaction.Protocol.Tuple':'__impl__'/1
+#
+####


### PR DESCRIPTION
#844 - first step towards, but probably the bulkiest

(commit squash pending!)

## Overview

This refactor puts the code used in `Transaction.Recovered.recover_from` and `State.Core.exec` (statless and stateful validation resp. and tx application) into different modules, so that it is more straightforward to introduce new transaction types. 

See branch https://github.com/omisego/elixir-omg/tree/844_experimental_tx_type for an example of how this could be leveraged.

This doesn't yet touch Watcher-specific nor input-pointer-specific abstractness.

## Changes

 - `Transaction.Protocol` lists the API needed from a transaction type, to be able to be processed
 - `Transaction.Payment` is now the "raw_tx" type, implements the `Transaction.Protocol`
 - `Transaction.Witness` holds code used to validate/recover various witnesses of various forms
 - `Transaction.OutputPredicateProtocol` (not an elixir protocol though) - checks whether the witness checks out with the output a tx intends to spend
 - `UtxoSet` - abstracts out all the code needed to fetch tx outputs to spend from the state

## Testing

Existing unit tests, mainly `mix test test/omg`. External APIs didn't change so, almost all the tests hold.