### PR TITLE
rix: unload childchain modules from watcher

### DIFF
--- a/apps/omg_watcher/lib/omg_watcher/application.ex
+++ b/apps/omg_watcher/lib/omg_watcher/application.ex
@@ -18,6 +18,9 @@ defmodule OMG.Watcher.Application do
   use OMG.Utils.LoggerExt
 
   def start(_type, _args) do
+    # TODO remove when we introduce releases!
+    _ = :code.purge(OMG.ChildChainRPC)
+    _ = :code.delete(OMG.ChildChainRPC)
     DeferredConfig.populate(:omg_watcher)
     cookie = System.get_env("ERL_W_COOKIE")
     true = set_cookie(cookie)

--- a/apps/xomg_tasks/lib/mix/tasks/watcher.ex
+++ b/apps/xomg_tasks/lib/mix/tasks/watcher.ex
@@ -36,9 +36,6 @@ defmodule Mix.Tasks.Xomg.Watcher.Start do
   end
 
   defp start_watcher(args) do
-    _ = :code.purge(OMG.ChildChainRPC)
-    _ = :code.delete(OMG.ChildChainRPC)
-
     args
     |> generic_prepare_args()
     |> generic_run([:omg_watcher, :omg_watcher_rpc])


### PR DESCRIPTION
Child Chain modules still loaded under Watcher app because of mix task usage for deployment.

## Overview

Trying to unload Child Chain modules under Watcher.

## Changes



- Purge and delete

## Testing

/
