### PR TITLE
Triage Sobelow findings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,6 @@ env/
 
 # Docker
 src/
+
+# Sobelow
+.sobelow

--- a/apps/omg_child_chain/lib/omg_child_chain/application.ex
+++ b/apps/omg_child_chain/lib/omg_child_chain/application.ex
@@ -54,7 +54,7 @@ defmodule OMG.ChildChain.Application do
     end)
   end
 
-  # Only set once during bootup. cookie value retrieved from ENV. 
+  # Only set once during bootup. cookie value retrieved from ENV.
   # sobelow_skip ["DOS.StringToAtom"]
   defp set_cookie(cookie) when is_binary(cookie) do
     cookie

--- a/apps/omg_child_chain/lib/omg_child_chain/application.ex
+++ b/apps/omg_child_chain/lib/omg_child_chain/application.ex
@@ -54,6 +54,8 @@ defmodule OMG.ChildChain.Application do
     end)
   end
 
+  # Only set once during bootup. cookie value retrieved from ENV. 
+  # sobelow_skip ["DOS.StringToAtom"]
   defp set_cookie(cookie) when is_binary(cookie) do
     cookie
     |> String.to_atom()

--- a/apps/omg_child_chain/lib/omg_child_chain/fee_server.ex
+++ b/apps/omg_child_chain/lib/omg_child_chain/fee_server.ex
@@ -83,7 +83,7 @@ defmodule OMG.ChildChain.FeeServer do
   end
 
   # Reads fee specification file if needed and updates :ets state with current fees information
-  # FeeServer is an internal elixir process* that holds child chain's fees per currency. 
+  # FeeServer is an internal elixir process* that holds child chain's fees per currency.
   # The operator can change the fees and this is done via a JSON file that iss loaded from disk (path variable).
   # sobelow_skip ["Traversal"]
   @spec update_fee_spec() :: :ok | {:error, atom() | [{:error, atom()}, ...]}

--- a/apps/omg_child_chain/lib/omg_child_chain/fee_server.ex
+++ b/apps/omg_child_chain/lib/omg_child_chain/fee_server.ex
@@ -83,6 +83,9 @@ defmodule OMG.ChildChain.FeeServer do
   end
 
   # Reads fee specification file if needed and updates :ets state with current fees information
+  # FeeServer is an internal elixir process* that holds child chain's fees per currency. 
+  # The operator can change the fees and this is done via a JSON file that iss loaded from disk (path variable).
+  # sobelow_skip ["Traversal"]
   @spec update_fee_spec() :: :ok | {:error, atom() | [{:error, atom()}, ...]}
   defp update_fee_spec do
     path = get_fees()

--- a/apps/omg_db/lib/omg_db/level_db.ex
+++ b/apps/omg_db/lib/omg_db/level_db.ex
@@ -132,6 +132,8 @@ defmodule OMG.DB.LevelDB do
   def init(server_name), do: do_init(server_name, Application.fetch_env!(:omg_db, :path))
   def init(server_name, path), do: do_init(server_name, path)
 
+  # File.mkdir_p is called at the application start
+  # sobelow_skip ["Traversal"]
   defp do_init(server_name, path) do
     :ok = File.mkdir_p(path)
 

--- a/apps/omg_db/lib/omg_db/rocks_db.ex
+++ b/apps/omg_db/lib/omg_db/rocks_db.ex
@@ -132,6 +132,8 @@ if Code.ensure_loaded?(:rocksdb) do
     def init(server_name), do: do_init(server_name, Application.fetch_env!(:omg_db, :path))
     def init(server_name, path), do: do_init(server_name, path)
 
+    # File.mkdir_p is called at the application start
+    # sobelow_skip ["Traversal"]
     defp do_init(server_name, path) do
       :ok = File.mkdir_p(path)
 

--- a/apps/omg_performance/lib/omg_performance/sender_manager.ex
+++ b/apps/omg_performance/lib/omg_performance/sender_manager.ex
@@ -173,6 +173,8 @@ defmodule OMG.Performance.SenderManager do
   defp txs_per_second(txs_count, interval_ms), do: Kernel.round(txs_count * 1000 / interval_ms)
 
   # handle termination
+  # omg_performance is not part of the application deployment bundle. It's used only for testing.
+  # sobelow_skip ["Traversal"]
   defp write_stats(%{destdir: destdir} = state) do
     destfile = Path.join(destdir, "perf_result_#{:os.system_time(:seconds)}_stats.json")
 

--- a/apps/omg_watcher/lib/omg_watcher/application.ex
+++ b/apps/omg_watcher/lib/omg_watcher/application.ex
@@ -83,7 +83,7 @@ defmodule OMG.Watcher.Application do
       end
     end)
   end
-  
+
   # Only set once during bootup. cookie value retrieved from ENV.
   # sobelow_skip ["DOS.StringToAtom"]
   defp set_cookie(cookie) when is_binary(cookie) do

--- a/apps/omg_watcher/lib/omg_watcher/application.ex
+++ b/apps/omg_watcher/lib/omg_watcher/application.ex
@@ -83,7 +83,9 @@ defmodule OMG.Watcher.Application do
       end
     end)
   end
-
+  
+  # Only set once during bootup. cookie value retrieved from ENV. 
+  # sobelow_skip ["DOS.StringToAtom"]
   defp set_cookie(cookie) when is_binary(cookie) do
     cookie
     |> String.to_atom()

--- a/apps/omg_watcher/lib/omg_watcher/application.ex
+++ b/apps/omg_watcher/lib/omg_watcher/application.ex
@@ -84,7 +84,7 @@ defmodule OMG.Watcher.Application do
     end)
   end
   
-  # Only set once during bootup. cookie value retrieved from ENV. 
+  # Only set once during bootup. cookie value retrieved from ENV.
   # sobelow_skip ["DOS.StringToAtom"]
   defp set_cookie(cookie) when is_binary(cookie) do
     cookie


### PR DESCRIPTION
## Overview

This PR triages all sobelow findings in apps. 

## Remaining

I am not convinced that the usage of binary_to_term in the below instances is not a security issue. In all of the cases data from the db is deserialized. Even running into a DOS condition could have very negative consequences. Deserialization bugs can often lead to RCE, I am just thinking of JAVA and PHP. Can we explore alternatives? 

## References 
http://erlang.org/pipermail/erlang-questions/2001-July/003372.html (dated)
https://hexdocs.pm/sobelow/Sobelow.Misc.BinToTerm.html#content

```
[31mMisc.BinToTerm: Unsafe `binary_to_term` - High Confidence[0m
File: apps/omg_db/lib/omg_db/leveldb/core.ex
Line: 114
Function: decode_response:111
Variable: encoded

-----------------------------------------------

[31mMisc.BinToTerm: Unsafe `binary_to_term` - High Confidence[0m
File: apps/omg_db/lib/omg_db/rocksdb/core.ex
Line: 115
Function: decode_response:105
Variable: encoded

-----------------------------------------------

[31mMisc.BinToTerm: Unsafe `binary_to_term` - High Confidence[0m
File: apps/omg_db/lib/omg_db/rocksdb/core.ex
Line: 111
Function: decode_response:105
Variable: encoded

-----------------------------------------------
```


