### PR TITLE
set inserted_at and updated_at null columns to epoch and add not null…

### DIFF
--- a/apps/omg_watcher/priv/repo/migrations/20190917165912_set_inserted_at_updated_at_to_epoc.exs
+++ b/apps/omg_watcher/priv/repo/migrations/20190917165912_set_inserted_at_updated_at_to_epoc.exs
@@ -1,0 +1,10 @@
+defmodule OMG.Watcher.Repo.Migrations.SetInsertedAtUpdatedAtToEpoch do
+  use Ecto.Migration
+
+  def change do
+    execute("UPDATE txoutputs SET inserted_at = 'epoch' at time zone 'utc';")
+    execute("UPDATE txoutputs SET updated_at = 'epoch' at time zone 'utc';")
+    execute("ALTER TABLE txoutputs ALTER COLUMN inserted_at SET NOT NULL;")
+    execute("ALTER TABLE txoutputs ALTER COLUMN updated_at SET NOT NULL;")
+  end
+end


### PR DESCRIPTION

See the testing steps 2 and 3 below. 2 is pre-migration. Null values are still allowed. 3. is post-migration and notice the not null modifier. Finally see in step 4 the values are epoch times.

## Testing
1. Grab dump of dev DB locally and populate local DB:
`$ psql omisego_dev -h localhost -p 5433 -U omisego_dev < ~/Downloads/omisego_dev.dump`
2. Verify the txoutputs table is the table prior to migration
```
omisego_dev=# \d txoutputs;
                                   Table "public.txoutputs"
        Column        |              Type              |              Modifiers               
----------------------+--------------------------------+--------------------------------------
 blknum               | bigint                         | not null
 txindex              | integer                        | not null
 oindex               | integer                        | not null
 creating_txhash      | bytea                          | 
 spending_txhash      | bytea                          | 
 spending_tx_oindex   | integer                        | 
 owner                | bytea                          | not null
 amount               | numeric(81,0)                  | not null
 currency             | bytea                          | not null
 proof                | bytea                          | 
 child_chain_utxohash | bytea                          | 
 inserted_at          | timestamp(0) without time zone | default timezone('utc'::text, now())
 updated_at           | timestamp(0) without time zone | default timezone('utc'::text, now())
Indexes:
    "txoutputs_pkey" PRIMARY KEY, btree (blknum, txindex, oindex)
    "txoutputs_child_chain_utxohash_index" UNIQUE, btree (child_chain_utxohash)
    "txoutputs_creating_txhash_spending_txhash_index" btree (creating_txhash, spending_txhash)
    "txoutputs_owner_index" btree (owner)
    "txoutputs_spending_txhash_index" btree (spending_txhash)
Foreign-key constraints:
    "txoutputs_creating_txhash_fkey" FOREIGN KEY (creating_txhash) REFERENCES transactions(txhash)
    "txoutputs_spending_txhash_fkey" FOREIGN KEY (spending_txhash) REFERENCES transactions(txhash)
Referenced by:
    TABLE "ethevents_txoutputs" CONSTRAINT "ethevents_txoutputs_child_chain_utxohash_fkey" FOREIGN KEY (child_chain_utxohash) REFERENCES txoutputs(child_chain_utxohash) ON DELETE RESTRICT
```
3. Run the migration and verify the output
```
omisego_dev=# \d txoutputs;
                                       Table "public.txoutputs"
        Column        |              Type              |                   Modifiers                   
----------------------+--------------------------------+-----------------------------------------------
 blknum               | bigint                         | not null
 txindex              | integer                        | not null
 oindex               | integer                        | not null
 creating_txhash      | bytea                          | 
 spending_txhash      | bytea                          | 
 spending_tx_oindex   | integer                        | 
 owner                | bytea                          | not null
 amount               | numeric(81,0)                  | not null
 currency             | bytea                          | not null
 proof                | bytea                          | 
 child_chain_utxohash | bytea                          | 
 inserted_at          | timestamp(0) without time zone | not null default timezone('utc'::text, now())
 updated_at           | timestamp(0) without time zone | not null default timezone('utc'::text, now())
Indexes:
    "txoutputs_pkey" PRIMARY KEY, btree (blknum, txindex, oindex)
    "txoutputs_child_chain_utxohash_index" UNIQUE, btree (child_chain_utxohash)
    "txoutputs_creating_txhash_spending_txhash_index" btree (creating_txhash, spending_txhash)
    "txoutputs_owner_index" btree (owner)
    "txoutputs_spending_txhash_index" btree (spending_txhash)
Foreign-key constraints:
    "txoutputs_creating_txhash_fkey" FOREIGN KEY (creating_txhash) REFERENCES transactions(txhash)
    "txoutputs_spending_txhash_fkey" FOREIGN KEY (spending_txhash) REFERENCES transactions(txhash)
Referenced by:
    TABLE "ethevents_txoutputs" CONSTRAINT "ethevents_txoutputs_child_chain_utxohash_fkey" FOREIGN KEY (child_chain_utxohash) REFERENCES txoutputs(child_chain_utxohash) ON DELETE RESTRICT
```
4. Check that exiting rows have the correct values
```
omisego_dev=# select blknum, txindex, oindex, inserted_at, updated_at from txoutputs limit 3;
 blknum | txindex | oindex |     inserted_at     |     updated_at      
--------+---------+--------+---------------------+---------------------
   7000 |     174 |      1 | 1970-01-01 00:00:00 | 1970-01-01 00:00:00
  10000 |       8 |      1 | 1970-01-01 00:00:00 | 1970-01-01 00:00:00
  11000 |      57 |      1 | 1970-01-01 00:00:00 | 1970-01-01 00:00:00
(3 rows)
```
