### PR TITLE
fix: deploy specific tag

### DIFF
--- a/.circleci/ci_deploy.sh
+++ b/.circleci/ci_deploy.sh
@@ -45,11 +45,12 @@ gcloud auth activate-service-account --key-file="$GCPFILE"
 gcloud config set project "$GCP_ACCOUNT_ID"
 gcloud config set compute/zone ${GCP_ZONE}
 gcloud container clusters get-credentials ${GCP_CLUSTER_DEVELOPMENT}
-
+image_tag="$(printf "%s" "$CIRCLE_SHA1" | head -c 8)"
 if [ "$DEPLOY" = "watcher" ]; then
-    kubectl set image statefulset watcher watcher=omisego/watcher:latest
+
+    kubectl set image statefulset watcher watcher=omisego/watcher:${image_tag}
     while true; do if [ "$(kubectl get pods watcher-0 -o jsonpath=\"{.status.phase}\" | grep Running)" ]; then break; fi; done
 else
-    kubectl set image statefulset childchain childchain=omisego/child_chain:latest
+    kubectl set image statefulset childchain childchain=omisego/child_chain:${image_tag}
     while true; do if [ "$(kubectl get pods childchain-0 -o jsonpath=\"{.status.phase}\" | grep Running)" ]; then break; fi; done
 fi;


### PR DESCRIPTION
/

## Overview

To avoid caching images by using :latest tag, use git sha of the build.

## Changes


- Get SHA
- Push image tagged with short git tag

## Testing

/
