### PR TITLE
Tidy composing SEs and prevent timeouting of request to the Watcher

### DIFF
--- a/apps/omg/test/omg/state/persistence_test.exs
+++ b/apps/omg/test/omg/state/persistence_test.exs
@@ -66,6 +66,15 @@ defmodule OMG.State.PersistenceTest do
   end
 
   @tag fixtures: [:alice, :bob, :state_empty]
+  test "utxos are persisted and can be fetched from db",
+       %{alice: alice, db_pid: db_pid, state_empty: state} do
+    state
+    |> persist_deposit([%{owner: alice.addr, currency: @eth, amount: 20, blknum: 1}], db_pid)
+
+    assert {:ok, {{1, 0, 0}, %{amount: 20}}} = OMG.DB.utxo({1, 0, 0}, db_pid)
+  end
+
+  @tag fixtures: [:alice, :bob, :state_empty]
   test "all utxos get initialized by query result from db",
        %{alice: alice, db_pid: db_pid, bob: bob, state_empty: state} do
     state

--- a/apps/omg_db/lib/db.ex
+++ b/apps/omg_db/lib/db.ex
@@ -30,6 +30,7 @@ defmodule OMG.DB do
   @callback multi_update(term()) :: :ok | {:error, any}
   @callback blocks(block_to_fetch :: list()) :: {:ok, list(term)}
   @callback utxos() :: {:ok, list({utxo_pos_db_t, term})}
+  @callback utxo(utxo_pos_db_t) :: {:ok, term}
   @callback exit_infos() :: {:ok, list(term)}
   @callback in_flight_exits_info() :: {:ok, list(term)}
   @callback competitors_info() :: {:ok, list(term)}
@@ -44,6 +45,7 @@ defmodule OMG.DB do
   @callback multi_update(term(), GenServer.server()) :: :ok | {:error, any}
   @callback blocks(block_to_fetch :: list(), GenServer.server()) :: {:ok, list()} | {:error, any}
   @callback utxos(GenServer.server()) :: {:ok, list({utxo_pos_db_t, term})} | {:error, any}
+  @callback utxo(utxo_pos_db_t, GenServer.server()) :: {:ok, term} | {:error, any}
   @callback exit_infos(GenServer.server()) :: {:ok, list(term)} | {:error, any}
   @callback in_flight_exits_info(GenServer.server()) :: {:ok, list(term)} | {:error, any}
   @callback competitors_info(GenServer.server()) :: {:ok, list(term)} | {:error, any}
@@ -58,6 +60,7 @@ defmodule OMG.DB do
                       multi_update: 2,
                       blocks: 2,
                       utxos: 1,
+                      utxo: 2,
                       exit_infos: 1,
                       in_flight_exits_info: 1,
                       competitors_info: 1,
@@ -96,6 +99,9 @@ defmodule OMG.DB do
 
   def utxos, do: driver().utxos()
   def utxos(server), do: driver().utxos(server)
+
+  def utxo(utxo_pos), do: driver().utxo(utxo_pos)
+  def utxo(utxo_pos, server), do: driver().utxo(utxo_pos, server)
 
   def exit_infos, do: driver().exit_infos
   def exit_infos(server), do: driver().exit_infos(server)

--- a/apps/omg_db/lib/omg_db/rocks_db.ex
+++ b/apps/omg_db/lib/omg_db/rocks_db.ex
@@ -73,6 +73,10 @@ if Code.ensure_loaded?(:rocksdb) do
       GenServer.call(server_name, :utxos, @ten_minutes)
     end
 
+    def utxo(utxo_pos, server_name \\ @server_name) do
+      GenServer.call(server_name, {:utxo, utxo_pos})
+    end
+
     def exit_infos(server_name \\ @server_name) do
       _ = Logger.info("Reading exits' info, this might take a while. Allowing #{inspect(@one_minute)} ms")
       GenServer.call(server_name, :exit_infos, @one_minute)

--- a/apps/omg_db/lib/omg_db/rocksdb/server.ex
+++ b/apps/omg_db/lib/omg_db/rocksdb/server.ex
@@ -78,6 +78,7 @@ if Code.ensure_loaded?(:rocksdb) do
     def handle_call({:multi_update, db_updates}, _from, state), do: do_multi_update(db_updates, state)
     def handle_call({:blocks, blocks_to_fetch}, _from, state), do: do_blocks(blocks_to_fetch, state)
     def handle_call(:utxos, _from, state), do: do_utxos(state)
+    def handle_call({:utxo, utxo_pos}, _from, state), do: do_utxo(utxo_pos, state)
     def handle_call(:exit_infos, _from, state), do: do_exit_infos(state)
 
     def handle_call({:block_hashes, block_numbers_to_fetch}, _from, state),
@@ -119,6 +120,11 @@ if Code.ensure_loaded?(:rocksdb) do
 
     defp do_utxos(state) do
       result = get_all_by_type(:utxo, state)
+      {:reply, result, state}
+    end
+
+    defp do_utxo(utxo_pos, state) do
+      result = Core.key(:utxo, utxo_pos) |> get(state) |> Core.decode_value(:utxo)
       {:reply, result, state}
     end
 

--- a/apps/omg_db/test/omg_db/db_test.exs
+++ b/apps/omg_db/test/omg_db/db_test.exs
@@ -78,6 +78,14 @@ defmodule OMG.DBTest do
     {:ok, ["xyz", "vxyz", "wvxyz"]} = OMG.DB.block_hashes([1, 2, 3], pid)
   end
 
+  test "utxo can be fetched by utxo position", %{db_pid: pid} do
+    index = 123
+    item = {{index, index, index}, %{test: :crypto.strong_rand_bytes(index)}}
+    db_writes = [{:put, :utxo, item}]
+    :ok = write(db_writes, pid)
+    assert {:ok, ^item} = DB.utxo({index, index, index}, pid)
+  end
+
   test "if multi reading exit infos returns writen results", %{db_dir: _dir, db_pid: pid} do
     db_writes = create_write(:exit_info, pid)
     {:ok, exits} = DB.exit_infos(pid)

--- a/apps/omg_watcher/lib/omg_watcher/api/utxo.ex
+++ b/apps/omg_watcher/lib/omg_watcher/api/utxo.ex
@@ -42,13 +42,13 @@ defmodule OMG.Watcher.API.Utxo do
 
   @spec compose_utxo_exit(Utxo.Position.t()) :: {:ok, exit_t()} | {:error, :utxo_not_found}
   def compose_utxo_exit(utxo_pos) when is_deposit(utxo_pos) do
-    OMG.DB.utxos() |> Core.get_deposit_utxo(utxo_pos) |> Core.compose_deposit_exit(utxo_pos)
+    utxo_pos |> Utxo.Position.to_db_key() |> OMG.DB.utxo() |> Core.compose_deposit_standard_exit()
   end
 
   def compose_utxo_exit(Utxo.position(blknum, _, _) = utxo_pos) do
     with {:ok, [blk_hash]} <- OMG.DB.block_hashes([blknum]),
          {:ok, [db_block]} <- OMG.DB.blocks([blk_hash]) do
-      Core.compose_output_exit(db_block, utxo_pos)
+      Core.compose_block_standard_exit(db_block, utxo_pos)
     else
       _error -> {:error, :utxo_not_found}
     end

--- a/apps/omg_watcher/lib/omg_watcher/api/utxo.ex
+++ b/apps/omg_watcher/lib/omg_watcher/api/utxo.ex
@@ -16,6 +16,7 @@ defmodule OMG.Watcher.API.Utxo do
   @moduledoc """
   Module provides API for utxos
   """
+
   alias OMG.Utxo
   alias OMG.Watcher.ExitProcessor
   alias OMG.Watcher.UtxoExit.Core
@@ -45,9 +46,9 @@ defmodule OMG.Watcher.API.Utxo do
   end
 
   def compose_utxo_exit(Utxo.position(blknum, _, _) = utxo_pos) do
-    with {:ok, blk_hashes} <- OMG.DB.block_hashes([blknum]),
-         {:ok, [%{transactions: transactions}]} <- OMG.DB.blocks(blk_hashes) do
-      Core.compose_output_exit(transactions, utxo_pos)
+    with {:ok, [blk_hash]} <- OMG.DB.block_hashes([blknum]),
+         {:ok, [db_block]} <- OMG.DB.blocks([blk_hash]) do
+      Core.compose_output_exit(db_block, utxo_pos)
     else
       _error -> {:error, :utxo_not_found}
     end

--- a/apps/omg_watcher/lib/omg_watcher/db/txoutput.ex
+++ b/apps/omg_watcher/lib/omg_watcher/db/txoutput.ex
@@ -24,12 +24,10 @@ defmodule OMG.Watcher.DB.TxOutput do
   alias OMG.Utxo
   alias OMG.Watcher.DB
   alias OMG.Watcher.DB.Repo
-  alias OMG.Watcher.UtxoExit.Core
 
   require Utxo
 
   import Ecto.Query, only: [from: 2, where: 2]
-  import Utxo, only: [is_deposit: 1]
 
   @type balance() :: %{
           currency: binary(),
@@ -67,14 +65,6 @@ defmodule OMG.Watcher.DB.TxOutput do
 
     timestamps(type: :utc_datetime)
   end
-
-  @spec compose_utxo_exit(Utxo.Position.t()) :: {:ok, exit_t()} | {:error, :utxo_not_found}
-  def compose_utxo_exit(Utxo.position(_, _, _) = decoded_utxo_pos) when is_deposit(decoded_utxo_pos),
-    do: get_by_position(decoded_utxo_pos) |> Core.compose_deposit_exit(decoded_utxo_pos)
-
-  def compose_utxo_exit(Utxo.position(blknum, _, _) = decoded_utxo_pos),
-    # TODO: Make use of Block API's block.get when available
-    do: DB.Transaction.get_by_blknum(blknum) |> Core.compose_output_exit(decoded_utxo_pos)
 
   # preload ethevents in a single query as there will not be a large number of them
   @spec get_by_position(Utxo.Position.t()) :: map() | nil

--- a/apps/omg_watcher/lib/omg_watcher/utxo_exit/core.ex
+++ b/apps/omg_watcher/lib/omg_watcher/utxo_exit/core.ex
@@ -23,9 +23,9 @@ defmodule OMG.Watcher.UtxoExit.Core do
 
   require Utxo
 
-  def compose_output_exit(:not_found, _), do: {:error, :utxo_not_found}
+  def compose_block_standard_exit(:not_found, _), do: {:error, :utxo_not_found}
 
-  def compose_output_exit(db_block, Utxo.position(blknum, txindex, _) = utxo_pos) do
+  def compose_block_standard_exit(db_block, Utxo.position(blknum, txindex, _) = utxo_pos) do
     %Block{transactions: sorted_txs_bytes, number: ^blknum} = block = Block.from_db_value(db_block)
 
     if signed_tx_bytes = Enum.at(sorted_txs_bytes, txindex) do
@@ -42,16 +42,7 @@ defmodule OMG.Watcher.UtxoExit.Core do
     end
   end
 
-  @spec get_deposit_utxo({:ok, list({OMG.DB.utxo_pos_db_t(), Transaction.Payment.output()})}, Utxo.Position.t()) ::
-          nil | Transaction.Payment.output()
-  def get_deposit_utxo({:ok, utxos}, Utxo.position(blknum, _, _)) do
-    case Enum.find(utxos, fn {{blk, _, _}, _} -> blk == blknum end) do
-      {_, utxo} -> utxo
-      _ -> nil
-    end
-  end
-
-  @spec compose_deposit_exit(Transaction.Payment.output() | any(), Utxo.Position.t()) ::
+  @spec compose_deposit_standard_exit({:ok, {tuple, map}} | :not_found) ::
           {:error, :no_deposit_for_given_blknum}
           | {:ok,
              %{
@@ -59,7 +50,9 @@ defmodule OMG.Watcher.UtxoExit.Core do
                txbytes: binary,
                proof: binary
              }}
-  def compose_deposit_exit(%{amount: amount, currency: currency, owner: owner}, utxo_pos) do
+  def compose_deposit_standard_exit({:ok, {db_utxo_pos, db_utxo_value}}) do
+    utxo_pos = Utxo.Position.from_db_key(db_utxo_pos)
+    %{amount: amount, currency: currency, owner: owner} = Utxo.from_db_value(db_utxo_value)
     tx = Transaction.Payment.new([], [{owner, currency, amount}])
     txs = [Transaction.Signed.encode(%Transaction.Signed{raw_tx: tx, sigs: []})]
 
@@ -71,5 +64,5 @@ defmodule OMG.Watcher.UtxoExit.Core do
      }}
   end
 
-  def compose_deposit_exit(_, _), do: {:error, :no_deposit_for_given_blknum}
+  def compose_deposit_standard_exit(:not_found), do: {:error, :no_deposit_for_given_blknum}
 end

--- a/apps/omg_watcher/test/omg_watcher/db/txoutput_test.exs
+++ b/apps/omg_watcher/test/omg_watcher/db/txoutput_test.exs
@@ -24,29 +24,6 @@ defmodule OMG.Watcher.DB.TxOutputTest do
 
   @eth OMG.Eth.RootChain.eth_pseudo_address()
 
-  @tag fixtures: [:initial_blocks]
-  test "compose_utxo_exit should return proper proof format" do
-    {:ok,
-     %{
-       utxo_pos: _utxo_pos,
-       txbytes: _txbytes,
-       proof: proof,
-       sigs: _sigs
-     }} = DB.TxOutput.compose_utxo_exit(Utxo.position(3000, 0, 1))
-
-    assert <<_proof::bytes-size(512)>> = proof
-  end
-
-  @tag fixtures: [:initial_blocks]
-  test "compose_utxo_exit should return error when there is no txs in specfic block" do
-    {:error, :no_deposit_for_given_blknum} = DB.TxOutput.compose_utxo_exit(Utxo.position(1001, 1, 0))
-  end
-
-  @tag fixtures: [:initial_blocks]
-  test "compose_utxo_exit should return error when there is no tx in specfic block" do
-    {:error, :utxo_not_found} = DB.TxOutput.compose_utxo_exit(Utxo.position(2000, 1, 0))
-  end
-
   @tag fixtures: [:phoenix_ecto_sandbox, :alice]
   test "transaction output schema handles big numbers properly", %{alice: alice} do
     power_of_2 = fn n -> :lists.duplicate(n, 2) |> Enum.reduce(&(&1 * &2)) end

--- a/apps/omg_watcher/test/omg_watcher/utxo_exit/core_test.exs
+++ b/apps/omg_watcher/test/omg_watcher/utxo_exit/core_test.exs
@@ -15,8 +15,8 @@
 defmodule OMG.Watcher.UtxoExit.CoreTest do
   use ExUnitFixtures
   use ExUnit.Case, async: true
-  use OMG.Fixtures
 
+  alias OMG.Block
   alias OMG.State.Transaction
   alias OMG.TestHelper
   alias OMG.Utxo
@@ -25,13 +25,17 @@ defmodule OMG.Watcher.UtxoExit.CoreTest do
 
   @eth OMG.Eth.RootChain.eth_pseudo_address()
 
+  setup do
+    alice = TestHelper.generate_entity()
+    %{alice: alice}
+  end
+
   test "getting exit data returns error when there is no deposit" do
     assert {:error, :no_deposit_for_given_blknum} == Core.compose_deposit_exit(nil, Utxo.position(1003, 0, 0))
   end
 
-  @tag fixtures: [:alice]
   test "creating deposit exit", %{alice: alice} do
-    position = Utxo.position(1000, 0, 0)
+    position = Utxo.position(1003, 0, 0)
     encode_utxo = position |> Utxo.Position.encode()
 
     assert {:ok,
@@ -50,41 +54,62 @@ defmodule OMG.Watcher.UtxoExit.CoreTest do
              )
   end
 
-  @tag fixtures: [:alice]
   test "compose output exit", %{alice: alice} do
-    tx_encode = fn number ->
-      TestHelper.create_encoded([{1_000, number, 0, alice}], @eth, [{alice, 10}])
-    end
-
-    tx_exit = tx_encode.(30)
-    tx_exit_raw_tx_bytes = Transaction.Signed.decode!(tx_exit) |> Transaction.raw_txbytes()
-
-    position = Utxo.position(3, 0, 1)
+    blknum = 4000
+    tx_exit = TestHelper.create_recovered([{1_000, 1, 0, alice}], @eth, [{alice, 10}])
+    tx_exit_raw_tx_bytes = Transaction.raw_txbytes(tx_exit)
+    position = Utxo.position(blknum, 1, 0)
     encode_utxo = position |> Utxo.Position.encode()
+
+    block =
+      [
+        TestHelper.create_recovered([{1_000, 2, 0, alice}], @eth, [{alice, 10}]),
+        tx_exit,
+        TestHelper.create_recovered([{1_000, 3, 0, alice}], @eth, [{alice, 10}])
+      ]
+      |> Block.hashed_txs_at(blknum)
+      |> Block.to_db_value()
 
     assert {:ok,
             %{
-              proof: _proof,
-              sigs: _sig,
+              proof: proof,
               txbytes: ^tx_exit_raw_tx_bytes,
               utxo_pos: ^encode_utxo
-            }} =
-             Core.compose_output_exit(
-               [
-                 %{txindex: 2, txbytes: tx_encode.(20)},
-                 %{txindex: 1, txbytes: tx_encode.(10)},
-                 %{txindex: 0, txbytes: tx_exit},
-                 %{txindex: 3, txbytes: tx_encode.(0)}
-               ],
-               position
-             )
+            }} = Core.compose_output_exit(block, position)
+
+    assert byte_size(proof) == 32 * 16
+  end
+
+  test "compose output exit, position exceeding the block tx count", %{alice: alice} do
+    blknum = 4000
+    position = Utxo.position(blknum, 1, 0)
+
+    block =
+      [TestHelper.create_recovered([{1_000, 1, 0, alice}], @eth, [{alice, 10}])]
+      |> Block.hashed_txs_at(blknum)
+      |> Block.to_db_value()
+
+    assert {:error, :utxo_not_found} = Core.compose_output_exit(block, position)
+  end
+
+  test "compose output exit, erroneously mismatch blknum and utxo pos (should never occur)", %{alice: alice} do
+    position = Utxo.position(3000, 0, 0)
+
+    block =
+      [TestHelper.create_recovered([{1_000, 1, 0, alice}], @eth, [{alice, 10}])]
+      |> Block.hashed_txs_at(4000)
+      |> Block.to_db_value()
+
+    assert_raise MatchError, fn -> Core.compose_output_exit(block, position) end
   end
 
   test "getting exit data returns error when there is no utxo" do
-    assert {:error, :utxo_not_found} == Core.compose_output_exit([], Utxo.position(1_000, 1, 2))
+    block = Block.hashed_txs_at([], 1000) |> Block.to_db_value()
+
+    assert {:error, :utxo_not_found} ==
+             Core.compose_output_exit(block, Utxo.position(1_000, 1, 2))
   end
 
-  @tag fixtures: [:alice]
   test "return utxo when in blknum in utxos map", %{alice: %{addr: alice_addr}} do
     assert %{amount: 7, currency: @eth, owner: alice_addr} ==
              Core.get_deposit_utxo(
@@ -94,7 +119,6 @@ defmodule OMG.Watcher.UtxoExit.CoreTest do
              )
   end
 
-  @tag fixtures: [:alice]
   test "return nil when in blknum not in utxos map", %{alice: alice} do
     assert nil ==
              Core.get_deposit_utxo(

--- a/apps/omg_watcher/test/omg_watcher/utxo_exit/core_test.exs
+++ b/apps/omg_watcher/test/omg_watcher/utxo_exit/core_test.exs
@@ -80,12 +80,25 @@ defmodule OMG.Watcher.UtxoExit.CoreTest do
                 utxo_pos: ^encode_utxo
               }} = Core.compose_block_standard_exit(block, position)
 
+      # hash byte_size * merkle tree depth
       assert byte_size(proof) == 32 * 16
     end
 
-    test "doesn't find utxo for the output exit, position exceeding the block tx count", %{alice: alice} do
+    test "doesn't find utxo for the output exit, tx position exceeding the block tx count", %{alice: alice} do
       blknum = 4000
       position = Utxo.position(blknum, 1, 0)
+
+      block =
+        [TestHelper.create_recovered([{1_000, 1, 0, alice}], @eth, [{alice, 10}])]
+        |> Block.hashed_txs_at(blknum)
+        |> Block.to_db_value()
+
+      assert {:error, :utxo_not_found} = Core.compose_block_standard_exit(block, position)
+    end
+
+    test "doesn't find utxo for the output exit, output position exceeding the output count", %{alice: alice} do
+      blknum = 4000
+      position = Utxo.position(blknum, 0, 3)
 
       block =
         [TestHelper.create_recovered([{1_000, 1, 0, alice}], @eth, [{alice, 10}])]

--- a/apps/omg_watcher_rpc/priv/swagger/security_critical_api_specs/utxo/response_schemas.yaml
+++ b/apps/omg_watcher_rpc/priv/swagger/security_critical_api_specs/utxo/response_schemas.yaml
@@ -26,6 +26,5 @@ GetUtxoExitResponseSchema:
     example:
       data:
         proof: '0xcedb8b31d1e4...'
-        sigs: '0xcc52d1d9ffe7...'
         txbytes: '0x3eb6ae5b06f3...'
         utxo_pos: 10000000010000000

--- a/apps/omg_watcher_rpc/priv/swagger/security_critical_api_specs/utxo/responses.yaml
+++ b/apps/omg_watcher_rpc/priv/swagger/security_critical_api_specs/utxo/responses.yaml
@@ -6,7 +6,7 @@ GetUtxoChallengeResponse:
         $ref: 'response_schemas.yaml#/GetUtxoChallengeResponseSchema'
 
 GetUtxoExitResponse:
-  description: Utxo challenge successful response
+  description: Utxo exit successful response
   content:
     application/json:
       schema:

--- a/apps/omg_watcher_rpc/test/omg_watcher_rpc/web/controllers/utxo_test.exs
+++ b/apps/omg_watcher_rpc/test/omg_watcher_rpc/web/controllers/utxo_test.exs
@@ -57,14 +57,13 @@ defmodule OMG.WatcherRPC.Web.Controller.UtxoTest do
       {:put, :utxo,
        {{1000, 0, 0},
         %{amount: 100, creating_txhash: OMG.State.Transaction.raw_txhash(tx), currency: @eth, owner: bob.addr}}},
-      {:put, :block, %{number: 1000, hash: 0, transactions: [tx_encode]}}
+      {:put, :block, %{number: 1000, hash: <<>>, transactions: [tx_encode]}}
     ])
 
     %{
       "utxo_pos" => _utxo_pos,
       "txbytes" => _txbytes,
-      "proof" => proof,
-      "sigs" => _sigs
+      "proof" => proof
     } = TestHelper.get_exit_data(1000, 0, 0)
 
     assert <<_proof::bytes-size(512)>> = proof


### PR DESCRIPTION
related to the #855 effort. Driven by results from #998 

## Overview

There has been some dead code in the handling of composing data for standard exits in the Watcher.

Also it has been discovered, that when child chain blocks are larger, requests to the Watcher that ask for standard exit data tend to timeout. `Block.inclusion_proof` has received some no-brainer optimizations to remove the bottleneck.

In case of `Block.inclusion_proof`, for a block of 20K txs, the time to generate the proof dropped from the timeoutable 3.5s to 0.5s. After this optimization, the blocker is now the encoding of `raw_tx`, necessary to hash it. If necessary the further optimization would be to somehow not have to encode, but this is more involved.

## Changes

- removes dead code
- tidies the flows, adds some tests conforming to the new testing standards
- optimizes the use of `Block.inclusion_proof` which (according to `:fprof`) did a lot of unnecessary encoding/decoding what not
- `OMG.DB` can now get UTXOs by utxo_pos

## Testing

`mix test` - logic
`mix test --only wrappers test/omg_db` for the addition to `OMG.DB`
`mix test --only integration test/omg_watcher/integration/block_getter_test.exs:126` all working together