### PR TITLE
fix: don't reload child chain module

### DIFF
--- a/apps/omg_status/lib/omg_status/application.ex
+++ b/apps/omg_status/lib/omg_status/application.ex
@@ -112,16 +112,9 @@ defmodule OMG.Status.Application do
   end
 
   defp application do
-    is_child_chain_running =
-      Enum.find(Application.started_applications(), fn
-        {:omg_child_chain_rpc, _, _} -> true
-        _ -> false
-      end)
-
-    if Code.ensure_loaded?(OMG.ChildChainRPC) and is_child_chain_running != nil do
-      :child_chain
-    else
-      :watcher
+    case String.downcase(System.get_env("ELIXIR_SERVICE")) do
+      "watcher" -> :watcher
+      _ -> :child_chain
     end
   end
 end


### PR DESCRIPTION
ensure_loaded? will reload the module again.

## Overview

Pull the service from env var.

## Changes


- There's no other way with using tasks

## Testing

/