### PR TITLE
multi-stage docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,15 @@
+.circleci/
+.elixir_ls/
+.githooks/
+.github
+.idea/
+.vscode/
+
+_build/
+deps/
+
+docker/
+
+docker-compose.*
+
+elixir-omg.iml

--- a/docker/Dockerfile.omg-base-env
+++ b/docker/Dockerfile.omg-base-env
@@ -1,0 +1,109 @@
+
+# this file is an intermediate build file to build anc cache mix dependencies
+
+ARG ALPINE_VERSION=3.9
+
+FROM alpine:${ALPINE_VERSION} AS alpine
+
+FROM alpine AS omg-base-env
+
+LABEL maintainer="OmiseGO Team <omg@omise.co>"
+LABEL description="Builder image for OmiseGO elixir-omg"
+
+COPY --from=omg-elixir-env /usr/local/otp /usr/local/otp
+COPY --from=omg-elixir-env /usr/local/rebar3 /usr/local/rebar3
+COPY --from=omg-elixir-env /usr/local/elixir /usr/local/elixir
+COPY --from=omg-rocksdb-env /usr/local/rocksdb /usr/local/rocksdb
+
+ARG USER=elixir-omg
+ARG GROUP=elixir-omg
+ARG UID=10000
+ARG GID=10000
+ARG HOME=/home/$USER
+ARG APP_DIR=/app
+ARG BUILD_DIR=/build
+
+ARG MIX_ENV=dev
+
+ENV LANG=en_US.UTF-8
+ENV LC_ALL=en_US.UTF-8
+
+ENV LD_LIBRARY_PATH=/usr/local/otp/lib:$LD_LIBRARY_PATH
+ENV LD_LIBRARY_PATH=/usr/local/elixir/lib:$LD_LIBRARY_PATH
+ENV LD_LIBRARY_PATH=/usr/local/rocksdb/lib:$LD_LIBRARY_PATH
+
+ENV CMAKE_PREFIX_PATH=/usr/local/otp:$CMAKE_PREFIX_PATH
+ENV CMAKE_PREFIX_PATH=/usr/local/elixir:$CMAKE_PREFIX_PATH
+ENV CMAKE_PREFIX_PATH=/usr/local/rocksdb:$CMAKE_PREFIX_PATH
+
+ENV PATH=/usr/local/otp/bin:$PATH
+ENV PATH=/usr/local/rebar3/bin:$PATH
+ENV PATH=/usr/local/elixir/bin:$PATH
+
+RUN wget https://github.com/ethereum/solidity/releases/download/v0.4.25/solc-static-linux \
+  && chmod +x solc-static-linux \
+  && mv solc-static-linux solc  \
+  && install -m0755 solc /usr/local/bin/solc
+
+RUN set -xe \
+ && apk add --update --no-cache --virtual .utils \
+        linux-headers \
+        bash \
+        build-base \
+        ca-certificates \
+        cmake \
+        curl \
+        expect \
+        findutils \
+        git \
+        gnupg \
+        libressl \
+        openssh \
+ && apk add --no-cache --virtual .libsecp256k1-build \
+        autoconf \
+        automake \
+        gmp \
+        gmp-dev \
+        libtool \
+ && rm -rf "$HOME/.cache" \
+ && RUN_DEPS="$( \
+        find /usr/local -type f -executable -not \( -name '*tkinter*' \) -exec \
+            scanelf --needed --nobanner --format '%n#p' '{}' ';' \
+            | tr ',' '\n' \
+            | sort -u \
+            | awk '! /^$/ && system("test -z $(find /usr/local -iname " $1 ")") == 0 { print "so:" $1 }' \
+    )" \
+ && apk add --update --no-cache --virtual .run-deps \
+        $RUN_DEPS \
+        ca-certificates \
+        libressl-dev \
+        lksctp-tools \
+ && addgroup -g $GID $GROUP \
+ && adduser -D -h $HOME -u $UID -G $GROUP -H $USER \
+ && mkdir -p $HOME \
+ && chown -R ${UID}:${GID} $HOME \
+ && mkdir -p $APP_DIR \
+ && mkdir -p $BUILD_DIR
+
+# need to build in $APP_DIR and copy files $BUILD_DIR later. child images will pick this up and do a
+# COPY . $APP_DIR and then a `mv -f $BUILD_DIR/* $APP_DIR. Otherwise this error will occur:
+#
+# CMake Error: The source "/app/deps/rocksdb/c_src/CMakeLists.txt" does not match the source
+# "/build/deps/rocksdb/c_src/CMakeLists.txt" used to generate cache.  Re-run cmake with a different source directory.
+#
+COPY . $APP_DIR
+
+RUN chown -R ${UID}:${GID} $APP_DIR && chown -R ${UID}:${GID} $BUILD_DIR
+
+USER $USER
+WORKDIR $APP_DIR
+
+RUN set -xe \
+ && MIX_ENV=$MIX_ENV mix do local.hex --force, local.rebar --force \
+ && MIX_ENV=$MIX_ENV mix deps.get \
+ && MIX_ENV=$MIX_ENV mix deps.compile
+
+RUN find . -maxdepth 1 \( -not -name "." -a -not -name ".." -a -not -name "mix.exs" -a -not -name "mix.lock" -a -not -name "_build" -a -not -name "deps" \) -print | xargs rm -rf
+
+# cache deps and _build dir for child images
+RUN mv $APP_DIR/* $BUILD_DIR

--- a/docker/Dockerfile.omg-dev-env
+++ b/docker/Dockerfile.omg-dev-env
@@ -1,0 +1,91 @@
+
+ARG ALPINE_VERSION=3.9
+
+FROM alpine:${ALPINE_VERSION} AS alpine
+
+FROM alpine AS omg-dev-env
+
+LABEL maintainer="OmiseGO Team <omg@omise.co>"
+LABEL description="Builder image for OmiseGO elixir-omg"
+
+COPY --from=omg-elixir-env /usr/local/otp /usr/local/otp
+COPY --from=omg-elixir-env /usr/local/rebar3 /usr/local/rebar3
+COPY --from=omg-elixir-env /usr/local/elixir /usr/local/elixir
+
+ARG USER=elixir-omg
+ARG GROUP=elixir-omg
+ARG UID=10000
+ARG GID=10000
+ARG HOME=/home/${USER}
+ARG APP_DIR=/app
+
+ARG MIX_ENV=dev
+
+ENV LANG=en_US.UTF-8
+ENV LC_ALL=en_US.UTF-8
+
+ENV LD_LIBRARY_PATH=/usr/local/otp/lib:$LD_LIBRARY_PATH
+ENV LD_LIBRARY_PATH=/usr/local/elixir/lib:$LD_LIBRARY_PATH
+ENV PATH=/usr/local/otp/bin:$PATH
+ENV PATH=/usr/local/rebar3/bin:$PATH
+ENV PATH=/usr/local/elixir/bin:$PATH
+
+RUN wget https://github.com/ethereum/solidity/releases/download/v0.4.25/solc-static-linux \
+  && chmod +x solc-static-linux \
+  && mv solc-static-linux solc  \
+  && install -m0755 solc /usr/local/bin/solc
+
+RUN set -xe \
+ && apk add --update --no-cache --virtual .utils \
+        linux-headers \
+        bash \
+        build-base \
+        ca-certificates \
+        cmake \
+        curl \
+        expect \
+        findutils \
+        git \
+        gnupg \
+        libressl \
+        openssh \
+ && apk add --no-cache --virtual .libsecp256k1-build \
+        autoconf \
+        automake \
+        gmp \
+        gmp-dev \
+        libtool \
+ && rm -rf "$HOME/.cache" \
+ && RUN_DEPS="$( \
+        find /usr/local -type f -executable -not \( -name '*tkinter*' \) -exec \
+            scanelf --needed --nobanner --format '%n#p' '{}' ';' \
+            | tr ',' '\n' \
+            | sort -u \
+            | awk '! /^$/ && system("test -z $(find /usr/local -iname " $1 ")") == 0 { print "so:" $1 }' \
+    )" \
+ && apk add --update --no-cache --virtual .run-deps \
+        $RUN_DEPS \
+        ca-certificates \
+        libressl-dev \
+        lksctp-tools \
+ && addgroup -g ${GID} ${GROUP} \
+ && adduser -D -h ${HOME} -u ${UID} -G ${GROUP} -H ${USER} \
+ && mkdir -p ${HOME} \
+ && chown -R ${UID}:${GID} ${HOME} \
+ && mkdir -p ${APP_DIR} \
+ && chown -R ${UID}:${GID} ${APP_DIR}
+
+USER ${USER}
+
+WORKDIR ${APP_DIR}
+
+RUN set -xe \
+  && mix do local.hex --force, local.rebar --force
+
+COPY . ${APP_DIR}
+
+RUN set -xe \
+ && MIX_ENV=${MIX_ENV} mix deps.get \
+ && MIX_ENV=${MIX_ENV} mix deps.compile
+
+ENTRYPOINT ["/bash"]

--- a/docker/Dockerfile.omg-dev-env
+++ b/docker/Dockerfile.omg-dev-env
@@ -1,91 +1,28 @@
 
-ARG ALPINE_VERSION=3.9
+FROM omg-base-env AS omg-dev-env
 
-FROM alpine:${ALPINE_VERSION} AS alpine
-
-FROM alpine AS omg-dev-env
-
-LABEL maintainer="OmiseGO Team <omg@omise.co>"
-LABEL description="Builder image for OmiseGO elixir-omg"
-
-COPY --from=omg-elixir-env /usr/local/otp /usr/local/otp
-COPY --from=omg-elixir-env /usr/local/rebar3 /usr/local/rebar3
-COPY --from=omg-elixir-env /usr/local/elixir /usr/local/elixir
+ENV MIX_ENV=dev
 
 ARG USER=elixir-omg
-ARG GROUP=elixir-omg
 ARG UID=10000
 ARG GID=10000
-ARG HOME=/home/${USER}
+
 ARG APP_DIR=/app
+ARG BUILD_DIR=/build
 
-ARG MIX_ENV=dev
+WORKDIR $APP_DIR
 
-ENV LANG=en_US.UTF-8
-ENV LC_ALL=en_US.UTF-8
+USER root
 
-ENV LD_LIBRARY_PATH=/usr/local/otp/lib:$LD_LIBRARY_PATH
-ENV LD_LIBRARY_PATH=/usr/local/elixir/lib:$LD_LIBRARY_PATH
-ENV PATH=/usr/local/otp/bin:$PATH
-ENV PATH=/usr/local/rebar3/bin:$PATH
-ENV PATH=/usr/local/elixir/bin:$PATH
+COPY . $APP_DIR
+RUN mv -f $BUILD_DIR/* $APP_DIR && rm -rf $BUILD_DIR
 
-RUN wget https://github.com/ethereum/solidity/releases/download/v0.4.25/solc-static-linux \
-  && chmod +x solc-static-linux \
-  && mv solc-static-linux solc  \
-  && install -m0755 solc /usr/local/bin/solc
+RUN chown -R ${UID}:${GID} $APP_DIR
 
-RUN set -xe \
- && apk add --update --no-cache --virtual .utils \
-        linux-headers \
-        bash \
-        build-base \
-        ca-certificates \
-        cmake \
-        curl \
-        expect \
-        findutils \
-        git \
-        gnupg \
-        libressl \
-        openssh \
- && apk add --no-cache --virtual .libsecp256k1-build \
-        autoconf \
-        automake \
-        gmp \
-        gmp-dev \
-        libtool \
- && rm -rf "$HOME/.cache" \
- && RUN_DEPS="$( \
-        find /usr/local -type f -executable -not \( -name '*tkinter*' \) -exec \
-            scanelf --needed --nobanner --format '%n#p' '{}' ';' \
-            | tr ',' '\n' \
-            | sort -u \
-            | awk '! /^$/ && system("test -z $(find /usr/local -iname " $1 ")") == 0 { print "so:" $1 }' \
-    )" \
- && apk add --update --no-cache --virtual .run-deps \
-        $RUN_DEPS \
-        ca-certificates \
-        libressl-dev \
-        lksctp-tools \
- && addgroup -g ${GID} ${GROUP} \
- && adduser -D -h ${HOME} -u ${UID} -G ${GROUP} -H ${USER} \
- && mkdir -p ${HOME} \
- && chown -R ${UID}:${GID} ${HOME} \
- && mkdir -p ${APP_DIR} \
- && chown -R ${UID}:${GID} ${APP_DIR}
+RUN MIX_ENV=test mix deps.get \
+ && MIX_ENV=test mix deps.compile
 
-USER ${USER}
+USER $USER
 
-WORKDIR ${APP_DIR}
+ENTRYPOINT ["/bin/bash"]
 
-RUN set -xe \
-  && mix do local.hex --force, local.rebar --force
-
-COPY . ${APP_DIR}
-
-RUN set -xe \
- && MIX_ENV=${MIX_ENV} mix deps.get \
- && MIX_ENV=${MIX_ENV} mix deps.compile
-
-ENTRYPOINT ["/bash"]

--- a/docker/Dockerfile.omg-elixir-env
+++ b/docker/Dockerfile.omg-elixir-env
@@ -1,0 +1,32 @@
+
+FROM omg-erlang-env AS omg-elixir-env
+
+LABEL maintainer="OmiseGO Team <omg@omise.co>"
+LABEL description="Builder image for OmiseGO elixir-omg"
+
+ARG ELIXIR_VERSION="1.8.1"
+ARG ELIXIR_DOWNLOAD_SHA256="de8c636ea999392496ccd9a204ccccbc8cb7f417d948fd12692cda2bd02d9822"
+
+RUN set -xe \
+ && apk add --update --no-cache --virtual .elixir-build \
+        ca-certificates \
+        curl \
+        make \
+        tar \
+ && ELIXIR_DOWNLOAD_URL="https://github.com/elixir-lang/elixir/archive/v${ELIXIR_VERSION}.tar.gz" \
+ && curl -fsL -o elixir-src.tar.gz ${ELIXIR_DOWNLOAD_URL} \
+ && echo "${ELIXIR_DOWNLOAD_SHA256}  elixir-src.tar.gz" | sha256sum -c - \
+ && mkdir -p /usr/local/src/elixir \
+ && tar -xzC /usr/local/src/elixir --strip-components=1 -f elixir-src.tar.gz \
+ && rm elixir-src.tar.gz \
+ && ( \
+        cd /usr/local/src/elixir \
+            && make -j$(nproc) \
+            && PREFIX=/usr/local/elixir make install \
+    ) \
+ && rm -rf /usr/local/src/elixir \
+ && apk del .elixir-build \
+ && rm -rf /usr/local/src
+
+ENV PATH=/usr/local/elixir/bin:$PATH
+ENV LD_LIBRARY_PATH=/usr/local/elixir/lib:$LD_LIBRARY_PATH

--- a/docker/Dockerfile.omg-erlang-env
+++ b/docker/Dockerfile.omg-erlang-env
@@ -1,0 +1,87 @@
+
+ARG ALPINE_VERSION=3.9
+
+FROM alpine:${ALPINE_VERSION} AS alpine
+
+FROM alpine AS omg-erlang-env
+
+LABEL maintainer="OmiseGO Team <omg@omise.co>"
+LABEL description="Builder image for OmiseGO elixir-omg"
+
+ARG OTP_VERSION="21.2.4"
+ARG OTP_DOWNLOAD_SHA256="833d31ac102536b752e474dc6d69be7cc3e37d2d944191317312b30b1ea8ef0d"
+
+RUN set -xe \
+ && OTP_DOWNLOAD_URL="https://github.com/erlang/otp/archive/OTP-${OTP_VERSION}.tar.gz" \
+ && apk add --update --no-cache --virtual .erlang-build \
+        autoconf \
+        ca-certificates \
+        curl \
+        dpkg \
+        dpkg-dev \
+        g++ \
+        gcc \
+        libc-dev \
+        libressl-dev \
+        linux-headers \
+        lksctp-tools-dev \
+        make \
+        ncurses-dev \
+        tar \
+        unixodbc-dev \
+ && curl -fsL -o otp-src.tar.gz ${OTP_DOWNLOAD_URL} \
+ && echo "${OTP_DOWNLOAD_SHA256}  otp-src.tar.gz" | sha256sum -c - \
+ && mkdir -vp /usr/local/src/otp \
+ && tar -xzC /usr/local/src/otp --strip-components=1 -f otp-src.tar.gz \
+ && rm otp-src.tar.gz \
+ && ( \
+        cd /usr/local/src/otp \
+            && ./otp_build autoconf \
+            && ./configure --prefix=/usr/local/otp --build="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
+            && make -j$(nproc) \
+            && make install \
+    ) \
+ && rm -rf /usr/local/src/otp \
+ && find /usr/local/otp -regex '/usr/local/otp/lib/erlang/\(lib/\|erts-\).*/\(man\|doc\|obj\|c_src\|emacs\|info\|examples\)' | xargs rm -rf \
+ && find /usr/local/otp -name src | xargs -r find | grep -v '\.hrl$' | xargs rm -v || true \
+ && find /usr/local/otp -name src | xargs -r find | xargs rmdir -vp || true \
+ && scanelf --nobanner -E ET_EXEC -BF '%F' --recursive /usr/local/otp | xargs -r strip --strip-all \
+ && scanelf --nobanner -E ET_DYN -BF '%F' --recursive /usr/local/otp | xargs -r strip --strip-unneeded \
+ && OTP_RUN_DEPS="$( \
+        scanelf --needed --nobanner --format '%n#p' --recursive /usr/local/otp \
+            | tr ',' '\n' \
+            | sort -u \
+            | awk 'system("[ -e /usr/local/otp/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
+    )" \
+ && apk add --update --no-cache --virtual .erlang-run \
+        $OTP_RUN_DEPS \
+        lksctp-tools \
+ && apk del .erlang-build \
+ && rm -rf /usr/local/src
+
+ENV PATH=/usr/local/otp/bin:$PATH
+ENV LD_LIBRARY_PATH=/usr/local/otp/lib:$LD_LIBRARY_PATH
+
+ARG REBAR3_VERSION="3.8.0"
+ARG REBAR3_DOWNLOAD_SHA256="fc4d08037d39bcc651a4a749f8a5b1a10b2205527df834c2aee8f60725c3f431"
+
+RUN set -xe \
+ && apk add --update --no-cache --virtual .fetch-deps \
+        ca-certificates \
+        curl \
+ && REBAR3_DOWNLOAD_URL="https://github.com/erlang/rebar3/archive/${REBAR3_VERSION}.tar.gz" \
+ && curl -fsL -o rebar3-src.tar.gz ${REBAR3_DOWNLOAD_URL} \
+ && echo "${REBAR3_DOWNLOAD_SHA256}  rebar3-src.tar.gz" | sha256sum -c - \
+ && mkdir -p /usr/local/src/rebar3 \
+ && tar -xzC /usr/local/src/rebar3 --strip-components=1 -f rebar3-src.tar.gz \
+ && rm rebar3-src.tar.gz \
+ && ( \
+        cd /usr/local/src/rebar3 \
+            && HOME=$PWD ./bootstrap \
+            && mkdir -p /usr/local/rebar3/bin \
+            && install -v ./rebar3 /usr/local/rebar3/bin/rebar3 \
+    ) \
+ && apk del .fetch-deps \
+ && rm -rf /usr/local/src
+
+ENV PATH=/usr/local/rebar3/bin:$PATH

--- a/docker/Dockerfile.omg-rocksdb-env
+++ b/docker/Dockerfile.omg-rocksdb-env
@@ -1,0 +1,48 @@
+
+ARG ALPINE_VERSION=3.9
+
+FROM alpine:${ALPINE_VERSION} AS alpine
+
+FROM alpine AS omg-rocksdb-env
+
+ARG ROCKSDB_VERSION="6.2.2"
+ARG ROCKSDB_DOWNLOAD_SHA256="3e7365cb2a35982e95e5e5dd0b3352dc78573193dafca02788572318c38483fb"
+
+RUN set -xe \
+ && ROCKSDB_DOWNLOAD_URL="https://github.com/facebook/rocksdb/archive/v${ROCKSDB_VERSION}.tar.gz" \
+ && apk add --update --no-cache --virtual .rocksdb-build \
+        bash \
+        curl \
+        g++ \
+        gcc \
+        linux-headers \
+        make \
+        perl \
+        tar \
+ && curl -fsL -o rocksdb-src.tar.gz "${ROCKSDB_DOWNLOAD_URL}" \
+ && echo "${ROCKSDB_DOWNLOAD_SHA256}  rocksdb-src.tar.gz" | sha256sum -c - \
+ && mkdir -vp /usr/local/src/rocksdb \
+ && tar -xzC /usr/local/src/rocksdb --strip-components=1 -f rocksdb-src.tar.gz \
+ && rm rocksdb-src.tar.gz \
+ && ( \
+        cd /usr/local/src/rocksdb \
+        && make -j$(nproc) shared_lib \
+        && mkdir -p /usr/local/rocksdb/lib \
+        && mkdir -p /usr/local/rocksdb/include \
+        && cp -dr librocksdb.so* /usr/local/rocksdb/lib \
+        && cp -dr include/* /usr/local/rocksdb/include \
+    ) \
+ && rm -rf /usr/local/src/rocksdb \
+ && scanelf --nobanner -E ET_EXEC -BF '%F' --recursive /usr/local/rocksdb | xargs -r strip --strip-all \
+ && scanelf --nobanner -E ET_DYN -BF '%F' --recursive /usr/local/rocksdb | xargs -r strip --strip-unneeded \
+ && ROCKSDB_RUN_DEPS="$( \
+        scanelf --needed --nobanner --format '%n#p' --recursive /usr/local/rocksdb \
+            | tr ',' '\n' \
+            | sort -u \
+            | awk 'system("[ -e /usr/local/rocksdb/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
+    )" \
+ && apk add --update --no-cache --virtual .rocksdb-run $ROCKSDB_RUN_DEPS \
+ && apk del .rocksdb-build \
+ && rm -rf /usr/local/src
+
+ENV LD_LIBRARY_PATH=/usr/local/rocksdb/lib:$LD_LIBRARY_PATH

--- a/docker/Dockerfile.omg-service-env
+++ b/docker/Dockerfile.omg-service-env
@@ -1,0 +1,58 @@
+
+FROM omg-dev-env AS omg-service-env
+
+LABEL maintainer="OmiseGO Team <omg@omise.co>"
+LABEL description="Builder image for OmiseGO elixir-omg"
+
+ARG USER=elixir-omg
+ARG GROUP=elixir-omg
+ARG UID=10000
+ARG GID=10000
+ARG HOME=/home/$USER
+ARG APP_DIR=/app
+
+ARG MIX_ENV=dev
+ARG PORT
+ARG RELEASE_VERSION
+ARG SERVICE
+
+ARG SHA
+
+COPY . $APP_DIR
+
+USER root
+
+#leveldb and rocksdb need libstdc++
+RUN apk add --update --no-cache --virtual .watcher-runtime \
+        bash \
+        libressl \
+        libressl-dev \
+        libstdc++ \
+        lksctp-tools
+
+#libsecp256k1
+RUN apk add --no-cache gmp-dev
+
+COPY /rootfs/${SERVICE}_entrypoint /entrypoint
+
+RUN set -xe \
+ && chmod +x /entrypoint
+
+WORKDIR $APP_DIR
+
+RUN set -xe \
+ && MIX_ENV=$MIX_ENV mix do compile, distillery.release $MIX_ENV --name $SERVICE --verbose \
+ && cp ${APP_DIR}/_build/${MIX_ENV}/rel/${SERVICE}/releases/${RELEASE_VERSION}${SHA}/${SERVICE}.tar.gz $APP_DIR \
+ && tar xzf ${APP_DIR}/${SERVICE}.tar.gz \
+ && chown -R ${UID}:${GID} $APP_DIR \
+ && rm ${APP_DIR}/${SERVICE}.tar.gz
+
+EXPOSE $PORT
+
+# curl for healthchecks
+RUN apk add --no-cache curl
+
+ENTRYPOINT ["/init", "/entrypoint"]
+
+CMD ["foreground"]
+

--- a/docker/Dockerfile.omg-service-release
+++ b/docker/Dockerfile.omg-service-release
@@ -1,0 +1,90 @@
+
+ARG ALPINE_VERSION=3.9
+
+ARG SERVICE
+
+FROM omg-service-env-$SERVICE as omg-service-env
+
+FROM alpine:$ALPINE_VERSION AS alpine
+
+FROM alpine AS omg-service-release
+
+LABEL maintainer="OmiseGO Team <omg@omise.co>"
+LABEL description="Official image for OmiseGO (Watcher) Plasma Network"
+
+ARG MIX_ENV=dev
+ARG PORT
+ARG RELEASE_VERSION
+
+ARG SHA
+
+# needed here again because cannot read the SERVICE ARG outside of the FROM context
+ARG SERVICE
+
+# USER directive is not being used here since privileges are dropped via
+# s6-setuigid in /entrypoint. s6-overlay is required to be run as root.
+ARG USER=$SERVICE
+ARG GROUP=$SERVICE
+ARG UID=10000
+ARG GID=10000
+ARG APP_DIR=/app
+
+ENV LANG=C.UTF-8
+
+## S6
+##
+
+ENV S6_VERSION="1.21.4.0"
+
+RUN set -xe \
+ && apk add --update --no-cache --virtual .fetch-deps \
+        curl \
+        ca-certificates \
+ && S6_DOWNLOAD_URL="https://github.com/just-containers/s6-overlay/releases/download/v${S6_VERSION}/s6-overlay-amd64.tar.gz" \
+ && S6_DOWNLOAD_SHA256="e903f138dea67e75afc0f61e79eba529212b311dc83accc1e18a449d58a2b10c" \
+ && curl -fsL -o s6-overlay.tar.gz ${S6_DOWNLOAD_URL} \
+ && echo "${S6_DOWNLOAD_SHA256}  s6-overlay.tar.gz" | sha256sum -c - \
+ && tar -xzC / -f s6-overlay.tar.gz \
+ && rm s6-overlay.tar.gz \
+ && apk del .fetch-deps
+
+## Application
+##
+
+#leveldb and rocksdb need libstdc++
+RUN apk add --update --no-cache --virtual .watcher-runtime \
+        bash \
+        libressl \
+        libressl-dev \
+        libstdc++ \
+        lksctp-tools
+
+#libsecp256k1
+RUN apk add --no-cache gmp-dev
+
+COPY --from=omg-service-env /entrypoint /entrypoint
+
+RUN set -xe \
+ && addgroup -g $GID $GROUP \
+ && adduser -D -h $APP_DIR -u $UID -G $GROUP $USER \
+ && chown ${UID}:${GID} $APP_DIR \
+ && chmod +x /entrypoint
+
+WORKDIR $APP_DIR
+
+COPY --from=omg-service-env ${APP_DIR}/_build/${MIX_ENV}/rel/${SERVICE}/releases/${RELEASE_VERSION}${SHA}/${SERVICE}.tar.gz $APP_DIR
+RUN set -xe \
+  && tar xzf ${APP_DIR}/${SERVICE}.tar.gz && chown -R ${UID}:${GID} $APP_DIR \
+  && rm ${APP_DIR}/${SERVICE}.tar.gz
+
+EXPOSE $PORT
+
+# These are ports required for clustering. The range is defined in vm.args
+# in inet_dist_listen_min and inet_dist_listen_max.
+#EXPOSE 4369 6900 6901 6902 6903 6904 6905 6906 6907 6908 6909
+# curl for healthchecks
+RUN apk add --no-cache curl
+
+ENTRYPOINT ["/init", "/entrypoint"]
+
+CMD ["foreground"]

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+
+
+build_all() {
+  docker build -t omg-erlang-env --target omg-erlang-env - < docker/Dockerfile.omg-erlang-env \
+    && docker build -t omg-elixir-env - < docker/Dockerfile.omg-elixir-env \
+    && docker build -t omg-base-env --target omg-base-env -f docker/Dockerfile.omg-base-env . \
+    && docker build -t omg-dev-env --target omg-dev-env - < docker/Dockerfile.omg-dev-env \
+    && docker build --build-arg SERVICE=child_chain --build-arg RELEASE_VERSION=0.2.2+ --build-arg SHA=`git rev-parse --short=7 HEAD` -t omg-service-env-child_chain -f docker/Dockerfile.omg-service-env . \
+    && docker build --build-arg SERVICE=watcher --build-arg RELEASE_VERSION=0.2.2+ --build-arg SHA=`git rev-parse --short=7 HEAD` -t omg-service-env-watcher -f docker/Dockerfile.omg-service-env . \
+    && docker build --build-arg SERVICE=child_chain --build-arg RELEASE_VERSION=0.2.2+ --build-arg PORT=9656 --build-arg SHA=`git rev-parse --short=7 HEAD` -t omg-service-release-child_chain -f docker/Dockerfile.omg-service-release . \
+    && docker build --build-arg SERVICE=watcher --build-arg RELEASE_VERSION=0.2.2+ --build-arg PORT=7434 --build-arg SHA=`git rev-parse --short=7 HEAD` -t omg-service-release-watcher -f docker/Dockerfile.omg-service-release .
+}
+
+build_erlang() {
+  docker build -t omg-erlang-env --target omg-erlang-env - < docker/Dockerfile.omg-erlang-env
+}
+
+build_elixir() {
+  docker build -t omg-elixir-env --target omg-elixir-env - < docker/Dockerfile.omg-elixir-env
+}
+
+build_rocksdb() {
+  docker build -t omg-rocksdb-env --target omg-rocksdb-env - < docker/Dockerfile.omg-rocksdb-env
+}
+
+build_base() {
+  docker build -t omg-base-env --target omg-base-env -f docker/Dockerfile.omg-base-env .
+}
+
+build_dev() {
+  docker build -t omg-dev-env --target omg-dev-env -f docker/Dockerfile.omg-dev-env .
+}
+
+build_child_chain_dev() {
+  docker build --build-arg SERVICE=child_chain --build-arg RELEASE_VERSION=0.2.2+ --build-arg SHA=`git rev-parse --short=7 HEAD` -t omg-service-env-child_chain -f docker/Dockerfile.omg-service-env .
+}
+
+build_watcher_dev() {
+  docker build --build-arg SERVICE=watcher --build-arg RELEASE_VERSION=0.2.2+ --build-arg SHA=`git rev-parse --short=7 HEAD` -t omg-service-env-watcher -f docker/Dockerfile.omg-service-env .
+}
+
+build_child_chain_release() {
+  docker build --build-arg SERVICE=child_chain --build-arg RELEASE_VERSION=0.2.2+ --build-arg PORT=9656 --build-arg SHA=`git rev-parse --short=7 HEAD` -t omg-service-release-child_chain -f docker/Dockerfile.omg-service-release .
+}
+
+build_watcher_release() {
+ docker build --build-arg SERVICE=watcher --build-arg RELEASE_VERSION=0.2.2+ --build-arg PORT=7434 --build-arg SHA=`git rev-parse --short=7 HEAD` -t omg-service-release-watcher -f docker/Dockerfile.omg-service-release .
+}
+
+"$@"

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -1,0 +1,29 @@
+version: "3.7"
+
+services:
+  postgres:
+    image: postgres:9.6.13-alpine
+    restart: always
+    environment:
+      POSTGRES_USER: omisego_dev
+      POSTGRES_PASSWORD: omisego_dev
+      POSTGRES_DB: omisego_dev
+    healthcheck:
+      test: pg_isready -U omisego_dev
+      interval: 5s
+      timeout: 3s
+      retries: 5
+  omg-dev:
+    build: .
+    image: omg-dev-env:latest
+    command: sh -c 'mv /build/* /app' && bash
+    environment:
+      DATABASE_URL: postgres://omisego_dev:omisego_dev@postgres:5432/omisego_dev
+      MIX_ENV: dev
+    depends_on:
+      - postgres
+    volumes:
+      - ..:/app
+    stdin_open: true
+    tty: true
+


### PR DESCRIPTION
## Overview

- Increase productivity by prebuilding all of our dependencies in an image. Starting from this prebuilt dependency image means we spend our time building our code and not building 3rd party code. Any time a dependency changes this image will be rebuilt.
  - `make docker-child_chain && make docker-watcher` are very expensive to do, because each make invocation ends up building the dependencies twice. A single dependency build is expensive on its own.
- Remove build artifacts that get left on the host `_build` and `deps`. This has caught a number of us resulting in build discrepancies and failures.
- Reduce image sizes via docker multi-stage builds

(Please note there is another PR out with similar goals at increasing build speeds and tidying up the build environment from @InoMurko. Have a look at it for reference of another perspective on this: https://github.com/omisego/elixir-omg/pull/956/files)

TL;DR on the files below. On a day-to-day basis developers will only need to care about `Dockerfile.omg-dev-env` and `Dockerfile.omg-service-env`. In general you’ll never need to touch or worry about the other Dockerfiles. In the end, only 2 of the Dockerfiles may end up living in the `elixir-omg` repository.

1. `Dockerfile.omg-erlang-env`
2. `Dockerfile.omg-elixir-env`
3. `Dockerfile.omg-dev-env`
4. `Dockerfile.omg-service-env`
5. `Dockerfile.omg-service-release`

The first 2 docker images were stolen from https://github.com/omisego-images/docker-elixir-omg/tree/master/builder. They build our foundational erlang/elixir images.

As a developer `Dockerfile.omg-dev-env` and `Dockerfile.omg-service-env` are what you will use the most.
- `Dockerfile.omg-dev-env` creates an elixir image with all the dependencies prebuilt and all the elixir tooling. Very fast as it only builds our code. Good for running tests and debugging code.
- `Dockerfile.omg-service-env` produces either a runnable child_chain or watcher image. It does not remove elixir or any other tooling so that you can run our services, step into the container and debug what you need to debug.

The last docker image was taken from `Dockerfile.childchain` and `Dockerfile.watcher` and combined into one. They have a few different dependencies, but there was a lot of duplicated code in them. Given that it doesn’t effect the production releases, I merged this into 1 file. You specify if you want to build child_chain or watcher via a `--build-arg` called `SERVICE`. This last image will definitely need buy-in from @InoMurko and @jbunce.

Unexpected bonus points! I either got really lucky or I broke something. 🤣  The release images created by this PR reduce our production images by 8%.

Current image sizes:
```
omisego/watcher                           169MB
omisego/child_chain                       163MB
```

Docker image sizes from this PR:
```
omg-service-release-watcher               156MB
omg-service-release-child_chain           151MB
```

Also just FYI and for fun! 😄 

The entire stack can be built from scratch with the command line below. This would obviously be tidied up in a nice script with functions for this or a Makefile, my preference being a script.


```
docker build -t omg-erlang-env --target omg-erlang-env - < docker/Dockerfile.omg-erlang-env \
  && docker build -t omg-elixir-env - < docker/Dockerfile.omg-elixir-env \
  && docker build -t omg-dev-env --target omg-dev-env -f docker/Dockerfile.omg-dev-env . \
  && docker build --build-arg SERVICE=child_chain --build-arg RELEASE_VERSION=0.2.2+ --build-arg SHA=`git rev-parse --short=7 HEAD` -t omg-service-env-child_chain -f docker/Dockerfile.omg-service-env . \
  && docker build --build-arg SERVICE=watcher --build-arg RELEASE_VERSION=0.2.2+ --build-arg SHA=`git rev-parse --short=7 HEAD` -t omg-service-env-watcher -f docker/Dockerfile.omg-service-env . \
  && docker build --build-arg SERVICE=child_chain --build-arg RELEASE_VERSION=0.2.2+ --build-arg PORT=9656 --build-arg SHA=`git rev-parse --short=7 HEAD` -t omg-service-release-child_chain -f docker/Dockerfile.omg-service-release . \
  && docker build --build-arg SERVICE=watcher --build-arg RELEASE_VERSION=0.2.2+ --build-arg PORT=7434 --build-arg SHA=`git rev-parse --short=7 HEAD` -t omg-service-release-watcher -f docker/Dockerfile.omg-service-release .
```


## Testing

Used the above command-line to build the system from scratch and bring up childchain and watcher and verify they were up and running correctly.
