### PR TITLE
fix: start and override config for dev datadog

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -132,6 +132,8 @@ docker-push: docker
 	docker push $(CHILD_CHAIN_IMAGE_NAME)
 	docker push $(WATCHER_IMAGE_NAME)
 
+cluster-with-datadog:
+	docker-compose -f docker-compose.yml -f docker-compose.dev.yml up plasma-deployer watcher childchain
 
 ### UTILS
 OSFLAG := ''

--- a/apps/omg_db/lib/omg_db/release_tasks/init_key_value_db.ex
+++ b/apps/omg_db/lib/omg_db/release_tasks/init_key_value_db.ex
@@ -21,7 +21,7 @@ defmodule OMG.DB.ReleaseTasks.InitKeyValueDB do
   alias OMG.Utils.CLI
 
   def run do
-    path = Application.get_env(:omg_db, :path)
+    path = System.get_env("DB_PATH")
     _ = process(path)
     :ok
   end

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -8,10 +8,14 @@ services:
     volumes:
       - .:/home/elixir-user/elixir-omg
   watcher:
+    environment:
+      - DD_DISABLED=false
     depends_on:
       datadog:
         condition: service_healthy
   childchain:
+    environment:
+      - DD_DISABLED=false
     depends_on:
       datadog:
         condition: service_healthy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,10 +57,12 @@ services:
       - ETHEREUM_WS_RPC_URL=ws://geth:8546
       - CHILD_CHAIN_URL=http://childchain:9656
       - ETHEREUM_NETWORK=LOCALCHAIN
-      - ERL_CC_COOKIE=develop
+      - ERLANG_COOKIE=develop
+      - NODE_HOST=127.0.0.1
       - APP_ENV=local_development_child_chain
       - DD_HOSTNAME=datadog
       - DD_DISABLED=true
+      - DB_PATH=/app/.omg/data
     restart: always
     ports:
       - "9656:9656"
@@ -87,10 +89,12 @@ services:
       - CHILD_CHAIN_URL=http://childchain:9656
       - ETHEREUM_NETWORK=LOCALCHAIN
       - DATABASE_URL=postgres://omisego_dev:omisego_dev@postgres:5432/omisego_dev
-      - ERL_W_COOKIE=develop
+      - ERLANG_COOKIE=develop
+      - NODE_HOST=127.0.0.1
       - APP_ENV=local_development_watcher
       - DD_HOSTNAME=datadog
       - DD_DISABLED=true
+      - DB_PATH=/app/.omg/data
     restart: always
     ports:
       - "7434:7434"


### PR DESCRIPTION
Quicker cluster startup with Datadog

## Overview

Override enivornment variables in docker compose for development and a Makefile entry to ease typing.

## Changes

^^

## Testing

/