### PR TITLE
fix: lower the fee_file_check_interval_ms in tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,6 +319,8 @@ Affects how quick the services reading Ethereum events realize there's a new blo
 
 * **`block_queue_eth_height_check_interval_ms`** - polling interval for checking whether the root chain had progressed for the `BlockQueue` exclusively
 
+* **`fee_file_check_interval_ms`** - interval for checking updates in the `fee_specs.json` file to update the fees required.
+
 * **`child_block_minimal_enqueue_gap`** - how many new Ethereum blocks must be mined, since previous submission **attempt**, before another block is going to be formed and submitted.
 
 * **`fee_specs_file_name`** - path to file which defines fee requirements, see [fee_specs.json](fee_specs.json) for an example.

--- a/apps/omg_child_chain/config/config.exs
+++ b/apps/omg_child_chain/config/config.exs
@@ -5,6 +5,7 @@ use Mix.Config
 config :omg_child_chain,
   submission_finality_margin: 20,
   block_queue_eth_height_check_interval_ms: 6_000,
+  fee_file_check_interval_ms: 10_000,
   child_block_minimal_enqueue_gap: 1,
   fee_specs_file_name: "fee_specs.json",
   ignore_fees: false,

--- a/apps/omg_child_chain/config/test.exs
+++ b/apps/omg_child_chain/config/test.exs
@@ -1,4 +1,5 @@
 use Mix.Config
 
 config :omg_child_chain,
-  block_queue_eth_height_check_interval_ms: 100
+  block_queue_eth_height_check_interval_ms: 100,
+  fee_file_check_interval_ms: 1_000

--- a/apps/omg_child_chain/lib/omg_child_chain/fee_server.ex
+++ b/apps/omg_child_chain/lib/omg_child_chain/fee_server.ex
@@ -28,7 +28,7 @@ defmodule OMG.ChildChain.FeeServer do
   use GenServer
   use OMG.Utils.LoggerExt
 
-  @file_check_default_interval_ms 10_000
+  @fee_file_check_interval_ms Application.fetch_env!(:omg_child_chain, :fee_file_check_interval_ms)
 
   def start_link(opts) do
     GenServer.start_link(__MODULE__, opts, name: __MODULE__)
@@ -46,7 +46,7 @@ defmodule OMG.ChildChain.FeeServer do
 
         opt when is_nil(opt) or is_boolean(opt) ->
           :ok = update_fee_spec()
-          interval = Keyword.get(args, :interval_ms, @file_check_default_interval_ms)
+          interval = Keyword.get(args, :interval_ms, @fee_file_check_interval_ms)
           {:ok, tref} = :timer.send_interval(interval, self(), :update_fee_spec)
           Keyword.put(args, :tref, tref)
       end


### PR DESCRIPTION
-

## Overview

Lowers the said interval in tests - without this, some glitches in the behavior of the child chain were uncaught (revolving around fee-file-reading and simple perf test)

## Changes

Unhardcodes the interval. Non `:test` behavior stays the same.

## Testing

Same tests