### PR TITLE
fix: expand the sla_margin to 23 worth of blocks by default

### DIFF
--- a/apps/omg_watcher/config/config.exs
+++ b/apps/omg_watcher/config/config.exs
@@ -13,8 +13,8 @@ config :omg_watcher, child_chain_url: "http://localhost:9656"
 config :omg_watcher,
   namespace: OMG.Watcher,
   ecto_repos: [OMG.Watcher.DB.Repo],
-  # 4 hours worth of blocks - this is how long the child chain server has to block spends from exiting utxos
-  exit_processor_sla_margin: 4 * 4 * 60,
+  # 23 hours worth of blocks - this is how long the child chain server has to block spends from exiting utxos
+  exit_processor_sla_margin: {:system, "EXIT_PROCESSOR_SLA_MARGIN", 23 * 60 * 4, {String, :to_integer}},
   maximum_block_withholding_time_ms: 1_200_000,
   block_getter_loops_interval_ms: 500,
   maximum_number_of_unapplied_blocks: 50,


### PR DESCRIPTION
Cherry-picked from v0.2:

Merge pull request #970 from omisego/hotfix_sla_margin

## Overview

see #970

## Changes

see #970

## Testing

see #970
