### PR TITLE
fix: set tags programatically

### DIFF
--- a/apps/omg_status/lib/omg_status/metric/vmstats_sink.ex
+++ b/apps/omg_status/lib/omg_status/metric/vmstats_sink.ex
@@ -29,9 +29,38 @@ defmodule OMG.Status.Metric.VmstatsSink do
 
   defp base_key, do: Application.get_env(:vmstats, :base_key)
 
-  def collect(:counter, key, value), do: _ = Datadog.set(key, value)
+  def collect(:counter, key, value), do: _ = Datadog.set(key, value, tags: ["application:#{get_application_mode()}"])
 
-  def collect(:gauge, key, value), do: _ = Datadog.gauge(key, value)
+  def collect(:gauge, key, value), do: _ = Datadog.gauge(key, value, tags: ["application:#{get_application_mode()}"])
 
-  def collect(:timing, key, value), do: _ = Datadog.timing(key, value)
+  def collect(:timing, key, value), do: _ = Datadog.timing(key, value, tags: ["application:#{get_application_mode()}"])
+
+  # TODO yet another hack because of lacking releases
+  # we store the tag in the process dictionary so that we don't have to go through the
+  # difficult path of retrieving it later
+  defp get_application_mode do
+    case Process.get(:application_mode) do
+      nil ->
+        application = application()
+        nil = Process.put(:application_mode, application)
+        application
+
+      application ->
+        application
+    end
+  end
+
+  defp application do
+    is_child_chain_running =
+      Enum.find(Application.started_applications(), fn
+        {:omg_child_chain_rpc, _, _} -> true
+        _ -> false
+      end)
+
+    if Code.ensure_loaded?(OMG.ChildChainRPC) and is_child_chain_running != nil do
+      :child_chain
+    else
+      :watcher
+    end
+  end
 end


### PR DESCRIPTION
DD support has been rather unhelpful in mitigating our infrastructure->tags->datadog problem. 
Just to move us forwards adding this "hack"

## Overview

Adding tags to metrics depending on which application is running

## Changes

- Get the application mode
- Store it in process dictionary
- retrieve it, send it to DD

## Testing


