### PR TITLE
fix: let alarms pass when healthchecks raised alarms

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,9 +7,9 @@ executors:
       - image: circleci/postgres:9.6
         environment:
           MIX_ENV: test
-          POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: postgres
-          POSTGRES_DB: omisego_dev
+          POSTGRES_USER: omisego_dev
+          POSTGRES_PASSWORD: omisego_dev
+          POSTGRES_DB: omisego_test
           CIRLCECI: true
 
     working_directory: ~/src

--- a/apps/omg_child_chain/test/omg_child_chain/child_chain_test.exs
+++ b/apps/omg_child_chain/test/omg_child_chain/child_chain_test.exs
@@ -36,6 +36,8 @@ defmodule OMG.ChildChainTest do
       :alarm_handler.clear_alarm(system_disk_alarm)
     end)
 
+    all = :gen_event.call(:alarm_handler, AlarmHandler, :get_alarms)
+    :ok = Enum.each(all, &:alarm_handler.clear_alarm(&1))
     %{system_alarm: system_alarm, system_disk_alarm: system_disk_alarm, app_alarm: app_alarm}
   end
 

--- a/apps/omg_child_chain_rpc/lib/omg_child_chain_rpc/web/plugs/health.ex
+++ b/apps/omg_child_chain_rpc/lib/omg_child_chain_rpc/web/plugs/health.ex
@@ -86,9 +86,11 @@ defmodule OMG.ChildChainRPC.Plugs.Health do
   ###
   def init(options), do: options
 
+  # we want to passthrough the alarm endpoint requests
+  def call(%{request_path: "/alarm.get"} = conn, _), do: conn
+
   def call(conn, _params) do
     # is anything raised?
-
     case :ets.match_object(@table_name, {:_, 1}) do
       [] ->
         conn

--- a/apps/omg_child_chain_rpc/test/fixtures.exs
+++ b/apps/omg_child_chain_rpc/test/fixtures.exs
@@ -18,11 +18,12 @@ defmodule OMG.ChildChainRPC.Fixtures do
   @doc "run only endpoint to make request"
   deffixture phoenix_sandbox do
     {:ok, apps} = Application.ensure_all_started(:omg_status)
+    {:ok, apps2} = Application.ensure_all_started(:plug_cowboy)
     {:ok, pid} = OMG.ChildChainRPC.Application.start([], [])
     _ = Application.load(:omg_child_chain_rpc)
 
     on_exit(fn ->
-      apps |> Enum.reverse() |> Enum.each(fn app -> :ok = Application.stop(app) end)
+      Enum.each(Enum.reverse(apps2 ++ apps), fn app -> :ok = Application.stop(app) end)
       ref = Process.monitor(pid)
 
       receive do

--- a/apps/omg_child_chain_rpc/test/omg_child_chain_rpc/web/plugs/health_test.exs
+++ b/apps/omg_child_chain_rpc/test/omg_child_chain_rpc/web/plugs/health_test.exs
@@ -22,6 +22,31 @@ defmodule OMG.ChildChainRPC.Plugs.HealthTest do
 
   describe "testing for boot_in_progress alarm" do
     @tag fixtures: [:phoenix_sandbox]
+    test "if alarm.get endpoint does not reject request because alarms are raised" do
+      :ok = :alarm_handler.clear_alarm(@alarm_2)
+      :ok = :alarm_handler.set_alarm(@alarm_1)
+
+      :ok =
+        pull_client_alarm(
+          300,
+          %{
+            "data" => [
+              %{
+                "boot_in_progress" => %{
+                  "node" => "nonode@nohost",
+                  "reporter" => "Elixir.OMG.ChildChainRPC.Plugs.HealthTest"
+                }
+              }
+            ],
+            "success" => true
+          },
+          fn -> TestHelper.rpc_call(:post, "/alarm.get", %{}) end
+        )
+
+      :ok = :alarm_handler.clear_alarm(@alarm_1)
+    end
+
+    @tag fixtures: [:phoenix_sandbox]
     test "if block.get endpoint rejects request because alarms are raised" do
       :ok = :alarm_handler.clear_alarm(@alarm_2)
       :ok = :alarm_handler.set_alarm(@alarm_1)
@@ -60,6 +85,31 @@ defmodule OMG.ChildChainRPC.Plugs.HealthTest do
   end
 
   describe "testing for ethereum_client_connection alarm " do
+    @tag fixtures: [:phoenix_sandbox]
+    test "if alarm.get endpoint works even though alarms are raised" do
+      :ok = :alarm_handler.set_alarm(@alarm_2)
+      :ok = :alarm_handler.clear_alarm(@alarm_1)
+
+      :ok =
+        pull_client_alarm(
+          300,
+          %{
+            "data" => [
+              %{
+                "ethereum_client_connection" => %{
+                  "node" => "nonode@nohost",
+                  "reporter" => "Elixir.OMG.ChildChainRPC.Plugs.HealthTest"
+                }
+              }
+            ],
+            "success" => true
+          },
+          fn -> TestHelper.rpc_call(:post, "/alarm.get", %{}) end
+        )
+
+      :ok = :alarm_handler.clear_alarm(@alarm_2)
+    end
+
     @tag fixtures: [:phoenix_sandbox]
     test "if block.get endpoint rejects request because alarms are raised" do
       :ok = :alarm_handler.set_alarm(@alarm_2)

--- a/apps/omg_eth/config/config.exs
+++ b/apps/omg_eth/config/config.exs
@@ -17,6 +17,7 @@ config :omg_eth,
   child_block_interval: 1000,
   exit_period_seconds: 7 * 24 * 60 * 60,
   ethereum_client_warning_time_ms: ethereum_client_timeout_ms / 4,
-  ws_url: "ws://localhost:8546/ws"
+  ws_url: "ws://localhost:8546/ws",
+  client_monitor_interval_ms: 10_000
 
 import_config "#{Mix.env()}.exs"

--- a/config/.credo.exs
+++ b/config/.credo.exs
@@ -85,7 +85,7 @@
         {Credo.Check.Readability.ModuleDoc, []},
         {Credo.Check.Readability.ModuleNames, []},
         {Credo.Check.Readability.ParenthesesInCondition, []},
-        {Credo.Check.Readability.ParenthesesOnZeroArityDefs, []},
+        {Credo.Check.Readability.ParenthesesOnZeroArityDefs, false},
         {Credo.Check.Readability.PredicateFunctionNames, []},
         {Credo.Check.Readability.PreferImplicitTry, []},
         {Credo.Check.Readability.RedundantBlankLines, []},


### PR DESCRIPTION
Found some alarming tickets 

## Overview

/

## Changes

- with the introduction of releases, db credentials changed
- client_monitor_interval_ms somehow got lost
- alarms on childchain needs to be passthrough otherwise we can't see alarms!!!

## Testing

Wrote some tests!