### PR TITLE
fix: set tag per app

### DIFF
--- a/apps/omg_child_chain_rpc/lib/omg_child_chain_rpc/application.ex
+++ b/apps/omg_child_chain_rpc/lib/omg_child_chain_rpc/application.ex
@@ -32,6 +32,7 @@ defmodule OMG.ChildChainRPC.Application do
       {OMG.ChildChainRPC.Web.Endpoint, []}
     ]
 
+    set_statix_global_tag()
     Supervisor.start_link(children, opts)
   end
 
@@ -40,5 +41,9 @@ defmodule OMG.ChildChainRPC.Application do
   def config_change(changed, _new, removed) do
     OMG.ChildChainRPC.Web.Endpoint.config_change(changed, removed)
     :ok
+  end
+
+  defp set_statix_global_tag do
+    Application.put_env(:statix, :tags, ["application:child_chain"], persistent: true)
   end
 end

--- a/apps/omg_watcher_rpc/lib/application.ex
+++ b/apps/omg_watcher_rpc/lib/application.ex
@@ -42,6 +42,7 @@ defmodule OMG.WatcherRPC.Application do
       name: OMG.WatcherRPC.RootSupervisor
     ]
 
+    set_statix_global_tag()
     Supervisor.start_link(children, opts)
   end
 
@@ -50,5 +51,9 @@ defmodule OMG.WatcherRPC.Application do
   def config_change(changed, _new, removed) do
     OMG.WatcherRPC.Web.Endpoint.config_change(changed, removed)
     :ok
+  end
+
+  defp set_statix_global_tag do
+    Application.put_env(:statix, :tags, ["application:watcher"], persistent: true)
   end
 end


### PR DESCRIPTION
Neither child chain or watcher are running when omg status app boots...

## Overview


## Changes

Describe your changes and implementation choices. More details make PRs easier to review.

- Changes in appropriate applications

## Testing

/
