### PR TITLE
917 response service type

### DIFF
--- a/apps/omg_child_chain_rpc/test/omg_child_chain_rpc/web/plugs/health_test.exs
+++ b/apps/omg_child_chain_rpc/test/omg_child_chain_rpc/web/plugs/health_test.exs
@@ -103,6 +103,7 @@ defmodule OMG.ChildChainRPC.Plugs.HealthTest do
   defp pull_client_alarm(n, match, fnn) do
     endpoint_call_result = fnn.()
     match = Map.put_new(match, "version", Map.get(endpoint_call_result, "version"))
+    match = Map.put_new(match, "service_name", Map.get(endpoint_call_result, "service_name"))
 
     case endpoint_call_result do
       ^match ->

--- a/apps/omg_utils/lib/omg_utils/http_rpc/response.ex
+++ b/apps/omg_utils/lib/omg_utils/http_rpc/response.ex
@@ -139,7 +139,7 @@ defmodule OMG.Utils.HttpRPC.Response do
         {:omg_child_chain_rpc, _, _} -> true
         _ -> false
       end)
-    
+
     # Is type "watcher" or "childchain"
     service_type =
       if Code.ensure_loaded?(OMG.ChildChainRPC) and is_child_chain_running != nil do
@@ -147,7 +147,7 @@ defmodule OMG.Utils.HttpRPC.Response do
       else
         "watcher"
       end
-    
+
     # Inject it into the response code
     Map.merge(response, %{type: service_type})
   end

--- a/apps/omg_utils/lib/omg_utils/http_rpc/response.ex
+++ b/apps/omg_utils/lib/omg_utils/http_rpc/response.ex
@@ -143,7 +143,7 @@ defmodule OMG.Utils.HttpRPC.Response do
     # Is type "watcher" or "childchain"
     service_type =
       if Code.ensure_loaded?(OMG.ChildChainRPC) and is_child_chain_running != nil do
-        "childchain"
+        "child_chain"
       else
         "watcher"
       end

--- a/apps/omg_utils/lib/omg_utils/http_rpc/response.ex
+++ b/apps/omg_utils/lib/omg_utils/http_rpc/response.ex
@@ -33,7 +33,7 @@ defmodule OMG.Utils.HttpRPC.Response do
   def serialize(%{object: :error} = error) do
     to_response(error, :error)
     |> add_version()
-    |> add_service_type()
+    |> add_service_name()
   end
 
   def serialize(data) do
@@ -41,7 +41,7 @@ defmodule OMG.Utils.HttpRPC.Response do
     |> sanitize()
     |> to_response(:success)
     |> add_version()
-    |> add_service_type()
+    |> add_service_name()
   end
 
   @doc """
@@ -132,7 +132,7 @@ defmodule OMG.Utils.HttpRPC.Response do
 
   # Not the most "beautiful way", but I'm just referencing
   # how they're injecting the version
-  defp add_service_type(response) do
+  defp add_service_name(response) do
     # TODO remove this hack when running releases
     is_child_chain_running =
       Enum.find(Application.started_applications(), fn
@@ -141,7 +141,7 @@ defmodule OMG.Utils.HttpRPC.Response do
       end)
 
     # Is type "watcher" or "childchain"
-    service_type =
+    service_name =
       if Code.ensure_loaded?(OMG.ChildChainRPC) and is_child_chain_running != nil do
         "child_chain"
       else
@@ -149,6 +149,6 @@ defmodule OMG.Utils.HttpRPC.Response do
       end
 
     # Inject it into the response code
-    Map.merge(response, %{type: service_type})
+    Map.merge(response, %{service_name: service_name})
   end
 end


### PR DESCRIPTION
https://github.com/omisego/elixir-omg/issues/917

## Overview
Added `type: [child_chain | watcher]` to `/`  response for clarity and debugging

## Changes
The `/` response type has change from

```json
{"data":{"code":"operation:not_found","description":"Operation cannot be found. Check request URL.","object":"error"},"success":false,"version":"0.2.2+a48c042"}
```

to

```json
{"data":{"code":"operation:not_found","description":"Operation cannot be found. Check request URL.","object":"error"},"success":false,"version":"0.2.2+a48c042","type":"[watcher|childchain]"}
```

## Testing
Deployed it locally and manually tested it. Haven't added any tests for it, yet
