### PR TITLE
feature: allow passing in timeout in opts

### DIFF
--- a/apps/omg_eth/test/support/dev_helpers.ex
+++ b/apps/omg_eth/test/support/dev_helpers.ex
@@ -169,7 +169,10 @@ defmodule OMG.Eth.DevHelpers do
     params = %{from: faucet, to: account_enc, value: to_hex(initial_funds)}
     {:ok, tx_fund} = OMG.Eth.send_transaction(params)
 
-    tx_fund |> WaitFor.eth_receipt(@about_4_blocks_time)
+    case Keyword.get(opts, :timeout) do
+      nil -> WaitFor.eth_receipt(tx_fund, @about_4_blocks_time)
+      timeout -> WaitFor.eth_receipt(tx_fund, timeout)
+    end
   end
 
   defp unlock_if_possible(account_enc) do


### PR DESCRIPTION
https://github.com/omisego/elixir-omg/issues/929

## Overview

I think it's a timeout issue, and this allows us to send in timeout value like
```

[
  faucet: "0x944a81beecac91802787fbcfb9767fcbf81db1f5",
  initial_funds: 1000000000000000000,
 timeout: 120_000
]
```

## Changes

- Check if timeout key is present in keywords

## Testing

/
