### PR TITLE
Fix docker-compose-watcher.yml

### DIFF
--- a/docker-compose-watcher.yml
+++ b/docker-compose-watcher.yml
@@ -29,6 +29,7 @@ services:
       - DATABASE_URL=postgres://omisego_dev:omisego_dev@postgres:5432/omisego_dev
       - NODE_HOST=127.0.0.1
       - DD_DISABLED=true
+      - DB_PATH=/app/.omg/data
       - APP_ENV=localwatcher
     ports:
       - "7434:7434"


### PR DESCRIPTION
## Overview

This PR addresses an issue I encountered when attempting to start the Watcher on it's own via the `docker-compose -f docker-compose-watcher.yml up` command. When attempting to do so, I would consistently get the following error:

```
watcher_1   | Creating database at nil
watcher_1   | ▸  Evaluation failed with: function nil.init_storage/1 is undefined
watcher_1   | ▸      nil.init_storage("/app")
watcher_1   | ▸      (omg_db) lib/omg_db/level_db.ex:138: OMG.DB.LevelDB.do_init/2
watcher_1   | ▸      (omg_db) lib/omg_db/release_tasks/init_key_value_db.ex:37: OMG.DB.ReleaseTasks.InitKeyValueDB.init_kv_db/1
watcher_1   | ▸      (omg_db) lib/omg_db/release_tasks/init_key_value_db.ex:32: OMG.DB.ReleaseTasks.InitKeyValueDB.process/1
watcher_1   | ▸      (omg_db) lib/omg_db/release_tasks/init_key_value_db.ex:25: OMG.DB.ReleaseTasks.InitKeyValueDB.run/0
watcher_1   | ▸      (distillery) lib/distillery/releases/runtime/control.ex:743: Distillery.Releases.Runtime.Control.eval/2
watcher_1   | ▸      (distillery) lib/entry.ex:44: Distillery.Releases.Runtime.Control.main/1
watcher_1   | ▸      (stdlib) erl_eval.erl:680: :erl_eval.do_apply/6
watcher_1   | [cmd] /watcher_entrypoint exited 1
watcher_1   | [cont-finish.d] executing container finish scripts...
watcher_1   | [cont-finish.d] done.
watcher_1   | [s6-finish] syncing disks.
watcher_1   | [s6-finish] sending all processes the TERM signal.
watcher_1   | [s6-finish] sending all processes the KILL signal and exiting.
elixir-omg_watcher_1 exited with code 1
```

## Changes

Add `- DB_PATH=/app/.omg/data` as an environment variable for the watcher in `docker-compose-watcher.yml `, as it is set in `docker-compose.yml`
