### PR TITLE
feature: migrate statix to bleacherreport branch for events support

### DIFF
--- a/apps/omg_status/lib/omg_status/metric/statix.ex
+++ b/apps/omg_status/lib/omg_status/metric/statix.ex
@@ -35,6 +35,10 @@ defmodule OMG.Status.Metric.Statix do
 
       def set(key, val, options \\ []), do: :ok
 
+      def event(key, val, options), do: :ok
+
+      def service_check(key, val, options), do: :ok
+
       def current_conn, do: %Statix.Conn{sock: __MODULE__}
     end
   end

--- a/apps/omg_status/mix.exs
+++ b/apps/omg_status/mix.exs
@@ -33,7 +33,7 @@ defmodule OMG.Status.Mixfile do
     do: [
       {:telemetry, "~> 0.4.0"},
       {:sentry, "~> 7.0"},
-      {:statix, "~> 1.2"},
+      {:statix, git: "git@github.com:bleacherreport/statix.git", branch: "otp-21.3.8.4-support"},
       {:spandex_datadog, "~> 0.4"},
       {:decorator, "~> 1.2"},
       {:vmstats, "~> 2.3", runtime: false},

--- a/mix.lock
+++ b/mix.lock
@@ -66,7 +66,7 @@
   "spandex_ecto": {:hex, :spandex_ecto, "0.6.0", "feedda8456deb37a87ee698f1f779304b68e7e42afc7c1fe5b9f801a732b89d6", [:mix], [{:spandex, "~> 2.2", [hex: :spandex, repo: "hexpm", optional: false]}], "hexpm"},
   "spandex_phoenix": {:hex, :spandex_phoenix, "0.4.1", "d52e12f801fce4efba658ac4e98be18ea9903ecf9f37682b401656ed8d9c7abe", [:mix], [{:plug, "~> 1.3", [hex: :plug, repo: "hexpm", optional: false]}, {:spandex, "~> 2.2", [hex: :spandex, repo: "hexpm", optional: false]}], "hexpm"},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.4", "f0eafff810d2041e93f915ef59899c923f4568f4585904d010387ed74988e77b", [:make, :mix, :rebar3], [], "hexpm"},
-  "statix": {:hex, :statix, "1.2.1", "4f23c8cc2477ea0de89fed5e34f08c54b0d28b838f7b8f26613155f2221bb31e", [:mix], [], "hexpm"},
+  "statix": {:git, "git@github.com:bleacherreport/statix.git", "f27c37bee69d1bbae89532049f6d3250b348f0ac", [branch: "otp-21.3.8.4-support"]},
   "telemetry": {:hex, :telemetry, "0.4.0", "8339bee3fa8b91cb84d14c2935f8ecf399ccd87301ad6da6b71c09553834b2ab", [:rebar3], [], "hexpm"},
   "unicode_util_compat": {:hex, :unicode_util_compat, "0.4.1", "d869e4c68901dd9531385bb0c8c40444ebf624e60b6962d95952775cac5e90cd", [:rebar3], [], "hexpm"},
   "vmstats": {:hex, :vmstats, "2.3.1", "fa719deb51c53672955cbf0e131cfe85be51732c700d2b58232157ac0478bf4a", [:rebar3], [], "hexpm"},


### PR DESCRIPTION
https://github.com/omisego/elixir-omg/issues/937

## Overview

Statix we used to have does not support `events` and `service_check`

## Changes


- Swap statix and lock on git SHA

## Testing
Same testing applies at the moment.
