### PR TITLE
feature: expose child chain alarms via alarm.get

### DIFF
--- a/apps/omg_child_chain/lib/child_chain.ex
+++ b/apps/omg_child_chain/lib/child_chain.ex
@@ -19,6 +19,7 @@ defmodule OMG.ChildChain do
   Should handle all the initial processing of requests like state-less validity, decoding/encoding
   (but not transport-specific encoding like hex).
   """
+  use OMG.Utils.LoggerExt
 
   alias OMG.Block
   alias OMG.ChildChain.FeeServer
@@ -26,7 +27,7 @@ defmodule OMG.ChildChain do
   alias OMG.Fees
   alias OMG.State
   alias OMG.State.Transaction
-  use OMG.Utils.LoggerExt
+  alias OMG.Status.Alert.Alarm
 
   @type submit_error() :: Transaction.Recovered.recover_tx_error() | State.exec_error()
 
@@ -51,8 +52,6 @@ defmodule OMG.ChildChain do
     end
     |> result_with_logging()
   end
-
-  alias OMG.Status.Alert.Alarm
 
   @spec get_alarms() :: {:ok, Alarm.raw_t()}
   def get_alarms, do: {:ok, Alarm.all()}

--- a/apps/omg_child_chain/lib/child_chain.ex
+++ b/apps/omg_child_chain/lib/child_chain.ex
@@ -52,6 +52,11 @@ defmodule OMG.ChildChain do
     |> result_with_logging()
   end
 
+  alias OMG.Status.Alert.Alarm
+
+  @spec get_alarms() :: {:ok, Alarm.raw_t()}
+  def get_alarms, do: {:ok, Alarm.all()}
+
   defp result_with_logging(result) do
     _ = Logger.debug(" resulted with #{inspect(result)}")
     result

--- a/apps/omg_child_chain/lib/omg_child_chain/monitor.ex
+++ b/apps/omg_child_chain/lib/omg_child_chain/monitor.ex
@@ -52,9 +52,8 @@ defmodule OMG.ChildChain.Monitor do
   def init([alarm_module, children_specs]) do
     install()
     Process.flag(:trap_exit, true)
-
+    _ = Logger.info("Starting #{__MODULE__}")
     children = Enum.map(children_specs, &start_child(&1))
-
     {:ok, %__MODULE__{alarm_module: alarm_module, children: children}}
   end
 
@@ -144,8 +143,8 @@ defmodule OMG.ChildChain.Monitor do
     alarms = alarm_module.all()
 
     alarms
-    |> Enum.find(fn x -> match?(%{id: :ethereum_client_connection}, x) end)
-    |> is_map()
+    |> Enum.find(fn x -> match?(:ethereum_client_connection, elem(x, 0)) end)
+    |> is_tuple()
   end
 
   defp install do

--- a/apps/omg_child_chain/mix.exs
+++ b/apps/omg_child_chain/mix.exs
@@ -41,7 +41,6 @@ defmodule OMG.ChildChain.MixProject do
       {:omg_db, in_umbrella: true},
       {:omg_eth, in_umbrella: true},
       {:omg_utils, in_umbrella: true}
-      # {:omg_child_chain_rpc, in_umbrella: true, only: [:test]}
     ]
   end
 end

--- a/apps/omg_child_chain/mix.exs
+++ b/apps/omg_child_chain/mix.exs
@@ -40,8 +40,8 @@ defmodule OMG.ChildChain.MixProject do
       {:omg_status, in_umbrella: true},
       {:omg_db, in_umbrella: true},
       {:omg_eth, in_umbrella: true},
-      {:omg_utils, in_umbrella: true},
-      {:omg_child_chain_rpc, in_umbrella: true, only: [:test]}
+      {:omg_utils, in_umbrella: true}
+      # {:omg_child_chain_rpc, in_umbrella: true, only: [:test]}
     ]
   end
 end

--- a/apps/omg_child_chain/test/omg_child_chain/child_chain_test.exs
+++ b/apps/omg_child_chain/test/omg_child_chain/child_chain_test.exs
@@ -18,10 +18,10 @@ defmodule OMG.ChildChainTest do
   use ExUnit.Case, async: false
 
   setup_all do
-    _ = Application.ensure_all_started(:omg_status)
+    {:ok, apps} = Application.ensure_all_started(:omg_status)
 
     on_exit(fn ->
-      _ = Application.stop(:omg_status)
+      apps |> Enum.reverse() |> Enum.each(fn app -> Application.stop(app) end)
     end)
   end
 

--- a/apps/omg_child_chain/test/omg_child_chain/child_chain_test.exs
+++ b/apps/omg_child_chain/test/omg_child_chain/child_chain_test.exs
@@ -1,0 +1,61 @@
+# Copyright 2019 OmiseGO Pte Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defmodule OMG.ChildChainTest do
+  alias OMG.ChildChain
+  use ExUnit.Case, async: false
+
+  setup_all do
+    _ = Application.ensure_all_started(:omg_status)
+
+    on_exit(fn ->
+      _ = Application.stop(:omg_status)
+    end)
+  end
+
+  setup %{} do
+    system_alarm = {:system_memory_high_watermark, []}
+    system_disk_alarm = {{:disk_almost_full, "/dev/null"}, []}
+    app_alarm = {:ethereum_client_connection, %{node: Node.self(), reporter: __MODULE__}}
+
+    on_exit(fn ->
+      :alarm_handler.clear_alarm(app_alarm)
+      :alarm_handler.clear_alarm(system_alarm)
+      :alarm_handler.clear_alarm(system_disk_alarm)
+    end)
+
+    %{system_alarm: system_alarm, system_disk_alarm: system_disk_alarm, app_alarm: app_alarm}
+  end
+
+  test "if alarms are returned when there are no alarms raised", _ do
+    {:ok, []} = ChildChain.get_alarms()
+  end
+
+  test "if alarms are returned when there are alarms raised", %{
+    system_alarm: system_alarm,
+    system_disk_alarm: system_disk_alarm,
+    app_alarm: app_alarm
+  } do
+    :alarm_handler.set_alarm(system_alarm)
+    :alarm_handler.set_alarm(app_alarm)
+    :alarm_handler.set_alarm(system_disk_alarm)
+
+    {:ok,
+     [
+       {{:disk_almost_full, "/dev/null"}, []},
+       {:ethereum_client_connection, %{node: :nonode@nohost, reporter: __MODULE__}},
+       {:system_memory_high_watermark, []}
+     ]} = ChildChain.get_alarms()
+  end
+end

--- a/apps/omg_child_chain/test/omg_child_chain/integration/fixtures.exs
+++ b/apps/omg_child_chain/test/omg_child_chain/integration/fixtures.exs
@@ -46,9 +46,10 @@ defmodule OMG.ChildChain.Integration.Fixtures do
     _ = fee_file
     # need to override that to very often, so that many checks fall in between a single child chain block submission
     {:ok, started_apps} = Application.ensure_all_started(:omg_child_chain)
+    {:ok, started_apps_rpc} = Application.ensure_all_started(:omg_child_chain_rpc)
 
     on_exit(fn ->
-      started_apps
+      (started_apps ++ started_apps_rpc)
       |> Enum.reverse()
       |> Enum.map(fn app -> :ok = Application.stop(app) end)
     end)

--- a/apps/omg_child_chain_rpc/config/config.exs
+++ b/apps/omg_child_chain_rpc/config/config.exs
@@ -7,9 +7,6 @@
 # General application configuration
 use Mix.Config
 
-config :omg_child_chain_rpc,
-  child_chain_api_module: OMG.ChildChain
-
 # Configures the endpoint
 config :omg_child_chain_rpc, OMG.ChildChainRPC.Web.Endpoint,
   render_errors: [view: OMG.ChildChainRPC.Web.Views.Error, accepts: ~w(json)],

--- a/apps/omg_child_chain_rpc/lib/omg_child_chain_rpc/web/controllers/alarm.ex
+++ b/apps/omg_child_chain_rpc/lib/omg_child_chain_rpc/web/controllers/alarm.ex
@@ -12,22 +12,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-defmodule OMG.ChildChainRPC.Web.Router do
-  use OMG.ChildChainRPC.Web, :router
+defmodule OMG.ChildChainRPC.Web.Controller.Alarm do
+  @moduledoc """
+  Module provides operation related to the child chain raised alarms that might point to
+  faulty childchain node.
+  """
 
-  pipeline :api do
-    plug(:accepts, ["json"])
-    plug(OMG.ChildChainRPC.Plugs.Health)
-  end
+  use OMG.ChildChainRPC.Web, :controller
 
-  scope "/", OMG.ChildChainRPC.Web do
-    pipe_through(:api)
+  alias OMG.ChildChain
+  alias OMG.ChildChainRPC.Web.View
 
-    post("/block.get", Controller.Block, :get_block)
-    post("/transaction.submit", Controller.Transaction, :submit)
-    post("/alarm.get", Controller.Alarm, :get_alarms)
+  def get_alarms(conn, _params) do
+    {:ok, alarms} = ChildChain.get_alarms()
 
-    # NOTE: This *has to* be the last route, catching all unhandled paths
-    match(:*, "/*path", Controller.Fallback, Route.NotFound)
+    conn
+    |> put_view(View.Alarm)
+    |> render(:alarm, response: alarms)
   end
 end

--- a/apps/omg_child_chain_rpc/lib/omg_child_chain_rpc/web/controllers/block.ex
+++ b/apps/omg_child_chain_rpc/lib/omg_child_chain_rpc/web/controllers/block.ex
@@ -19,13 +19,12 @@ defmodule OMG.ChildChainRPC.Web.Controller.Block do
 
   use OMG.ChildChainRPC.Web, :controller
 
+  alias OMG.ChildChain
   alias OMG.ChildChainRPC.Web.View
-
-  @api_module Application.fetch_env!(:omg_child_chain_rpc, :child_chain_api_module)
 
   def get_block(conn, params) do
     with {:ok, hash} <- expect(params, "hash", :hash),
-         {:ok, block} <- apply(@api_module, :get_block, [hash]) do
+         {:ok, block} <- ChildChain.get_block(hash) do
       conn
       |> put_view(View.Block)
       |> render(:block, block: block)

--- a/apps/omg_child_chain_rpc/lib/omg_child_chain_rpc/web/controllers/transaction.ex
+++ b/apps/omg_child_chain_rpc/lib/omg_child_chain_rpc/web/controllers/transaction.ex
@@ -19,13 +19,12 @@ defmodule OMG.ChildChainRPC.Web.Controller.Transaction do
 
   use OMG.ChildChainRPC.Web, :controller
 
+  alias OMG.ChildChain
   alias OMG.ChildChainRPC.Web.View
-
-  @api_module Application.fetch_env!(:omg_child_chain_rpc, :child_chain_api_module)
 
   def submit(conn, params) do
     with {:ok, txbytes} <- expect(params, "transaction", :hex),
-         {:ok, details} <- apply(@api_module, :submit, [txbytes]) do
+         {:ok, details} <- ChildChain.submit(txbytes) do
       conn
       |> put_view(View.Transaction)
       |> render(:submit, result: details)

--- a/apps/omg_child_chain_rpc/lib/omg_child_chain_rpc/web/views/alarm.ex
+++ b/apps/omg_child_chain_rpc/lib/omg_child_chain_rpc/web/views/alarm.ex
@@ -12,22 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-defmodule OMG.ChildChainRPC.Web.Router do
-  use OMG.ChildChainRPC.Web, :router
+defmodule OMG.ChildChainRPC.Web.View.Alarm do
+  @moduledoc """
+  The status view for rendering json
+  """
 
-  pipeline :api do
-    plug(:accepts, ["json"])
-    plug(OMG.ChildChainRPC.Plugs.Health)
-  end
+  use OMG.ChildChainRPC.Web, :view
+  alias OMG.Utils.HttpRPC.Response
 
-  scope "/", OMG.ChildChainRPC.Web do
-    pipe_through(:api)
-
-    post("/block.get", Controller.Block, :get_block)
-    post("/transaction.submit", Controller.Transaction, :submit)
-    post("/alarm.get", Controller.Alarm, :get_alarms)
-
-    # NOTE: This *has to* be the last route, catching all unhandled paths
-    match(:*, "/*path", Controller.Fallback, Route.NotFound)
+  def render("alarm.json", %{response: alarms}) do
+    Response.serialize(alarms)
   end
 end

--- a/apps/omg_child_chain_rpc/mix.exs
+++ b/apps/omg_child_chain_rpc/mix.exs
@@ -48,7 +48,8 @@ defmodule OMG.ChildChainRPC.MixProject do
       #
       {:omg_bus, in_umbrella: true},
       {:omg_status, in_umbrella: true},
-      {:omg_utils, in_umbrella: true}
+      {:omg_utils, in_umbrella: true},
+      {:omg_child_chain, in_umbrella: true}
     ]
   end
 end

--- a/apps/omg_child_chain_rpc/test/omg_child_chain_rpc/web/controllers/alarm_test.exs
+++ b/apps/omg_child_chain_rpc/test/omg_child_chain_rpc/web/controllers/alarm_test.exs
@@ -1,0 +1,40 @@
+# Copyright 2019 OmiseGO Pte Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defmodule OMG.ChildChainRPC.Web.Controller.AlarmTest do
+  use ExUnitFixtures
+  use ExUnit.Case, async: true
+
+  alias OMG.ChildChainRPC.Web.TestHelper
+
+  setup do
+    {:ok, apps} = Application.ensure_all_started(:omg_status)
+
+    Enum.each(
+      :gen_event.call(:alarm_handler, OMG.Status.Alert.AlarmHandler, :get_alarms),
+      fn alarm -> :alarm_handler.clear_alarm(alarm) end
+    )
+
+    on_exit(fn ->
+      Enum.each(apps, fn app -> :ok = Application.stop(app) end)
+    end)
+  end
+
+  ### a very basic test of empty alarms should be sufficient, alarms encoding is
+  ### covered in OMG.Utils.HttpRPC.ResponseTest
+  @tag fixtures: [:phoenix_sandbox]
+  test "if the controller returns the correct result when there's no alarms raised", _ do
+    assert %{"data" => [], "success" => true, "version" => "0.2"} == TestHelper.rpc_call(:post, "alarm.get")
+  end
+end

--- a/apps/omg_child_chain_rpc/test/support/web/test_helper.ex
+++ b/apps/omg_child_chain_rpc/test/support/web/test_helper.ex
@@ -45,5 +45,17 @@ defmodule OMG.ChildChainRPC.Web.TestHelper do
     Jason.decode!(response.resp_body)
   end
 
-  defp send_request(req), do: OMG.ChildChainRPC.Web.Endpoint.call(req, [])
+  # dear god this is ugly
+  defp send_request(req) do
+    case Process.whereis(OMG.ChildChainRPC.Web.Endpoint) do
+      nil ->
+        _ = Application.ensure_all_started(:omg_child_chain_rpc)
+        do_send_request(req)
+
+      _ ->
+        do_send_request(req)
+    end
+  end
+
+  defp do_send_request(req), do: apply(OMG.ChildChainRPC.Web.Endpoint, :call, [req, []])
 end

--- a/apps/omg_performance/lib/performance.ex
+++ b/apps/omg_performance/lib/performance.ex
@@ -151,7 +151,7 @@ defmodule OMG.Performance do
 
     :ok = OMG.DB.init()
 
-    started_apps = ensure_all_started([:omg_db, :cowboy, :hackney, :omg_bus, :omg_child_chain_rpc])
+    started_apps = ensure_all_started([:omg_db, :cowboy, :hackney, :omg_bus])
     {:ok, simple_perftest_chain} = start_simple_perftest_chain(opts)
 
     {:ok, started_apps, simple_perftest_chain}
@@ -163,6 +163,8 @@ defmodule OMG.Performance do
   # Instead, we start the artificial `BlockCreator`
   defp start_simple_perftest_chain(opts) do
     children = [
+      {OMG.ChildChainRPC.Plugs.Health, []},
+      {OMG.ChildChainRPC.Web.Endpoint, []},
       {OMG.State, []},
       {OMG.ChildChain.FreshBlocks, []},
       {OMG.ChildChain.FeeServer, []},

--- a/apps/omg_status/lib/omg_status/alert/alarm_handler.ex
+++ b/apps/omg_status/lib/omg_status/alert/alarm_handler.ex
@@ -18,10 +18,16 @@ defmodule OMG.Status.Alert.AlarmHandler do
   """
 
   def install do
-    previous_alarms = :alarm_handler.get_alarms()
-    :ok = :gen_event.swap_handler(:alarm_handler, {:alarm_handler, :swap}, {__MODULE__, :ok})
-    # migrates old alarms
-    Enum.each(previous_alarms, &:alarm_handler.set_alarm(&1))
+    case Enum.member?(:gen_event.which_handlers(:alarm_handler), __MODULE__) do
+      true ->
+        :ok
+
+      false ->
+        previous_alarms = :alarm_handler.get_alarms()
+        :ok = :gen_event.swap_handler(:alarm_handler, {:alarm_handler, :swap}, {__MODULE__, :ok})
+        # migrates old alarms
+        Enum.each(previous_alarms, &:alarm_handler.set_alarm(&1))
+    end
   end
 
   # -----------------------------------------------------------------

--- a/apps/omg_watcher/lib/omg_watcher/monitor.ex
+++ b/apps/omg_watcher/lib/omg_watcher/monitor.ex
@@ -144,8 +144,8 @@ defmodule OMG.Watcher.Monitor do
     alarms = alarm_module.all()
 
     alarms
-    |> Enum.find(fn x -> match?(%{id: :ethereum_client_connection}, x) end)
-    |> is_map()
+    |> Enum.find(fn x -> match?(:ethereum_client_connection, elem(x, 0)) end)
+    |> is_tuple()
   end
 
   defp install do

--- a/apps/omg_watcher/test/omg_watcher/api/alarm_test.exs
+++ b/apps/omg_watcher/test/omg_watcher/api/alarm_test.exs
@@ -21,7 +21,7 @@ defmodule OMG.Watcher.API.AlarmTest do
     {:ok, apps} = Application.ensure_all_started(:omg_status)
     system_alarm = {:system_memory_high_watermark, []}
     system_disk_alarm = {{:disk_almost_full, "/dev/null"}, []}
-    app_alarm = {:ethereum_client_connection, %{node: Node.self(), reporter: __MODULE__}}
+    app_alarm = {:ethereum_client_connection, %{node: Node.self(), reporter: Reporter}}
 
     on_exit(fn ->
       apps |> Enum.reverse() |> Enum.each(fn app -> Application.stop(app) end)
@@ -47,7 +47,7 @@ defmodule OMG.Watcher.API.AlarmTest do
     {:ok,
      [
        {{:disk_almost_full, "/dev/null"}, []},
-       {:ethereum_client_connection, %{node: :nonode@nohost, reporter: __MODULE__}},
+       {:ethereum_client_connection, %{node: :nonode@nohost, reporter: Reporter}},
        {:system_memory_high_watermark, []}
      ]} = Alarm.get_alarms()
   end

--- a/apps/omg_watcher/test/omg_watcher/integration/monitor_test.exs
+++ b/apps/omg_watcher/test/omg_watcher/integration/monitor_test.exs
@@ -26,7 +26,12 @@ defmodule OMG.Watcher.MonitorTest do
   @moduletag timeout: 120_000
 
   setup_all do
-    _ = Application.ensure_all_started(:omg_status)
+    {:ok, apps} = Application.ensure_all_started(:omg_status)
+
+    on_exit(fn ->
+      apps |> Enum.reverse() |> Enum.each(fn app -> Application.stop(app) end)
+    end)
+
     :ok
   end
 

--- a/apps/omg_watcher/test/omg_watcher/integration/monitor_test.exs
+++ b/apps/omg_watcher/test/omg_watcher/integration/monitor_test.exs
@@ -12,26 +12,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-defmodule OMG.ChildChain.MonitorTest do
+defmodule OMG.Watcher.MonitorTest do
   @moduledoc false
   alias __MODULE__.EthereumClientMock
 
-  alias OMG.ChildChain.Monitor
   alias OMG.Status.Alert.Alarm
+  alias OMG.Watcher.Monitor
 
   use ExUnit.Case, async: true
 
   @moduletag :integration
-  @moduletag :child_chain
+  @moduletag :watcher
   @moduletag timeout: 120_000
 
   setup_all do
-    {:ok, apps} = Application.ensure_all_started(:omg_status)
-
-    on_exit(fn ->
-      apps |> Enum.reverse() |> Enum.each(fn app -> Application.stop(app) end)
-    end)
-
+    _ = Application.ensure_all_started(:omg_status)
     :ok
   end
 

--- a/apps/omg_watcher_rpc/lib/web/controllers/alarm.ex
+++ b/apps/omg_watcher_rpc/lib/web/controllers/alarm.ex
@@ -14,8 +14,8 @@
 
 defmodule OMG.WatcherRPC.Web.Controller.Alarm do
   @moduledoc """
-  Module provides operation related to the child chain raised alarms that might point to
-  faulty childchain node.
+  Module provides operation related to the watcher raised alarms that might point to
+  faulty watcher node.
   """
 
   use OMG.WatcherRPC.Web, :controller

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -93,9 +93,6 @@ Actually `OMG.EthereumEventListener` setup with `:depositor`.
 
 - pushes events to `Phoenix app`
 
-### `OMG.RPC`
-
-- exposes `OMG.ChildChain` (as configured by `:omg_child_chain_rpc, :child_chain_api_module` setting) via a `phoenix`-driven HTTP-RPC interface
 
 ### `OMG.Performance`
 


### PR DESCRIPTION
///

## Overview

Read the raised alarms on an Child Chain endpoint _http://child_chain/alarm.get_

## Changes

- Added a new route!
- Copied tests from Watcher
- Fixed a few other issues
- Decoupled Child Chain from Child Chain RPC so that coupling occurs in the same way as in Watcher. RPC->APP (this allowed me to remove slow dynamic module invocation `apply/3`)


## Testing

Wrote a few tests that should cover all behaviors. 
