### PR TITLE
fix: move measurement into separate process

### DIFF
--- a/apps/omg/lib/omg/state/measure.ex
+++ b/apps/omg/lib/omg/state/measure.ex
@@ -27,9 +27,14 @@ defmodule OMG.State.Measure do
   def supported_events, do: @supported_events
 
   def handle_event([:process, OMG.State], _, %Core{} = state, _config) do
-    Enum.each(MeasurementCalculation.calculate(state), fn
-      {key, value} -> _ = Datadog.gauge(name(key), value)
-      {key, value, metadata} -> _ = Datadog.gauge(name(key), value, tags: [metadata])
-    end)
+    execute = fn ->
+      Enum.each(MeasurementCalculation.calculate(state), fn
+        {key, value} -> _ = Datadog.gauge(name(key), value)
+        {key, value, metadata} -> _ = Datadog.gauge(name(key), value, tags: [metadata])
+      end)
+    end
+
+    _ = Task.start(execute)
+    :ok
   end
 end

--- a/apps/omg/lib/omg/state/measure.ex
+++ b/apps/omg/lib/omg/state/measure.ex
@@ -34,6 +34,8 @@ defmodule OMG.State.Measure do
       end)
     end
 
+    # TODO proper fix! this is a very hackish approach to get measurements off the back
+    # of OMG State
     _ = Task.start(execute)
     :ok
   end

--- a/apps/omg_child_chain_rpc/test/omg_child_chain_rpc/web/controllers/alarm_test.exs
+++ b/apps/omg_child_chain_rpc/test/omg_child_chain_rpc/web/controllers/alarm_test.exs
@@ -27,7 +27,7 @@ defmodule OMG.ChildChainRPC.Web.Controller.AlarmTest do
     )
 
     on_exit(fn ->
-      Enum.each(apps, fn app -> :ok = Application.stop(app) end)
+      Enum.each(Enum.reverse(apps), fn app -> :ok = Application.stop(app) end)
     end)
   end
 

--- a/apps/omg_watcher_rpc/test/omg_watcher_rpc/web/controllers/alarm_test.exs
+++ b/apps/omg_watcher_rpc/test/omg_watcher_rpc/web/controllers/alarm_test.exs
@@ -29,7 +29,7 @@ defmodule OMG.WatcherRPC.Web.Controller.AlarmTest do
     )
 
     on_exit(fn ->
-      Enum.each(apps, fn app -> :ok = Application.stop(app) end)
+      Enum.each(Enum.reverse(apps), fn app -> :ok = Application.stop(app) end)
     end)
   end
 


### PR DESCRIPTION
https://github.com/omisego/elixir-omg/issues/936

## Overview

Lets try a solution and see how it behaves in the wild, metrics are available in Datadog.

## Changes


- Spawn a process that does a complete copy of OMG.State state and performs the necessary computation and dies. 

## Testing

/