### PR TITLE
fix: repeated exits coming from kernel monitor, because it spawns a p…

### DIFF
--- a/apps/omg_status/lib/omg_status/metric/datadog.ex
+++ b/apps/omg_status/lib/omg_status/metric/datadog.ex
@@ -30,6 +30,7 @@ defmodule OMG.Status.Metric.Datadog do
   def start_link, do: GenServer.start_link(__MODULE__, [], [])
 
   def init(_opts) do
+    _ = Process.flag(:trap_exit, true)
     _ = Logger.info("Starting #{inspect(__MODULE__)} and connecting to Datadog.")
     __MODULE__.connect()
     _ = Logger.info("Connection opened #{inspect(current_conn())}")

--- a/apps/omg_status/lib/omg_status/metric/datadog.ex
+++ b/apps/omg_status/lib/omg_status/metric/datadog.ex
@@ -27,12 +27,12 @@ defmodule OMG.Status.Metric.Datadog do
   use GenServer
   require Logger
 
-  def start, do: GenServer.start(__MODULE__, [], [])
+  def start_link, do: GenServer.start_link(__MODULE__, [], [])
 
   def init(_opts) do
     _ = Logger.info("Starting #{inspect(__MODULE__)} and connecting to Datadog.")
-    Process.flag(:trap_exit, true)
-    connect()
+    __MODULE__.connect()
+    _ = Logger.info("Connection opened #{inspect(current_conn())}")
     {:ok, current_conn()}
   end
 

--- a/apps/omg_status/test/omg_status/metric/datadog_test.exs
+++ b/apps/omg_status/test/omg_status/metric/datadog_test.exs
@@ -16,32 +16,26 @@ defmodule OMG.Status.Metric.DatadogTest do
   use ExUnit.Case, async: true
   alias OMG.Status.Metric.Datadog
 
-  setup do
+  test "if exiting process/port sends an exit signal to the parent process" do
     parent = self()
-
-    spawn(fn ->
-      {:ok, datadog_pid} = Datadog.start_link()
-      send(parent, {:ok, datadog_pid})
-    end)
-
-    receive do
-      {:ok, datadog_pid} ->
-        %{datadog: {:ok, datadog_pid}}
-    end
-  end
-
-  test "if exiting process/port sends an exit signal to the parent process", %{datadog: {:ok, datadog_pid}} do
-    :erlang.trace(datadog_pid, true, [:receive])
 
     {:ok, _} =
       Task.start(fn ->
+        {:ok, datadog_pid} = Datadog.start_link()
         port = Port.open({:spawn, "cat"}, [:binary])
         true = Process.link(datadog_pid)
-        true = Process.exit(port, :portkill)
+        send(parent, {:data, port, datadog_pid})
 
         # we want to exit because the port forcefully closes
         # so this sleep shouldn't happen
         Process.sleep(10_000)
       end)
+
+    receive do
+      {:data, port, datadog_pid} ->
+        :erlang.trace(datadog_pid, true, [:receive])
+        true = Process.exit(port, :portkill)
+        assert_receive {:trace, ^datadog_pid, :receive, {:EXIT, port, :portkill}}
+    end
   end
 end

--- a/apps/omg_status/test/omg_status/metric/statsd_monitor_test.exs
+++ b/apps/omg_status/test/omg_status/metric/statsd_monitor_test.exs
@@ -25,6 +25,7 @@ defmodule OMG.Status.Metric.StatsdMonitorTest do
     on_exit(fn ->
       Process.exit(alarm_process, :cleanup)
       Process.exit(statsd_monitor, :cleanup)
+      Process.sleep(10)
     end)
 
     %{

--- a/apps/omg_status/test/omg_status/metric/statsd_monitor_test.exs
+++ b/apps/omg_status/test/omg_status/metric/statsd_monitor_test.exs
@@ -35,6 +35,8 @@ defmodule OMG.Status.Metric.StatsdMonitorTest do
 
   test "if exiting process/port sends an exit signal to the parent process", %{alarm_process: alarm_process} do
     :erlang.trace(alarm_process, true, [:receive])
+    %{pid: pid} = :sys.get_state(StatsdMonitor)
+    true = Process.exit(pid, :testkill)
     assert_receive :got_raise_alarm
   end
 
@@ -42,10 +44,9 @@ defmodule OMG.Status.Metric.StatsdMonitorTest do
     alarm_process: alarm_process,
     statsd_monitor: _statsd_monitor
   } do
+    %{pid: pid} = :sys.get_state(StatsdMonitor)
     :erlang.trace(alarm_process, true, [:receive])
-    {:ok, statsd_wrapper} = __MODULE__.StasdWrapper.start()
-    assert_receive :got_clear_alarm
-    true = Process.exit(statsd_wrapper, :testkill)
+    true = Process.exit(pid, :testkill)
     assert_receive :got_raise_alarm
     assert_receive :got_clear_alarm
   end
@@ -81,8 +82,8 @@ defmodule OMG.Status.Metric.StatsdMonitorTest do
   defmodule StasdWrapper do
     use GenServer
 
-    def start do
-      GenServer.start(__MODULE__, [], [])
+    def start_link do
+      GenServer.start_link(__MODULE__, [], [])
     end
 
     def init(_) do


### PR DESCRIPTION
…rocess

//

## Overview

Swaping Kernel monitor for link.

## Changes

- test fixes
- genserver exposing start_link instead of kernel monitor

## Testing

/
