### PR TITLE
fix: deploying frequently dies because of insufficient gas

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,5 @@ env/
 # VS Code config file
 .vscode/
 
+# Docker
+src/

--- a/Makefile
+++ b/Makefile
@@ -135,6 +135,9 @@ docker-push: docker
 cluster-with-datadog:
 	docker-compose -f docker-compose.yml -f docker-compose.dev.yml up plasma-deployer watcher childchain
 
+stop-cluster-with-datadog:
+	docker-compose -f docker-compose.yml -f docker-compose.dev.yml down
+
 ### UTILS
 OSFLAG := ''
 UNAME_S := $(shell uname -s)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,18 +23,19 @@ services:
       - "8000:8000"
     expose:
       - "8000"
+    restart: always
     healthcheck:
       test: curl plasma-deployer:8000
-      interval: 7s
-      timeout: 3s
-      retries: 15
+      interval: 30s
+      timeout: 1s
+      retries: 5
     depends_on:
       geth:
         condition: service_healthy
 
   geth:
-    image: ethereum/client-go:v1.8.21
-    entrypoint: /bin/sh -c "apk add curl && geth --targetgaslimit "8000000" --dev --dev.period 1 --rpc --rpcapi personal,web3,eth,net --rpcaddr 0.0.0.0 --rpcvhosts=* --rpcport=8545 --ws --wsaddr 0.0.0.0 --wsorigins='*'"
+    image: ethereum/client-go:v1.8.27
+    entrypoint: /bin/sh -c "apk add curl && geth --miner.gastarget 7500000 --miner.gasprice "10" --dev --dev.period 1 --rpc --rpcapi personal,web3,eth,net --rpcaddr 0.0.0.0 --rpcvhosts=* --rpcport=8545 --ws --wsaddr 0.0.0.0 --wsorigins='*'"
     ports:
       - "8545:8545"
       - "8546:8546"
@@ -70,9 +71,9 @@ services:
       - "9656"
     healthcheck:
       test: curl childchain:9656
-      interval: 7s
-      timeout: 3s
-      retries: 15
+      interval: 30s
+      timeout: 1s
+      retries: 5
     depends_on:
       plasma-deployer:
         condition: service_healthy
@@ -102,8 +103,8 @@ services:
       - "7434"
     healthcheck:
       test: curl watcher:7434
-      interval: 5s
-      timeout: 3s
+      interval: 30s
+      timeout: 1s
       retries: 5
     depends_on:
       plasma-deployer:


### PR DESCRIPTION
deploying dies
```
plasma-deployer_1  | 15:49:08.921 [info]  2_initial_migration.js
plasma-deployer_1  | 
plasma-deployer_1  | 15:49:08.921 [info]  ======================
plasma-deployer_1  | 
plasma-deployer_1  | 15:49:08.921 [info]  
plasma-deployer_1  | 
plasma-deployer_1  | 15:49:08.921 [info]     Deploying 'Migrations'
plasma-deployer_1  | 
plasma-deployer_1  | 15:49:08.921 [info]     ----------------------
plasma-deployer_1  | 
plasma-deployer_1  | 15:49:08.921 [info]  Error: Error: Error:  *** Deployment Failed ***
plasma-deployer_1  | 
plasma-deployer_1  | 15:49:08.921 [info]  
plasma-deployer_1  | 
plasma-deployer_1  | 15:49:08.921 [info]  "Migrations" exceeded the block limit (with a gas value you set).
plasma-deployer_1  | 
plasma-deployer_1  | 15:49:08.921 [info]     * Block limit:  0x2015b79
plasma-deployer_1  | 
plasma-deployer_1  | 15:49:08.921 [info]     * Gas sent:     6721975
plasma-deployer_1  | 
plasma-deployer_1  | 15:49:08.921 [info]     * Try:
plasma-deployer_1  | 
plasma-deployer_1  | 15:49:08.921 [info]        + Sending less gas.
plasma-deployer_1  | 
plasma-deployer_1  | 15:49:08.921 [info]        + Setting a higher network block limit if you are on a
plasma-deployer_1  | 
plasma-deployer_1  | 15:49:08.921 [info]          private network or test client (like ganache).
plasma-deployer_1  | 
plasma-deployer_1  | 15:49:08.921 [info]  
plasma-deployer_1  | 
plasma-deployer_1  | 15:49:08.921 [info]      at Object.run (/opt/plasma_deployer/node_modules/truffle/build/webpack:/packages/truffle-migrate/index.js:92:1)
```

## Overview

Not sure why but the third retry usually succeeds.

## Changes

- Makefile and dockercompose timeouts for healthchecks
- `targetgaslimit` is deprecated (https://github.com/ethereum/go-ethereum/blob/release/1.8/cmd/utils/flags.go#L353)
- geth bump

## Testing
