### PR TITLE
fix: global dd tags comes in 1.2

### DIFF
--- a/apps/omg_status/mix.exs
+++ b/apps/omg_status/mix.exs
@@ -33,7 +33,7 @@ defmodule OMG.Status.Mixfile do
     do: [
       {:telemetry, "~> 0.4.0"},
       {:sentry, "~> 7.0"},
-      {:statix, "~> 1.1"},
+      {:statix, "~> 1.2"},
       {:spandex_datadog, "~> 0.4"},
       {:decorator, "~> 1.2"},
       {:vmstats, "~> 2.3", runtime: false},

--- a/mix.lock
+++ b/mix.lock
@@ -71,7 +71,7 @@
   "spandex_ecto": {:hex, :spandex_ecto, "0.6.0", "feedda8456deb37a87ee698f1f779304b68e7e42afc7c1fe5b9f801a732b89d6", [:mix], [{:spandex, "~> 2.2", [hex: :spandex, repo: "hexpm", optional: false]}], "hexpm"},
   "spandex_phoenix": {:hex, :spandex_phoenix, "0.4.1", "d52e12f801fce4efba658ac4e98be18ea9903ecf9f37682b401656ed8d9c7abe", [:mix], [{:plug, "~> 1.3", [hex: :plug, repo: "hexpm", optional: false]}, {:spandex, "~> 2.2", [hex: :spandex, repo: "hexpm", optional: false]}], "hexpm"},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.4", "f0eafff810d2041e93f915ef59899c923f4568f4585904d010387ed74988e77b", [:make, :mix, :rebar3], [], "hexpm"},
-  "statix": {:hex, :statix, "1.1.0", "af9a4586c5cd58f879e0595f06a4790878715de5b8f75f6346693aaa38da2424", [:mix], [], "hexpm"},
+  "statix": {:hex, :statix, "1.2.1", "4f23c8cc2477ea0de89fed5e34f08c54b0d28b838f7b8f26613155f2221bb31e", [:mix], [], "hexpm"},
   "telemetry": {:hex, :telemetry, "0.4.0", "8339bee3fa8b91cb84d14c2935f8ecf399ccd87301ad6da6b71c09553834b2ab", [:rebar3], [], "hexpm"},
   "unicode_util_compat": {:hex, :unicode_util_compat, "0.4.1", "d869e4c68901dd9531385bb0c8c40444ebf624e60b6962d95952775cac5e90cd", [:rebar3], [], "hexpm"},
   "vmstats": {:hex, :vmstats, "2.3.1", "fa719deb51c53672955cbf0e131cfe85be51732c700d2b58232157ac0478bf4a", [:rebar3], [], "hexpm"},


### PR DESCRIPTION
Tags stopped appearing because https://github.com/lexmag/statix/commit/d1e65cc98a75d22a2d8a36dad41e88ffd802e9ff#diff-4ac32a78649ca5bdd8e0ba38b7006a1eR10

## Overview

Updated Statix to 1.2

## Changes



## Testing

/
