### PR TITLE
fix: Add missing quotes to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ help:
 	@echo "-----------------------------"
 	@echo "This presumes you want to run geth, plasma-deployer and postgres as containers"
 	@echo "but Watcher and Child Chain bare metal."
-	@echo "You will need four terminal windows.
+	@echo "You will need four terminal windows."
 	@echo "In the first one run:"
 	@echo "make raw-start-services"
 	@echo "This will start geth, postgres and plasma-deployer. In case on of the containers is faulty, restart it by running the command again. Usually it's plasma-deployer."
@@ -24,9 +24,9 @@ help:
 	@echo "Wait until they all boot. And run in the fourth terminal window"
 	@echo "make get-alarms"
 	@echo "If you want to attach yourself to running services, use"
-	@echoe "make remote-child_chain"
+	@echo "make remote-child_chain"
 	@echo "or make remote-watcher"
-	@echo "Discover other rules with
+	@echo "Discover other rules with"
 	@echo "make list"
 
 .PHONY: list


### PR DESCRIPTION
:clipboard: /

## Overview

Adds missing quotes to the `make help` section, which was returning errors:

```sh
Dont Fear the Makefile
*DOCKER DEVELOPMENT*:
make docker-start-cluster - will start everything for you, but if there are no local images
for Watcher and Child chain tagged with latest they will get pulled from our repository.
If you want to use your own image containers for Watcher and Child Chain
use make docker-watcher && make docker-child_chain.
For rapid development that replaces containers with your code changes
one can use make docker-update-watcher or make docker-update-child_chain.
BARE METAL DEVELOPMENT:
ATTENTION ATTENTION ATTENTION
-----------------------------
This presumes you want to run geth, plasma-deployer and postgres as containers
but Watcher and Child Chain bare metal.
/bin/sh: 1: Syntax error: Unterminated quoted string
Makefile:3: recipe for target 'help' failed
```

## Changes

Adds the missing quotes

## Testing

Run `make` or `make help`. This should now proceed without errors.