### PR TITLE
refactor: exclude leveldb from build

### DIFF
--- a/apps/omg_db/lib/omg_db/level_db.ex
+++ b/apps/omg_db/lib/omg_db/level_db.ex
@@ -11,142 +11,143 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+if Code.ensure_loaded?(Exleveldb) do
+  defmodule OMG.DB.LevelDB do
+    @moduledoc """
+    Our-types-aware port/adapter to a database backend.
+    Contains functions to access data stored in the database
+    """
+    alias OMG.DB
+    @behaviour OMG.DB
 
-defmodule OMG.DB.LevelDB do
-  @moduledoc """
-  Our-types-aware port/adapter to a database backend.
-  Contains functions to access data stored in the database
-  """
-  alias OMG.DB
-  @behaviour OMG.DB
+    require Logger
 
-  require Logger
+    @server_name OMG.DB.LevelDB.Server
 
-  @server_name OMG.DB.LevelDB.Server
+    @one_minute 60_000
+    @ten_minutes 10 * @one_minute
 
-  @one_minute 60_000
-  @ten_minutes 10 * @one_minute
+    @type utxo_pos_db_t :: {pos_integer, non_neg_integer, non_neg_integer}
 
-  @type utxo_pos_db_t :: {pos_integer, non_neg_integer, non_neg_integer}
+    def start_link(args) do
+      @server_name.start_link(args)
+    end
 
-  def start_link(args) do
-    @server_name.start_link(args)
-  end
+    def child_spec do
+      db_path = Application.fetch_env!(:omg_db, :path)
+      [server_module: server_module, server_name: server_name] = Application.fetch_env!(:omg_db, :leveldb)
+      args = [db_path: db_path, name: server_name]
 
-  def child_spec do
-    db_path = Application.fetch_env!(:omg_db, :path)
-    [server_module: server_module, server_name: server_name] = Application.fetch_env!(:omg_db, :leveldb)
-    args = [db_path: db_path, name: server_name]
+      %{
+        id: server_module,
+        start: {server_module, :start_link, [args]},
+        type: :worker
+      }
+    end
 
-    %{
-      id: server_module,
-      start: {server_module, :start_link, [args]},
-      type: :worker
-    }
-  end
+    def child_spec([db_path: _db_path, name: server_name] = args) do
+      [server_module: server_module, server_name: _] = Application.fetch_env!(:omg_db, :leveldb)
 
-  def child_spec([db_path: _db_path, name: server_name] = args) do
-    [server_module: server_module, server_name: _] = Application.fetch_env!(:omg_db, :leveldb)
+      %{
+        id: server_name,
+        start: {server_module, :start_link, [args]},
+        type: :worker
+      }
+    end
 
-    %{
-      id: server_name,
-      start: {server_module, :start_link, [args]},
-      type: :worker
-    }
-  end
+    def multi_update(db_updates, server_name \\ @server_name) do
+      GenServer.call(server_name, {:multi_update, db_updates})
+    end
 
-  def multi_update(db_updates, server_name \\ @server_name) do
-    GenServer.call(server_name, {:multi_update, db_updates})
-  end
+    @spec blocks(block_to_fetch :: list(), atom) :: {:ok, list()} | {:error, any}
+    def blocks(blocks_to_fetch, server_name \\ @server_name)
 
-  @spec blocks(block_to_fetch :: list(), atom) :: {:ok, list()} | {:error, any}
-  def blocks(blocks_to_fetch, server_name \\ @server_name)
+    def blocks([], _server_name), do: {:ok, []}
 
-  def blocks([], _server_name), do: {:ok, []}
+    def blocks(blocks_to_fetch, server_name) do
+      GenServer.call(server_name, {:blocks, blocks_to_fetch})
+    end
 
-  def blocks(blocks_to_fetch, server_name) do
-    GenServer.call(server_name, {:blocks, blocks_to_fetch})
-  end
+    def utxos(server_name \\ @server_name) do
+      _ = Logger.info("Reading UTXO set, this might take a while. Allowing #{inspect(@ten_minutes)} ms")
+      GenServer.call(server_name, :utxos, @ten_minutes)
+    end
 
-  def utxos(server_name \\ @server_name) do
-    _ = Logger.info("Reading UTXO set, this might take a while. Allowing #{inspect(@ten_minutes)} ms")
-    GenServer.call(server_name, :utxos, @ten_minutes)
-  end
+    def exit_infos(server_name \\ @server_name) do
+      _ = Logger.info("Reading exits' info, this might take a while. Allowing #{inspect(@one_minute)} ms")
+      GenServer.call(server_name, :exit_infos, @one_minute)
+    end
 
-  def exit_infos(server_name \\ @server_name) do
-    _ = Logger.info("Reading exits' info, this might take a while. Allowing #{inspect(@one_minute)} ms")
-    GenServer.call(server_name, :exit_infos, @one_minute)
-  end
+    def in_flight_exits_info(server_name \\ @server_name) do
+      _ = Logger.info("Reading in flight exits' info, this might take a while. Allowing #{inspect(@one_minute)} ms")
+      GenServer.call(server_name, :in_flight_exits_info, @one_minute)
+    end
 
-  def in_flight_exits_info(server_name \\ @server_name) do
-    _ = Logger.info("Reading in flight exits' info, this might take a while. Allowing #{inspect(@one_minute)} ms")
-    GenServer.call(server_name, :in_flight_exits_info, @one_minute)
-  end
+    def competitors_info(server_name \\ @server_name) do
+      _ = Logger.info("Reading competitors' info, this might take a while. Allowing #{inspect(@one_minute)} ms")
+      GenServer.call(server_name, :competitors_info, @one_minute)
+    end
 
-  def competitors_info(server_name \\ @server_name) do
-    _ = Logger.info("Reading competitors' info, this might take a while. Allowing #{inspect(@one_minute)} ms")
-    GenServer.call(server_name, :competitors_info, @one_minute)
-  end
+    @spec exit_info({pos_integer, non_neg_integer, non_neg_integer}, atom) :: {:ok, map} | {:error, atom}
+    def exit_info(utxo_pos, server_name \\ @server_name) do
+      GenServer.call(server_name, {:exit_info, utxo_pos})
+    end
 
-  @spec exit_info({pos_integer, non_neg_integer, non_neg_integer}, atom) :: {:ok, map} | {:error, atom}
-  def exit_info(utxo_pos, server_name \\ @server_name) do
-    GenServer.call(server_name, {:exit_info, utxo_pos})
-  end
+    @spec spent_blknum(utxo_pos_db_t(), atom) :: {:ok, pos_integer} | {:error, atom}
+    def spent_blknum(utxo_pos, server_name \\ @server_name) do
+      GenServer.call(server_name, {:spent_blknum, utxo_pos})
+    end
 
-  @spec spent_blknum(utxo_pos_db_t(), atom) :: {:ok, pos_integer} | {:error, atom}
-  def spent_blknum(utxo_pos, server_name \\ @server_name) do
-    GenServer.call(server_name, {:spent_blknum, utxo_pos})
-  end
+    def block_hashes(block_numbers_to_fetch, server_name \\ @server_name) do
+      GenServer.call(server_name, {:block_hashes, block_numbers_to_fetch})
+    end
 
-  def block_hashes(block_numbers_to_fetch, server_name \\ @server_name) do
-    GenServer.call(server_name, {:block_hashes, block_numbers_to_fetch})
-  end
+    def last_deposit_child_blknum(server_name \\ @server_name) do
+      GenServer.call(server_name, :last_deposit_child_blknum)
+    end
 
-  def last_deposit_child_blknum(server_name \\ @server_name) do
-    GenServer.call(server_name, :last_deposit_child_blknum)
-  end
+    def child_top_block_number(server_name \\ @server_name) do
+      GenServer.call(server_name, :child_top_block_number)
+    end
 
-  def child_top_block_number(server_name \\ @server_name) do
-    GenServer.call(server_name, :child_top_block_number)
-  end
+    # Note: *_eth_height values below denote actual Ethereum height service has processed.
+    # It might differ from "latest" Ethereum block.
 
-  # Note: *_eth_height values below denote actual Ethereum height service has processed.
-  # It might differ from "latest" Ethereum block.
+    def get_single_value(parameter_name, server_name \\ @server_name) do
+      GenServer.call(server_name, {:get_single_value, parameter_name})
+    end
 
-  def get_single_value(parameter_name, server_name \\ @server_name) do
-    GenServer.call(server_name, {:get_single_value, parameter_name})
-  end
+    def initiation_multiupdate(server_name \\ @server_name) do
+      # setting a number of markers to zeroes
+      DB.single_value_parameter_names()
+      |> Enum.map(&{:put, &1, 0})
+      |> multi_update(server_name)
+    end
 
-  def initiation_multiupdate(server_name \\ @server_name) do
-    # setting a number of markers to zeroes
-    DB.single_value_parameter_names()
-    |> Enum.map(&{:put, &1, 0})
-    |> multi_update(server_name)
-  end
+    @doc """
+    Does all of the initialization of `OMG.DB` based on the configured path
+    """
+    def init, do: do_init(@server_name, Application.fetch_env!(:omg_db, :path))
+    def init(path) when is_binary(path), do: do_init(@server_name, path)
+    def init(server_name), do: do_init(server_name, Application.fetch_env!(:omg_db, :path))
+    def init(server_name, path), do: do_init(server_name, path)
 
-  @doc """
-  Does all of the initialization of `OMG.DB` based on the configured path
-  """
-  def init, do: do_init(@server_name, Application.fetch_env!(:omg_db, :path))
-  def init(path) when is_binary(path), do: do_init(@server_name, path)
-  def init(server_name), do: do_init(server_name, Application.fetch_env!(:omg_db, :path))
-  def init(server_name, path), do: do_init(server_name, path)
+    # File.mkdir_p is called at the application start
+    # sobelow_skip ["Traversal"]
+    defp do_init(server_name, path) do
+      :ok = File.mkdir_p(path)
 
-  # File.mkdir_p is called at the application start
-  # sobelow_skip ["Traversal"]
-  defp do_init(server_name, path) do
-    :ok = File.mkdir_p(path)
+      with :ok <- server_name.init_storage(path),
+           {:ok, started_apps} <- Application.ensure_all_started(:omg_db),
+           :ok <- initiation_multiupdate(server_name) do
+        started_apps |> Enum.reverse() |> Enum.each(fn app -> :ok = Application.stop(app) end)
 
-    with :ok <- server_name.init_storage(path),
-         {:ok, started_apps} <- Application.ensure_all_started(:omg_db),
-         :ok <- initiation_multiupdate(server_name) do
-      started_apps |> Enum.reverse() |> Enum.each(fn app -> :ok = Application.stop(app) end)
-
-      :ok
-    else
-      error ->
-        _ = Logger.error("Unable to init: #{inspect(error)}")
-        error
+        :ok
+      else
+        error ->
+          _ = Logger.error("Unable to init: #{inspect(error)}")
+          error
+      end
     end
   end
 end

--- a/apps/omg_db/lib/omg_db/leveldb/core.ex
+++ b/apps/omg_db/lib/omg_db/leveldb/core.ex
@@ -11,113 +11,114 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+if Code.ensure_loaded?(Exleveldb) do
+  defmodule OMG.DB.LevelDB.Core do
+    @moduledoc """
+    Responsible for converting type-aware, logic-specific queries and updates into leveldb specific queries and updates
+    """
 
-defmodule OMG.DB.LevelDB.Core do
-  @moduledoc """
-  Responsible for converting type-aware, logic-specific queries and updates into leveldb specific queries and updates
-  """
+    # adapter - testable, if we really really want to
 
-  # adapter - testable, if we really really want to
+    @single_value_parameter_names OMG.DB.single_value_parameter_names()
 
-  @single_value_parameter_names OMG.DB.single_value_parameter_names()
+    @keys_prefixes %{
+      block: "b",
+      block_hash: "bn",
+      # watcher and child chain
+      utxo: "u",
+      # watcher and child chain
+      exit_info: "e",
+      # watcher only
+      in_flight_exit_info: "ife",
+      # watcher only
+      competitor_info: "ci",
+      # watcher only
+      spend: "s"
+    }
 
-  @keys_prefixes %{
-    block: "b",
-    block_hash: "bn",
-    # watcher and child chain
-    utxo: "u",
-    # watcher and child chain
-    exit_info: "e",
-    # watcher only
-    in_flight_exit_info: "ife",
-    # watcher only
-    competitor_info: "ci",
-    # watcher only
-    spend: "s"
-  }
+    @key_types Map.keys(@keys_prefixes)
 
-  @key_types Map.keys(@keys_prefixes)
-
-  def parse_multi_updates(db_updates) do
-    db_updates
-    |> Enum.flat_map(&parse_multi_update/1)
-  end
-
-  @doc """
-  Interprets the response from leveldb and returns a success-decorated result
-  """
-  @spec decode_value({:ok, binary()} | :not_found, atom()) :: {:ok, term()} | {:error, term()}
-  def decode_value(db_response, type) do
-    case decode_response(type, db_response) do
-      # :not_found -> :not_found
-      # TODO delete
-      {:error, error} -> {:error, error}
-      other -> {:ok, other}
+    def parse_multi_updates(db_updates) do
+      db_updates
+      |> Enum.flat_map(&parse_multi_update/1)
     end
-  end
 
-  @doc """
-  Interprets an enumerable of responses from leveldb and decorates the enumerable with a `{:ok, _enumerable}`
-  if no errors occurred
-  """
-  @spec decode_values(Enumerable.t(), atom) :: {:ok, list}
-  def decode_values(encoded_enumerable, type) do
-    raw_decoded =
-      encoded_enumerable
-      |> Enum.map(fn encoded -> decode_response(type, encoded) end)
-
-    # TODO delete
-    if Enum.any?(raw_decoded, &match?({:error, _}, &1)),
-      do: {:error, raw_decoded},
-      else: {:ok, raw_decoded}
-
-    # {:ok, raw_decoded}
-  end
-
-  def filter_keys(key_stream, type) when type in @key_types,
-    do: do_filter_keys(key_stream, Map.get(@keys_prefixes, type))
-
-  @doc """
-  Produces a type-specific LevelDB key for a combination of type and type-agnostic/LevelDB-ignorant key
-  """
-  def key(:block, hash) when is_binary(hash), do: @keys_prefixes.block <> hash
-  def key(parameter, _) when parameter in @single_value_parameter_names, do: Atom.to_string(parameter)
-
-  def key(type, specific_key) when type in @key_types,
-    do: Map.get(@keys_prefixes, type) <> :erlang.term_to_binary(specific_key)
-
-  # `key_for_item` gets the type-specific key to persist a whole item at, as used by `:put` updates
-  defp key_for_item(:block, %{hash: hash} = _block), do: key(:block, hash)
-  defp key_for_item(:utxo, {position, _utxo}), do: key(:utxo, position)
-  defp key_for_item(:spend, {position, _blknum}), do: key(:spend, position)
-  defp key_for_item(:exit_info, {position, _exit_info}), do: key(:exit_info, position)
-  defp key_for_item(:in_flight_exit_info, {position, _info}), do: key(:in_flight_exit_info, position)
-  defp key_for_item(:competitor_info, {position, _info}), do: key(:competitor_info, position)
-  defp key_for_item(parameter, value) when parameter in @single_value_parameter_names, do: key(parameter, value)
-
-  defp parse_multi_update({:put, :block, %{number: number, hash: hash} = item}) do
-    [
-      {:put, key_for_item(:block, item), encode_value(:block, item)},
-      {:put, key(:block_hash, number), encode_value(:block_hash, hash)}
-    ]
-  end
-
-  defp parse_multi_update({:put, type, item}), do: [{:put, key_for_item(type, item), encode_value(type, item)}]
-  defp parse_multi_update({:delete, type, item}), do: [{:delete, key(type, item)}]
-
-  defp encode_value(:spend, {_position, blknum}), do: :erlang.term_to_binary(blknum)
-  defp encode_value(_type, value), do: :erlang.term_to_binary(value)
-
-  # sobelow_skip ["Misc.BinToTerm"]
-  defp decode_response(_type, db_response) do
-    case db_response do
-      :not_found -> :not_found
-      {:ok, encoded} -> :erlang.binary_to_term(encoded, [:safe])
-      # TODO delete
-      other -> {:error, other}
+    @doc """
+    Interprets the response from leveldb and returns a success-decorated result
+    """
+    @spec decode_value({:ok, binary()} | :not_found, atom()) :: {:ok, term()} | {:error, term()}
+    def decode_value(db_response, type) do
+      case decode_response(type, db_response) do
+        # :not_found -> :not_found
+        # TODO delete
+        {:error, error} -> {:error, error}
+        other -> {:ok, other}
+      end
     end
-  end
 
-  defp do_filter_keys(keys_stream, prefix),
-    do: Stream.filter(keys_stream, fn {key, _} -> String.starts_with?(key, prefix) end)
+    @doc """
+    Interprets an enumerable of responses from leveldb and decorates the enumerable with a `{:ok, _enumerable}`
+    if no errors occurred
+    """
+    @spec decode_values(Enumerable.t(), atom) :: {:ok, list}
+    def decode_values(encoded_enumerable, type) do
+      raw_decoded =
+        encoded_enumerable
+        |> Enum.map(fn encoded -> decode_response(type, encoded) end)
+
+      # TODO delete
+      if Enum.any?(raw_decoded, &match?({:error, _}, &1)),
+        do: {:error, raw_decoded},
+        else: {:ok, raw_decoded}
+
+      # {:ok, raw_decoded}
+    end
+
+    def filter_keys(key_stream, type) when type in @key_types,
+      do: do_filter_keys(key_stream, Map.get(@keys_prefixes, type))
+
+    @doc """
+    Produces a type-specific LevelDB key for a combination of type and type-agnostic/LevelDB-ignorant key
+    """
+    def key(:block, hash) when is_binary(hash), do: @keys_prefixes.block <> hash
+    def key(parameter, _) when parameter in @single_value_parameter_names, do: Atom.to_string(parameter)
+
+    def key(type, specific_key) when type in @key_types,
+      do: Map.get(@keys_prefixes, type) <> :erlang.term_to_binary(specific_key)
+
+    # `key_for_item` gets the type-specific key to persist a whole item at, as used by `:put` updates
+    defp key_for_item(:block, %{hash: hash} = _block), do: key(:block, hash)
+    defp key_for_item(:utxo, {position, _utxo}), do: key(:utxo, position)
+    defp key_for_item(:spend, {position, _blknum}), do: key(:spend, position)
+    defp key_for_item(:exit_info, {position, _exit_info}), do: key(:exit_info, position)
+    defp key_for_item(:in_flight_exit_info, {position, _info}), do: key(:in_flight_exit_info, position)
+    defp key_for_item(:competitor_info, {position, _info}), do: key(:competitor_info, position)
+    defp key_for_item(parameter, value) when parameter in @single_value_parameter_names, do: key(parameter, value)
+
+    defp parse_multi_update({:put, :block, %{number: number, hash: hash} = item}) do
+      [
+        {:put, key_for_item(:block, item), encode_value(:block, item)},
+        {:put, key(:block_hash, number), encode_value(:block_hash, hash)}
+      ]
+    end
+
+    defp parse_multi_update({:put, type, item}), do: [{:put, key_for_item(type, item), encode_value(type, item)}]
+    defp parse_multi_update({:delete, type, item}), do: [{:delete, key(type, item)}]
+
+    defp encode_value(:spend, {_position, blknum}), do: :erlang.term_to_binary(blknum)
+    defp encode_value(_type, value), do: :erlang.term_to_binary(value)
+
+    # sobelow_skip ["Misc.BinToTerm"]
+    defp decode_response(_type, db_response) do
+      case db_response do
+        :not_found -> :not_found
+        {:ok, encoded} -> :erlang.binary_to_term(encoded, [:safe])
+        # TODO delete
+        other -> {:error, other}
+      end
+    end
+
+    defp do_filter_keys(keys_stream, prefix),
+      do: Stream.filter(keys_stream, fn {key, _} -> String.starts_with?(key, prefix) end)
+  end
 end

--- a/apps/omg_db/lib/omg_db/leveldb/server.ex
+++ b/apps/omg_db/lib/omg_db/leveldb/server.ex
@@ -11,201 +11,202 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+if Code.ensure_loaded?(Exleveldb) do
+  defmodule OMG.DB.LevelDB.Server do
+    @moduledoc """
+    Handles connection to leveldb
+    """
 
-defmodule OMG.DB.LevelDB.Server do
-  @moduledoc """
-  Handles connection to leveldb
-  """
+    # All complex operations on data written/read should go into OMG.DB.LevelDB.Core
+    use GenServer
 
-  # All complex operations on data written/read should go into OMG.DB.LevelDB.Core
-  use GenServer
+    alias OMG.DB.LevelDB.Core
+    require Logger
 
-  alias OMG.DB.LevelDB.Core
-  require Logger
+    defstruct [:db_ref, :name]
 
-  defstruct [:db_ref, :name]
-
-  @type t() :: %__MODULE__{
-          db_ref: Exleveldb.db_reference(),
-          name: GenServer.name()
-        }
-  @doc """
-  Initializes an empty LevelDB instance explicitly, so we can have control over it.
-  NOTE: `init` here is to init the GenServer and that assumes that `init_storage` has already been called
-  """
-  @spec init_storage(binary) :: :ok | {:error, atom}
-  def init_storage(db_path) do
-    # open and close with the create flag set to true to initialize the LevelDB itself
-    with {:ok, db_ref} <- Exleveldb.open(db_path, create_if_missing: true),
-         true <- Exleveldb.is_empty?(db_ref) || {:error, :leveldb_not_empty},
-         do: Exleveldb.close(db_ref)
-  end
-
-  def start_link([db_path: _db_path, name: name] = args) do
-    GenServer.start_link(__MODULE__, args, name: name)
-  end
-
-  def init(db_path: db_path, name: name) do
-    # needed so that terminate callback is called on normal close
-    Process.flag(:trap_exit, true)
-    ^name = create_stats_table(name)
-
-    with {:ok, db_ref} <- Exleveldb.open(db_path, create_if_missing: false) do
-      {:ok, _} =
-        :timer.send_interval(Application.fetch_env!(:omg_db, :metrics_collection_interval), self(), :send_metrics)
-
-      _ = Logger.info("Started #{inspect(__MODULE__)}")
-
-      {:ok, %__MODULE__{name: name, db_ref: db_ref}}
-    else
-      error ->
-        _ = Logger.error("It seems that Child chain database is not initialized. Check README.md")
-        error
+    @type t() :: %__MODULE__{
+            db_ref: Exleveldb.db_reference(),
+            name: GenServer.name()
+          }
+    @doc """
+    Initializes an empty LevelDB instance explicitly, so we can have control over it.
+    NOTE: `init` here is to init the GenServer and that assumes that `init_storage` has already been called
+    """
+    @spec init_storage(binary) :: :ok | {:error, atom}
+    def init_storage(db_path) do
+      # open and close with the create flag set to true to initialize the LevelDB itself
+      with {:ok, db_ref} <- Exleveldb.open(db_path, create_if_missing: true),
+           true <- Exleveldb.is_empty?(db_ref) || {:error, :leveldb_not_empty},
+           do: Exleveldb.close(db_ref)
     end
-  end
 
-  def handle_info(:send_metrics, state) do
-    :ok = :telemetry.execute([:process, __MODULE__], %{}, state)
-    {:noreply, state}
-  end
-
-  def handle_call({:multi_update, db_updates}, _from, state), do: do_multi_update(db_updates, state)
-  def handle_call({:blocks, blocks_to_fetch}, _from, state), do: do_blocks(blocks_to_fetch, state)
-  def handle_call(:utxos, _from, state), do: do_utxos(state)
-  def handle_call(:exit_infos, _from, state), do: do_exit_infos(state)
-
-  def handle_call({:block_hashes, block_numbers_to_fetch}, _from, state),
-    do: do_block_hashes(block_numbers_to_fetch, state)
-
-  def handle_call(:in_flight_exits_info, _from, state), do: do_in_flight_exits_info(state)
-  def handle_call(:competitors_info, _from, state), do: do_competitors_info(state)
-
-  def handle_call({:get_single_value, parameter}, _from, state)
-      when is_atom(parameter),
-      do: do_get_single_value(parameter, state)
-
-  def handle_call({:exit_info, utxo_pos}, _from, state), do: do_exit_info(utxo_pos, state)
-  def handle_call({:spent_blknum, utxo_pos}, _from, state), do: do_spent_blknum(utxo_pos, state)
-
-  defp do_multi_update(db_updates, state) do
-    result =
-      db_updates
-      |> Core.parse_multi_updates()
-      |> write(state)
-
-    {:reply, result, state}
-  end
-
-  defp do_blocks(blocks_to_fetch, state) do
-    result =
-      blocks_to_fetch
-      |> Enum.map(fn block -> Core.key(:block, block) end)
-      |> Enum.map(fn key -> get(key, state) end)
-      |> Core.decode_values(:block)
-
-    {:reply, result, state}
-  end
-
-  defp do_utxos(state) do
-    result = get_all_by_type(:utxo, state)
-    {:reply, result, state}
-  end
-
-  defp do_exit_infos(state) do
-    result = get_all_by_type(:exit_info, state)
-    {:reply, result, state}
-  end
-
-  defp do_block_hashes(block_numbers_to_fetch, state) do
-    result =
-      block_numbers_to_fetch
-      |> Enum.map(fn block_number -> Core.key(:block_hash, block_number) end)
-      |> Enum.map(fn key -> get(key, state) end)
-      |> Core.decode_values(:block_hash)
-
-    {:reply, result, state}
-  end
-
-  defp do_in_flight_exits_info(state) do
-    result = get_all_by_type(:in_flight_exit_info, state)
-    {:reply, result, state}
-  end
-
-  defp do_competitors_info(state) do
-    result = get_all_by_type(:competitor_info, state)
-    {:reply, result, state}
-  end
-
-  defp do_get_single_value(parameter, state) do
-    result =
-      parameter
-      |> Core.key(nil)
-      |> get(state)
-      |> Core.decode_value(parameter)
-
-    {:reply, result, state}
-  end
-
-  defp do_exit_info(utxo_pos, state) do
-    result =
-      :exit_info
-      |> Core.key(utxo_pos)
-      |> get(state)
-      |> Core.decode_value(:exit_info)
-
-    {:reply, result, state}
-  end
-
-  defp do_spent_blknum(utxo_pos, state) do
-    result =
-      :spend
-      |> Core.key(utxo_pos)
-      |> get(state)
-      |> Core.decode_value(:spend)
-
-    {:reply, result, state}
-  end
-
-  # Argument order flipping tools :(
-  @spec write(Exleveldb.write_actions(), t) :: :ok | {:error, any}
-  defp write(operations, %__MODULE__{db_ref: db_ref} = state) do
-    :ok = :telemetry.execute([:update_write, __MODULE__], %{}, state)
-    Exleveldb.write(db_ref, operations)
-  end
-
-  @spec get(atom() | binary(), t) :: {:ok, binary()} | :not_found
-  defp get(key, %__MODULE__{db_ref: db_ref} = state) do
-    :ok = :telemetry.execute([:update_read, __MODULE__], %{}, state)
-    Exleveldb.get(db_ref, key)
-  end
-
-  defp get_all_by_type(type, %__MODULE__{db_ref: db_ref} = state) do
-    :ok = :telemetry.execute([:update_multiread, __MODULE__], %{}, state)
-    do_get_all_by_type(type, db_ref)
-  end
-
-  defp do_get_all_by_type(type, db_ref) do
-    db_ref
-    |> Exleveldb.stream()
-    |> Core.filter_keys(type)
-    |> Enum.map(fn {_, value} -> {:ok, value} end)
-    |> Core.decode_values(type)
-  end
-
-  defp create_stats_table(name) do
-    case :ets.whereis(name) do
-      :undefined ->
-        true = name == :ets.new(name, table_settings())
-
-        name
-
-      _ ->
-        name
+    def start_link([db_path: _db_path, name: name] = args) do
+      GenServer.start_link(__MODULE__, args, name: name)
     end
+
+    def init(db_path: db_path, name: name) do
+      # needed so that terminate callback is called on normal close
+      Process.flag(:trap_exit, true)
+      ^name = create_stats_table(name)
+
+      with {:ok, db_ref} <- Exleveldb.open(db_path, create_if_missing: false) do
+        {:ok, _} =
+          :timer.send_interval(Application.fetch_env!(:omg_db, :metrics_collection_interval), self(), :send_metrics)
+
+        _ = Logger.info("Started #{inspect(__MODULE__)}")
+
+        {:ok, %__MODULE__{name: name, db_ref: db_ref}}
+      else
+        error ->
+          _ = Logger.error("It seems that Child chain database is not initialized. Check README.md")
+          error
+      end
+    end
+
+    def handle_info(:send_metrics, state) do
+      :ok = :telemetry.execute([:process, __MODULE__], %{}, state)
+      {:noreply, state}
+    end
+
+    def handle_call({:multi_update, db_updates}, _from, state), do: do_multi_update(db_updates, state)
+    def handle_call({:blocks, blocks_to_fetch}, _from, state), do: do_blocks(blocks_to_fetch, state)
+    def handle_call(:utxos, _from, state), do: do_utxos(state)
+    def handle_call(:exit_infos, _from, state), do: do_exit_infos(state)
+
+    def handle_call({:block_hashes, block_numbers_to_fetch}, _from, state),
+      do: do_block_hashes(block_numbers_to_fetch, state)
+
+    def handle_call(:in_flight_exits_info, _from, state), do: do_in_flight_exits_info(state)
+    def handle_call(:competitors_info, _from, state), do: do_competitors_info(state)
+
+    def handle_call({:get_single_value, parameter}, _from, state)
+        when is_atom(parameter),
+        do: do_get_single_value(parameter, state)
+
+    def handle_call({:exit_info, utxo_pos}, _from, state), do: do_exit_info(utxo_pos, state)
+    def handle_call({:spent_blknum, utxo_pos}, _from, state), do: do_spent_blknum(utxo_pos, state)
+
+    defp do_multi_update(db_updates, state) do
+      result =
+        db_updates
+        |> Core.parse_multi_updates()
+        |> write(state)
+
+      {:reply, result, state}
+    end
+
+    defp do_blocks(blocks_to_fetch, state) do
+      result =
+        blocks_to_fetch
+        |> Enum.map(fn block -> Core.key(:block, block) end)
+        |> Enum.map(fn key -> get(key, state) end)
+        |> Core.decode_values(:block)
+
+      {:reply, result, state}
+    end
+
+    defp do_utxos(state) do
+      result = get_all_by_type(:utxo, state)
+      {:reply, result, state}
+    end
+
+    defp do_exit_infos(state) do
+      result = get_all_by_type(:exit_info, state)
+      {:reply, result, state}
+    end
+
+    defp do_block_hashes(block_numbers_to_fetch, state) do
+      result =
+        block_numbers_to_fetch
+        |> Enum.map(fn block_number -> Core.key(:block_hash, block_number) end)
+        |> Enum.map(fn key -> get(key, state) end)
+        |> Core.decode_values(:block_hash)
+
+      {:reply, result, state}
+    end
+
+    defp do_in_flight_exits_info(state) do
+      result = get_all_by_type(:in_flight_exit_info, state)
+      {:reply, result, state}
+    end
+
+    defp do_competitors_info(state) do
+      result = get_all_by_type(:competitor_info, state)
+      {:reply, result, state}
+    end
+
+    defp do_get_single_value(parameter, state) do
+      result =
+        parameter
+        |> Core.key(nil)
+        |> get(state)
+        |> Core.decode_value(parameter)
+
+      {:reply, result, state}
+    end
+
+    defp do_exit_info(utxo_pos, state) do
+      result =
+        :exit_info
+        |> Core.key(utxo_pos)
+        |> get(state)
+        |> Core.decode_value(:exit_info)
+
+      {:reply, result, state}
+    end
+
+    defp do_spent_blknum(utxo_pos, state) do
+      result =
+        :spend
+        |> Core.key(utxo_pos)
+        |> get(state)
+        |> Core.decode_value(:spend)
+
+      {:reply, result, state}
+    end
+
+    # Argument order flipping tools :(
+    @spec write(Exleveldb.write_actions(), t) :: :ok | {:error, any}
+    defp write(operations, %__MODULE__{db_ref: db_ref} = state) do
+      :ok = :telemetry.execute([:update_write, __MODULE__], %{}, state)
+      Exleveldb.write(db_ref, operations)
+    end
+
+    @spec get(atom() | binary(), t) :: {:ok, binary()} | :not_found
+    defp get(key, %__MODULE__{db_ref: db_ref} = state) do
+      :ok = :telemetry.execute([:update_read, __MODULE__], %{}, state)
+      Exleveldb.get(db_ref, key)
+    end
+
+    defp get_all_by_type(type, %__MODULE__{db_ref: db_ref} = state) do
+      :ok = :telemetry.execute([:update_multiread, __MODULE__], %{}, state)
+      do_get_all_by_type(type, db_ref)
+    end
+
+    defp do_get_all_by_type(type, db_ref) do
+      db_ref
+      |> Exleveldb.stream()
+      |> Core.filter_keys(type)
+      |> Enum.map(fn {_, value} -> {:ok, value} end)
+      |> Core.decode_values(type)
+    end
+
+    defp create_stats_table(name) do
+      case :ets.whereis(name) do
+        :undefined ->
+          true = name == :ets.new(name, table_settings())
+
+          name
+
+        _ ->
+          name
+      end
+    end
+
+    defp table_settings, do: [:named_table, :set, :public, write_concurrency: true]
+
+    # WARNING, terminate below will be called only if :trap_exit is set to true
+    def terminate(_reason, %__MODULE__{db_ref: db_ref}), do: :ok = Exleveldb.close(db_ref)
   end
-
-  defp table_settings, do: [:named_table, :set, :public, write_concurrency: true]
-
-  # WARNING, terminate below will be called only if :trap_exit is set to true
-  def terminate(_reason, %__MODULE__{db_ref: db_ref}), do: :ok = Exleveldb.close(db_ref)
 end

--- a/apps/omg_db/mix.exs
+++ b/apps/omg_db/mix.exs
@@ -12,7 +12,7 @@ defmodule OMG.DB.MixProject do
       elixir: "~> 1.6",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,
-      deps: deps() ++ rocksdb(),
+      deps: deps() ++ rocksdb() ++ leveldb(),
       test_coverage: [tool: ExCoveralls]
     ]
   end
@@ -31,7 +31,6 @@ defmodule OMG.DB.MixProject do
 
   defp deps do
     [
-      {:exleveldb, "~> 0.11"},
       {:omg_status, in_umbrella: true},
       # NOTE: we only need in :dev and :test here, but we need in :prod too in performance
       #       then there's some unexpected behavior of mix that won't allow to mix these, see
@@ -47,6 +46,13 @@ defmodule OMG.DB.MixProject do
   defp rocksdb do
     case System.get_env("EXCLUDE_ROCKSDB") do
       nil -> [{:rocksdb, "~> 1.2"}]
+      _ -> []
+    end
+  end
+
+  defp leveldb do
+    case System.get_env("EXCLUDE_LEVELDB") do
+      nil -> [{:exleveldb, "~> 0.11"}]
       _ -> []
     end
   end

--- a/apps/omg_db/test/omg_db/db_test.exs
+++ b/apps/omg_db/test/omg_db/db_test.exs
@@ -11,156 +11,157 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+if Code.ensure_loaded?(Exleveldb) do
+  defmodule OMG.DBTest do
+    @moduledoc """
+    A smoke test of the LevelDB support. The intention here is to **only** test minimally, that the pipes work.
 
-defmodule OMG.DBTest do
-  @moduledoc """
-  A smoke test of the LevelDB support. The intention here is to **only** test minimally, that the pipes work.
+    For more detailed persistence test look for `...PersistenceTest` tests throughout the apps.
 
-  For more detailed persistence test look for `...PersistenceTest` tests throughout the apps.
+    Note the excluded moduletag, this test requires an explicit `--include wrappers`
+    """
+    use ExUnitFixtures
+    use OMG.DB.LevelDBCase, async: false
 
-  Note the excluded moduletag, this test requires an explicit `--include wrappers`
-  """
-  use ExUnitFixtures
-  use OMG.DB.LevelDBCase, async: false
+    alias OMG.DB
 
-  alias OMG.DB
+    @moduletag :wrappers
+    @moduletag :common
+    @writes 10
 
-  @moduletag :wrappers
-  @moduletag :common
-  @writes 10
+    test "handles object storage", %{db_dir: dir, db_pid: pid} do
+      :ok =
+        DB.multi_update(
+          [{:put, :block, %{hash: "xyz"}}, {:put, :block, %{hash: "vxyz"}}, {:put, :block, %{hash: "wvxyz"}}],
+          pid
+        )
 
-  test "handles object storage", %{db_dir: dir, db_pid: pid} do
-    :ok =
-      DB.multi_update(
-        [{:put, :block, %{hash: "xyz"}}, {:put, :block, %{hash: "vxyz"}}, {:put, :block, %{hash: "wvxyz"}}],
-        pid
-      )
+      assert {:ok, [%{hash: "wvxyz"}, %{hash: "xyz"}]} == DB.blocks(["wvxyz", "xyz"], pid)
 
-    assert {:ok, [%{hash: "wvxyz"}, %{hash: "xyz"}]} == DB.blocks(["wvxyz", "xyz"], pid)
+      :ok = DB.multi_update([{:delete, :block, "xyz"}], pid)
 
-    :ok = DB.multi_update([{:delete, :block, "xyz"}], pid)
+      checks = fn pid ->
+        assert {:ok, [%{hash: "wvxyz"}, :not_found, %{hash: "vxyz"}]} == DB.blocks(["wvxyz", "xyz", "vxyz"], pid)
+      end
 
-    checks = fn pid ->
-      assert {:ok, [%{hash: "wvxyz"}, :not_found, %{hash: "vxyz"}]} == DB.blocks(["wvxyz", "xyz", "vxyz"], pid)
+      checks.(pid)
+
+      # check actual persistence
+      pid = restart(dir, pid)
+      checks.(pid)
     end
 
-    checks.(pid)
+    test "handles single value storage", %{db_dir: dir, db_pid: pid} do
+      :ok = DB.multi_update([{:put, :last_exit_finalizer_eth_height, 12}], pid)
 
-    # check actual persistence
-    pid = restart(dir, pid)
-    checks.(pid)
-  end
+      checks = fn pid ->
+        assert {:ok, 12} == DB.get_single_value(:last_exit_finalizer_eth_height, pid)
+      end
 
-  test "handles single value storage", %{db_dir: dir, db_pid: pid} do
-    :ok = DB.multi_update([{:put, :last_exit_finalizer_eth_height, 12}], pid)
-
-    checks = fn pid ->
-      assert {:ok, 12} == DB.get_single_value(:last_exit_finalizer_eth_height, pid)
+      checks.(pid)
+      # check actual persistence
+      pid = restart(dir, pid)
+      checks.(pid)
     end
 
-    checks.(pid)
-    # check actual persistence
-    pid = restart(dir, pid)
-    checks.(pid)
-  end
+    test "block hashes return the correct range", %{db_dir: _dir, db_pid: pid} do
+      :ok =
+        DB.multi_update(
+          [
+            {:put, :block, %{hash: "xyz", number: 1}},
+            {:put, :block, %{hash: "vxyz", number: 2}},
+            {:put, :block, %{hash: "wvxyz", number: 3}}
+          ],
+          pid
+        )
 
-  test "block hashes return the correct range", %{db_dir: _dir, db_pid: pid} do
-    :ok =
-      DB.multi_update(
-        [
-          {:put, :block, %{hash: "xyz", number: 1}},
-          {:put, :block, %{hash: "vxyz", number: 2}},
-          {:put, :block, %{hash: "wvxyz", number: 3}}
-        ],
-        pid
-      )
+      {:ok, ["xyz", "vxyz", "wvxyz"]} = OMG.DB.block_hashes([1, 2, 3], pid)
+    end
 
-    {:ok, ["xyz", "vxyz", "wvxyz"]} = OMG.DB.block_hashes([1, 2, 3], pid)
-  end
+    test "if multi reading exit infos returns writen results", %{db_dir: _dir, db_pid: pid} do
+      db_writes = create_write(:exit_info, pid)
+      {:ok, exits} = DB.exit_infos(pid)
+      # what we wrote and what we read must be equal
+      [] = exits -- db_writes
+    end
 
-  test "if multi reading exit infos returns writen results", %{db_dir: _dir, db_pid: pid} do
-    db_writes = create_write(:exit_info, pid)
-    {:ok, exits} = DB.exit_infos(pid)
-    # what we wrote and what we read must be equal
-    [] = exits -- db_writes
-  end
+    test "if multi reading utxos returns writen results", %{db_dir: _dir, db_pid: pid} do
+      db_writes = create_write(:utxo, pid)
+      {:ok, utxos} = DB.utxos(pid)
+      [] = utxos -- db_writes
+    end
 
-  test "if multi reading utxos returns writen results", %{db_dir: _dir, db_pid: pid} do
-    db_writes = create_write(:utxo, pid)
-    {:ok, utxos} = DB.utxos(pid)
-    [] = utxos -- db_writes
-  end
+    test "if multi reading in flight exit infos returns writen results", %{db_dir: _dir, db_pid: pid} do
+      db_writes = create_write(:in_flight_exit_info, pid)
+      {:ok, in_flight_exits_infos} = DB.in_flight_exits_info(pid)
+      [] = in_flight_exits_infos -- db_writes
+    end
 
-  test "if multi reading in flight exit infos returns writen results", %{db_dir: _dir, db_pid: pid} do
-    db_writes = create_write(:in_flight_exit_info, pid)
-    {:ok, in_flight_exits_infos} = DB.in_flight_exits_info(pid)
-    [] = in_flight_exits_infos -- db_writes
-  end
+    test "if multi reading competitor infos returns writen results", %{db_dir: _dir, db_pid: pid} do
+      db_writes = create_write(:competitor_info, pid)
+      {:ok, competitors_info} = DB.competitors_info(pid)
+      [] = competitors_info -- db_writes
+    end
 
-  test "if multi reading competitor infos returns writen results", %{db_dir: _dir, db_pid: pid} do
-    db_writes = create_write(:competitor_info, pid)
-    {:ok, competitors_info} = DB.competitors_info(pid)
-    [] = competitors_info -- db_writes
-  end
+    test "if multi reading and writting does not pollute returned values", %{db_dir: _dir, db_pid: pid} do
+      db_writes = create_write(:exit_info, pid)
+      {:ok, exits} = DB.exit_infos(pid)
+      # what we wrote and what we read must be equal
+      [] = exits -- db_writes
 
-  test "if multi reading and writting does not pollute returned values", %{db_dir: _dir, db_pid: pid} do
-    db_writes = create_write(:exit_info, pid)
-    {:ok, exits} = DB.exit_infos(pid)
-    # what we wrote and what we read must be equal
-    [] = exits -- db_writes
+      db_writes = create_write(:utxo, pid)
+      {:ok, utxos} = DB.utxos(pid)
+      [] = utxos -- db_writes
 
-    db_writes = create_write(:utxo, pid)
-    {:ok, utxos} = DB.utxos(pid)
-    [] = utxos -- db_writes
+      db_writes = create_write(:in_flight_exit_info, pid)
+      {:ok, in_flight_exits_infos} = DB.in_flight_exits_info(pid)
+      [] = in_flight_exits_infos -- db_writes
 
-    db_writes = create_write(:in_flight_exit_info, pid)
-    {:ok, in_flight_exits_infos} = DB.in_flight_exits_info(pid)
-    [] = in_flight_exits_infos -- db_writes
+      db_writes = create_write(:competitor_info, pid)
+      {:ok, competitors_info} = DB.competitors_info(pid)
+      [] = competitors_info -- db_writes
+    end
 
-    db_writes = create_write(:competitor_info, pid)
-    {:ok, competitors_info} = DB.competitors_info(pid)
-    [] = competitors_info -- db_writes
-  end
+    defp create_write(:exit_info = type, pid) do
+      db_writes =
+        Enum.map(1..@writes, fn index -> {:put, type, {{index, index, index}, :crypto.strong_rand_bytes(index)}} end)
 
-  defp create_write(:exit_info = type, pid) do
-    db_writes =
-      Enum.map(1..@writes, fn index -> {:put, type, {{index, index, index}, :crypto.strong_rand_bytes(index)}} end)
+      :ok = write(db_writes, pid)
+      get_raw_values(db_writes)
+    end
 
-    :ok = write(db_writes, pid)
-    get_raw_values(db_writes)
-  end
+    defp create_write(:utxo = type, pid) do
+      db_writes =
+        Enum.map(1..@writes, fn index ->
+          {:put, type, {{index, index, index}, %{test: :crypto.strong_rand_bytes(index)}}}
+        end)
 
-  defp create_write(:utxo = type, pid) do
-    db_writes =
-      Enum.map(1..@writes, fn index ->
-        {:put, type, {{index, index, index}, %{test: :crypto.strong_rand_bytes(index)}}}
-      end)
+      :ok = write(db_writes, pid)
+      get_raw_values(db_writes)
+    end
 
-    :ok = write(db_writes, pid)
-    get_raw_values(db_writes)
-  end
+    defp create_write(:in_flight_exit_info = type, pid) do
+      db_writes = Enum.map(1..@writes, fn index -> {:put, type, {:crypto.strong_rand_bytes(index), index}} end)
 
-  defp create_write(:in_flight_exit_info = type, pid) do
-    db_writes = Enum.map(1..@writes, fn index -> {:put, type, {:crypto.strong_rand_bytes(index), index}} end)
+      :ok = write(db_writes, pid)
+      get_raw_values(db_writes)
+    end
 
-    :ok = write(db_writes, pid)
-    get_raw_values(db_writes)
-  end
+    defp create_write(:competitor_info = type, pid) do
+      db_writes = Enum.map(1..@writes, fn index -> {:put, type, {:crypto.strong_rand_bytes(index), index}} end)
 
-  defp create_write(:competitor_info = type, pid) do
-    db_writes = Enum.map(1..@writes, fn index -> {:put, type, {:crypto.strong_rand_bytes(index), index}} end)
+      :ok = write(db_writes, pid)
+      get_raw_values(db_writes)
+    end
 
-    :ok = write(db_writes, pid)
-    get_raw_values(db_writes)
-  end
+    defp write(db_writes, pid), do: OMG.DB.multi_update(db_writes, pid)
+    defp get_raw_values(db_writes), do: Enum.map(db_writes, &elem(&1, 2))
 
-  defp write(db_writes, pid), do: OMG.DB.multi_update(db_writes, pid)
-  defp get_raw_values(db_writes), do: Enum.map(db_writes, &elem(&1, 2))
-
-  defp restart(dir, pid) do
-    :ok = GenServer.stop(pid)
-    name = :"TestDB_#{make_ref() |> inspect()}"
-    {:ok, pid} = start_supervised(OMG.DB.child_spec(db_path: dir, name: name), restart: :temporary)
-    pid
+    defp restart(dir, pid) do
+      :ok = GenServer.stop(pid)
+      name = :"TestDB_#{make_ref() |> inspect()}"
+      {:ok, pid} = start_supervised(OMG.DB.child_spec(db_path: dir, name: name), restart: :temporary)
+      pid
+    end
   end
 end

--- a/apps/omg_db/test/support/level_db_case.ex
+++ b/apps/omg_db/test/support/level_db_case.ex
@@ -11,29 +11,30 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+if Code.ensure_loaded?(Exleveldb) do
+  defmodule OMG.DB.LevelDBCase do
+    @moduledoc """
+    Defines the useful common setup for all `...PersistenceTests`:
+     - starts temporary file handler `:briefly`
+     - creates temp dir with that
+     - initializes the low-level LevelDB storage and starts the test DB server
+    """
 
-defmodule OMG.DB.LevelDBCase do
-  @moduledoc """
-  Defines the useful common setup for all `...PersistenceTests`:
-   - starts temporary file handler `:briefly`
-   - creates temp dir with that
-   - initializes the low-level LevelDB storage and starts the test DB server
-  """
+    use ExUnit.CaseTemplate
+    alias OMG.DB.LevelDB.Server
 
-  use ExUnit.CaseTemplate
-  alias OMG.DB.LevelDB.Server
+    setup_all do
+      :ok = Application.put_env(:omg_db, :type, :leveldb, persistent: true)
+      {:ok, _} = Application.ensure_all_started(:briefly)
+      :ok
+    end
 
-  setup_all do
-    :ok = Application.put_env(:omg_db, :type, :leveldb, persistent: true)
-    {:ok, _} = Application.ensure_all_started(:briefly)
-    :ok
-  end
-
-  setup %{test: test_name} do
-    {:ok, dir} = Briefly.create(directory: true)
-    :ok = Server.init_storage(dir)
-    name = :"TestDB_#{test_name}"
-    {:ok, pid} = start_supervised(OMG.DB.child_spec(db_path: dir, name: name), restart: :temporary)
-    {:ok, %{db_dir: dir, db_pid: pid, db_pid_name: name}}
+    setup %{test: test_name} do
+      {:ok, dir} = Briefly.create(directory: true)
+      :ok = Server.init_storage(dir)
+      name = :"TestDB_#{test_name}"
+      {:ok, pid} = start_supervised(OMG.DB.child_spec(db_path: dir, name: name), restart: :temporary)
+      {:ok, %{db_dir: dir, db_pid: pid, db_pid_name: name}}
+    end
   end
 end


### PR DESCRIPTION
Ability to exclude LevelDB via env var

## Overview

Useful for skiping leveldb compilation

## Changes


- Include/exclude leveldb modules

## Testing

/
