### PR TITLE
fix: use release_version in the watcher Dockerfile too, not fixed 0.2.0

### DIFF
--- a/Dockerfile.watcher
+++ b/Dockerfile.watcher
@@ -53,7 +53,7 @@ RUN set -xe \
 
 ARG release_version
 
-ADD _build/prod/rel/watcher/releases/0.2.0/watcher.tar.gz /app
+ADD _build/prod/rel/watcher/releases/${release_version}/watcher.tar.gz /app
 RUN chown -R "${uid}:${gid}" /app
 WORKDIR /app
 


### PR DESCRIPTION
Follow-up to #904 which broke `master` publishing of images b/c of hard-coded 0.2.0 missed.

## Overview

-
## Changes

I'm just doing for `Dockerfile.watcher` what is already done for `child_chain` that works fine.

## Testing

-