### PR TITLE
Functional Tests Posts on Slack on Failure

### DIFF
--- a/.circleci/test_runner.py
+++ b/.circleci/test_runner.py
@@ -104,15 +104,18 @@ def start_workflow():
         check_job_result(envs['TEST_RUNNER_SERVICE'], job_id)
 
         # Post success to slack
+        success_text = """
+        Functional tests for elixir-omg completed successfully!\n{}
+        """.format(
+            envs['CIRCLE_BUILD_URL']
+        )
         for webhook in [
             envs['TEST_RUNNER_SLACK_WEBHOOK_01'],
             envs['TEST_RUNNER_SLACK_WEBHOOK_02']
         ]:
             if webhook is not None:
                 requests.post(webhook, json={
-                    'text': 'Functional tests for elixir-omg completed successfully!\n{}'.format(
-                        envs['CIRCLE_BUILD_URL']
-                    )
+                    'text': success_text
                 })
 
     except Exception as e:

--- a/.circleci/test_runner.py
+++ b/.circleci/test_runner.py
@@ -102,17 +102,23 @@ def start_workflow():
         logging.critical(
             f'Test runner service crashed, exception: {e}\ntraceback: {tb}')
 
+        # Formatted text
         circleci_build_url = envs['CIRCLE_BUILD_URL']
+        pretext = """
+        Test runner service crashed, exception: `{}`
+        CircleCI build results: {}
+        """.format(e, circleci_build_url)
         # Sends notification to the web slack hooks
-        for webhook in [envs['TEST_RUNNER_SLACK_WEBHOOK_01'], envs['TEST_RUNNER_SLACK_WEBHOOK_02']]:
+        for webhook in [
+            envs['TEST_RUNNER_SLACK_WEBHOOK_01'],
+            envs['TEST_RUNNER_SLACK_WEBHOOK_02']
+        ]:
             if webhook is not None:
                 requests.post(webhook, json={
                     'attachments': [
                         {
                             'title': 'Traceback',
-                            'pretext': 'Test runner service crashed, exception: `{}`\nCircleCI build results: {}'.format(
-                                e, circleci_build_url
-                            ),
+                            'pretext': pretext,
                             'text': '```{}```'.format(tb),
                             "mrkdwn_in": [
                                 "text",

--- a/.circleci/test_runner.py
+++ b/.circleci/test_runner.py
@@ -39,9 +39,16 @@ def check_job_completed(test_runner: str, job_id: str):
             '{}/job/{}/status'.format(test_runner, job_id),
             headers={'Cache-Control': 'no-cache'}
         )
-        if 'Exited' in request.content.decode('utf-8'):
+
+        resp = request.content.decode('utf-8')
+
+        if 'Exited' in resp:
             logging.info('Job completed successfully')
             break
+
+        elif 'Failed' in resp:
+            logging.info(f'Job failed, reason: {resp}')
+            raise Exception(f'Job failed, reason: {resp}')
 
 
 def check_job_result(test_runner: str, job_id: str):


### PR DESCRIPTION
##  Overview
Currently when the functional tests fail, it fails silently as the deployment happens _before_ the functional tests.

## Changes
`test_runner.py` now posts to slack on failure

## Testing
Manual testing - `python .circleci/test_runner.py`
