### PR TITLE
fix: set to gauge

### DIFF
--- a/apps/omg_status/lib/omg_status/metric/vmstats_sink.ex
+++ b/apps/omg_status/lib/omg_status/metric/vmstats_sink.ex
@@ -28,8 +28,9 @@ defmodule OMG.Status.Metric.VmstatsSink do
   end
 
   defp base_key, do: Application.get_env(:vmstats, :base_key)
-
-  def collect(:counter, key, value), do: _ = Datadog.set(key, value)
+  # statix currently does not support `count` or `monotonic_count`, only increment and decrement
+  # because of that, we're sending counters as gauges
+  def collect(:counter, key, value), do: _ = Datadog.gauge(key, value)
 
   def collect(:gauge, key, value), do: _ = Datadog.gauge(key, value)
 


### PR DESCRIPTION
As per 
https://docs.datadoghq.com/developers/metrics/counts/
and
https://github.com/lexmag/statix/blob/master/lib/statix.ex

Statix does not currently support sending counters as `count`

## Overview

Changing wrong use of `set` to `gauge` so that we're able to show reductions, io operations etc.

## Changes

- set to gaguge + comment

## Testing
/
