### PR TITLE
fix: check if child chain is running

### DIFF
--- a/apps/omg_utils/lib/omg_utils/http_rpc/response.ex
+++ b/apps/omg_utils/lib/omg_utils/http_rpc/response.ex
@@ -98,8 +98,15 @@ defmodule OMG.Utils.HttpRPC.Response do
   # not the most beatuful way of doing this but
   # because our "response serializer" is in utils there's no other way
   defp add_version(response) do
+    # TODO remove this hack when running releases
+    is_child_chain_running =
+      Enum.find(Application.started_applications(), fn
+        {:omg_child_chain_rpc, _, _} -> true
+        _ -> false
+      end)
+
     vsn =
-      if Code.ensure_loaded?(OMG.ChildChainRPC) do
+      if Code.ensure_loaded?(OMG.ChildChainRPC) and is_child_chain_running != nil do
         {:ok, vsn} = :application.get_key(:omg_child_chain_rpc, :vsn)
 
         vsn


### PR DESCRIPTION
Using mix tasks to startup the application (watcher or child chain) all modules are always loaded into the VM. But the application VSN is part of application running which is not. Now development is down.

## Overview

Check if child chain is running every request... HACK.

## Changes

## Testing
