### PR TITLE
integrate with ALD IFE

### DIFF
--- a/apps/omg/lib/omg/ethereum_event_listener.ex
+++ b/apps/omg/lib/omg/ethereum_event_listener.ex
@@ -18,6 +18,7 @@ defmodule OMG.EthereumEventListener do
   """
 
   alias OMG.EthereumEventListener.Core
+  alias OMG.EthereumEventListener.Groomer
   alias OMG.RootChainCoordinator
   alias OMG.RootChainCoordinator.SyncGuide
 
@@ -119,7 +120,12 @@ defmodule OMG.EthereumEventListener do
       |> Core.get_events(sync_height)
 
     :ok = :telemetry.execute([:process, __MODULE__], %{events: events}, core)
-    {:ok, db_updates_from_callback} = callbacks.process_events_callback.(events)
+
+    {:ok, db_updates_from_callback} =
+      events
+      |> Enum.map(&Groomer.apply/1)
+      |> callbacks.process_events_callback.()
+
     :ok = OMG.DB.multi_update(db_updates ++ db_updates_from_callback)
     :ok = RootChainCoordinator.check_in(height_to_check_in, core.service_name)
 

--- a/apps/omg/lib/omg/ethereum_event_listener/groomer.ex
+++ b/apps/omg/lib/omg/ethereum_event_listener/groomer.ex
@@ -1,0 +1,31 @@
+# Copyright 2019 OmiseGO Pte Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defmodule OMG.EthereumEventListener.Groomer do
+  @moduledoc """
+  Handles various business-logic specific processing of ethereum events
+  """
+
+  @doc """
+  Applies the grooming procedure to the event received from `OMG.Eth`
+  """
+  @spec apply(%{required(:event_signature) => binary(), optional(any()) => any()}) :: map()
+  def apply(%{event_signature: "InFlightExitInput" <> _} = raw_event),
+    do: Map.update(raw_event, :omg_data, %{piggyback_type: :input}, &Map.put(&1, :piggyback_type, :input))
+
+  def apply(%{event_signature: "InFlightExitOutput" <> _} = raw_event),
+    do: Map.update(raw_event, :omg_data, %{piggyback_type: :output}, &Map.put(&1, :piggyback_type, :output))
+
+  def apply(%{event_signature: signature} = other_event) when is_binary(signature), do: other_event
+end

--- a/apps/omg/lib/omg/state/core.ex
+++ b/apps/omg/lib/omg/state/core.ex
@@ -18,7 +18,7 @@ defmodule OMG.State.Core do
   All spend transactions, deposits and exits should sync on this for validity of moving funds.
   """
 
-  defstruct [:height, :last_deposit_child_blknum, :utxos, pending_txs: [], tx_index: 0, utxo_db_updates: []]
+  defstruct [:height, :utxos, pending_txs: [], tx_index: 0, utxo_db_updates: []]
 
   alias OMG.Block
   alias OMG.Crypto
@@ -36,7 +36,6 @@ defmodule OMG.State.Core do
 
   @type t() :: %__MODULE__{
           height: non_neg_integer(),
-          last_deposit_child_blknum: non_neg_integer(),
           utxos: utxos,
           pending_txs: list(Transaction.Recovered.t()),
           tx_index: non_neg_integer(),
@@ -85,7 +84,6 @@ defmodule OMG.State.Core do
           {:put, :utxo, {Utxo.Position.db_t(), map()}}
           | {:delete, :utxo, Utxo.Position.db_t()}
           | {:put, :child_top_block_number, pos_integer()}
-          | {:put, :last_deposit_child_blknum, pos_integer()}
           | {:put, :block, Block.db_t()}
 
   @type exitable_utxos :: %{
@@ -103,23 +101,15 @@ defmodule OMG.State.Core do
   @spec extract_initial_state(
           utxos_query_result :: [list({OMG.DB.utxo_pos_db_t(), OMG.Utxo.t()})],
           height_query_result :: non_neg_integer() | :not_found,
-          last_deposit_child_blknum_query_result :: non_neg_integer() | :not_found,
           child_block_interval :: pos_integer()
-        ) :: {:ok, t()} | {:error, :last_deposit_not_found | :top_block_number_not_found}
-  def extract_initial_state(
-        utxos_query_result,
-        height_query_result,
-        last_deposit_child_blknum_query_result,
-        child_block_interval
-      )
-      when is_list(utxos_query_result) and is_integer(height_query_result) and
-             is_integer(last_deposit_child_blknum_query_result) and is_integer(child_block_interval) do
+        ) :: {:ok, t()} | {:error, :top_block_number_not_found}
+  def extract_initial_state(utxos_query_result, height_query_result, child_block_interval)
+      when is_list(utxos_query_result) and is_integer(height_query_result) and is_integer(child_block_interval) do
     # extract height, last deposit height and utxos from query result
     height = height_query_result + child_block_interval
 
     state = %__MODULE__{
       height: height,
-      last_deposit_child_blknum: last_deposit_child_blknum_query_result,
       utxos: UtxoSet.init(utxos_query_result)
     }
 
@@ -128,17 +118,7 @@ defmodule OMG.State.Core do
 
   def extract_initial_state(
         _utxos_query_result,
-        _height_query_result,
         :not_found,
-        _child_block_interval
-      ) do
-    {:error, :last_deposit_not_found}
-  end
-
-  def extract_initial_state(
-        _utxos_query_result,
-        :not_found,
-        _last_deposit_child_blknum_query_result,
         _child_block_interval
       ) do
     {:error, :top_block_number_not_found}
@@ -237,32 +217,18 @@ defmodule OMG.State.Core do
   end
 
   @spec deposit(deposits :: [deposit()], state :: t()) :: {:ok, {[deposit_event], [db_update]}, new_state :: t()}
-  def deposit(deposits, %Core{utxos: utxos, last_deposit_child_blknum: last_deposit_child_blknum} = state) do
-    # FIXME: after the refactor of EthereumEventListener pipes mentioned in root_chain.ex, we need to remove this check
-    #        this check seems like unnecessary defensive coding now - the only-once for deposits processing is now reliant on
-    #        `depositor`'s eth height tracking and atomicity of writes to the db of that marker and the deposit utxos
-    deposits = deposits |> Enum.filter(&(&1.blknum > last_deposit_child_blknum))
-
+  def deposit(deposits, %Core{utxos: utxos} = state) do
     new_utxos_map = deposits |> Enum.into(%{}, &deposit_to_utxo/1)
     new_utxos = UtxoSet.apply_effects(utxos, [], new_utxos_map)
-    db_updates_new_utxos = UtxoSet.db_updates([], new_utxos_map)
+    db_updates = UtxoSet.db_updates([], new_utxos_map)
 
     event_triggers =
       deposits
       |> Enum.map(fn %{owner: owner, amount: amount} -> %{deposit: %{amount: amount, owner: owner}} end)
 
-    last_deposit_child_blknum = get_last_deposit_child_blknum(deposits, last_deposit_child_blknum)
-
-    db_updates = db_updates_new_utxos ++ last_deposit_child_blknum_db_update(deposits, last_deposit_child_blknum)
-
     _ = if deposits != [], do: Logger.info("Recognized deposits #{inspect(deposits)}")
 
-    new_state = %Core{
-      state
-      | utxos: new_utxos,
-        last_deposit_child_blknum: last_deposit_child_blknum
-    }
-
+    new_state = %Core{state | utxos: new_utxos}
     {:ok, {event_triggers, db_updates}, new_state}
   end
 
@@ -407,19 +373,6 @@ defmodule OMG.State.Core do
     |> Enum.map(& &1)
     |> hd()
   end
-
-  defp get_last_deposit_child_blknum([] = _deposits, current_height), do: current_height
-
-  defp get_last_deposit_child_blknum(deposits, _current_height),
-    do:
-      deposits
-      |> Enum.max_by(& &1.blknum)
-      |> Map.get(:blknum)
-
-  defp last_deposit_child_blknum_db_update([] = deposits, _last_deposit_child_blknum), do: deposits
-
-  defp last_deposit_child_blknum_db_update(_deposits, last_deposit_child_blknum),
-    do: [{:put, :last_deposit_child_blknum, last_deposit_child_blknum}]
 
   # if looking for an input of the piggyback, we won't find it like this (by creating tx that is), and we don't care
   defp find_utxo_matching_piggyback(%{omg_data: %{piggyback_type: :input}}, %Core{}),

--- a/apps/omg/lib/omg/state/transaction/payment.ex
+++ b/apps/omg/lib/omg/state/transaction/payment.ex
@@ -64,7 +64,7 @@ defmodule OMG.State.Transaction.Payment do
   ```
   """
   @spec new(
-          list({pos_integer, pos_integer, 0..3}),
+          list({pos_integer, pos_integer, 0..unquote(@max_outputs - 1)}),
           list({Crypto.address_t(), currency(), pos_integer}),
           Transaction.metadata()
         ) :: t()

--- a/apps/omg/test/fixtures.exs
+++ b/apps/omg/test/fixtures.exs
@@ -33,7 +33,7 @@ defmodule OMG.Fixtures do
 
   deffixture state_empty() do
     {:ok, child_block_interval} = OMG.Eth.RootChain.get_child_block_interval()
-    {:ok, state} = Core.extract_initial_state([], 0, 0, child_block_interval)
+    {:ok, state} = Core.extract_initial_state([], 0, child_block_interval)
     state
   end
 

--- a/apps/omg/test/omg/ethereum_event_listener/groomer_test.exs
+++ b/apps/omg/test/omg/ethereum_event_listener/groomer_test.exs
@@ -1,0 +1,58 @@
+# Copyright 2019 OmiseGO Pte Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defmodule OMG.EthereumEventListener.GroomerTest do
+  @moduledoc """
+  Tests whether all known events are groomed accurately
+  """
+
+  use ExUnit.Case, async: true
+
+  alias OMG.EthereumEventListener.Groomer
+
+  describe "apply/1" do
+    test "injects input/output information into piggyback-related events" do
+      assert %{omg_data: %{piggyback_type: :input}} =
+               Groomer.apply(%{event_signature: "InFlightExitInputPiggybacked(address,bytes32,uint16)"})
+
+      assert %{omg_data: %{piggyback_type: :input}} =
+               Groomer.apply(%{event_signature: "InFlightExitInputBlocked(address,bytes32,uint16)"})
+
+      assert %{omg_data: %{piggyback_type: :input}} =
+               Groomer.apply(%{event_signature: "InFlightExitInputWithdrawn(uint160,uint16)"})
+
+      assert %{omg_data: %{piggyback_type: :output}} =
+               Groomer.apply(%{event_signature: "InFlightExitOutputPiggybacked(address,bytes32,uint16)"})
+
+      assert %{omg_data: %{piggyback_type: :output}} =
+               Groomer.apply(%{event_signature: "InFlightExitOutputBlocked(address,bytes32,uint16)"})
+
+      assert %{omg_data: %{piggyback_type: :output}} =
+               Groomer.apply(%{event_signature: "InFlightExitOutputWithdrawn(uint160,uint16)"})
+    end
+  end
+
+  test "preserves existing event data" do
+    event = %{event_signature: "InFlightExitInputPiggybacked(address,bytes32,uint16)", other_stuff: ""}
+
+    assert %{event_signature: "InFlightExitInputPiggybacked(address,bytes32,uint16)", other_stuff: ""} =
+             Groomer.apply(event)
+  end
+
+  test "by default does nothing, if only the signature is defined (it must be)" do
+    event = %{event_signature: "NoSuchEvent()"}
+    assert ^event = Groomer.apply(event)
+    assert_raise FunctionClauseError, fn -> Groomer.apply({%{}}) end
+  end
+end

--- a/apps/omg/test/omg/state/core_test.exs
+++ b/apps/omg/test/omg/state/core_test.exs
@@ -601,7 +601,11 @@ defmodule OMG.State.CoreTest do
              |> Enum.map(&Utxo.Position.encode/1)
              |> Core.exit_utxos(state)
 
-    piggybacks = [%{tx_hash: tx_hash, output_index: 4}, %{tx_hash: tx_hash, output_index: 5}]
+    piggybacks = [
+      %{tx_hash: tx_hash, output_index: 0, omg_data: %{piggyback_type: :output}},
+      %{tx_hash: tx_hash, output_index: 1, omg_data: %{piggyback_type: :output}}
+    ]
+
     assert exit_utxos_response_reference == Core.exit_utxos(piggybacks, state)
   end
 
@@ -642,7 +646,11 @@ defmodule OMG.State.CoreTest do
     state = state |> Core.exec(tx, :no_fees_required) |> success?
 
     utxo_pos_exits_in_flight = [%{call_data: %{in_flight_tx: Transaction.raw_txbytes(tx)}}]
-    utxo_pos_exits_piggyback = [%{tx_hash: Transaction.raw_txhash(tx), output_index: 4}]
+
+    utxo_pos_exits_piggyback = [
+      %{tx_hash: Transaction.raw_txhash(tx), output_index: 0, omg_data: %{piggyback_type: :output}}
+    ]
+
     expected_position = Utxo.position(@blknum1, 0, 0)
 
     assert {:ok, {[], {[], _}}, ^state} = Core.exit_utxos(utxo_pos_exits_in_flight, state)
@@ -691,7 +699,7 @@ defmodule OMG.State.CoreTest do
 
   @tag fixtures: [:state_empty]
   test "notifies about invalid in-flight exit", %{state_empty: state} do
-    piggyback = %{tx_hash: 1, output_index: 5}
+    piggyback = %{tx_hash: 1, output_index: 1, omg_data: %{piggyback_type: :output}}
 
     assert {:ok, {[], {[], [^piggyback]}}, ^state} = Core.exit_utxos([piggyback], state)
   end

--- a/apps/omg/test/omg/state/persistence_test.exs
+++ b/apps/omg/test/omg/state/persistence_test.exs
@@ -164,11 +164,9 @@ defmodule OMG.State.PersistenceTest do
   # mimics `&OMG.State.init/1`
   defp state_from(db_pid) do
     {:ok, height_query_result} = OMG.DB.get_single_value(:child_top_block_number, db_pid)
-    {:ok, last_deposit_query_result} = OMG.DB.get_single_value(:last_deposit_child_blknum, db_pid)
     {:ok, utxos_query_result} = OMG.DB.utxos(db_pid)
 
-    {:ok, state} =
-      Core.extract_initial_state(utxos_query_result, height_query_result, last_deposit_query_result, @interval)
+    {:ok, state} = Core.extract_initial_state(utxos_query_result, height_query_result, @interval)
 
     state
   end

--- a/apps/omg/test/omg/state/persistence_test.exs
+++ b/apps/omg/test/omg/state/persistence_test.exs
@@ -106,7 +106,10 @@ defmodule OMG.State.PersistenceTest do
     tx = create_recovered([{1, 0, 0, alice}], @eth, [{alice, 7}, {alice, 3}])
 
     utxo_pos_exits_in_flight = [%{call_data: %{in_flight_tx: Transaction.raw_txbytes(tx)}}]
-    utxo_pos_exits_piggyback = [%{tx_hash: Transaction.raw_txhash(tx), output_index: 4}]
+
+    utxo_pos_exits_piggyback = [
+      %{tx_hash: Transaction.raw_txhash(tx), output_index: 0, omg_data: %{piggyback_type: :output}}
+    ]
 
     state
     |> persist_deposit([%{owner: alice.addr, currency: @eth, amount: 20, blknum: 1}], db_pid)

--- a/apps/omg_child_chain/test/omg_child_chain/integration/happy_path_test.exs
+++ b/apps/omg_child_chain/test/omg_child_chain/integration/happy_path_test.exs
@@ -188,7 +188,7 @@ defmodule OMG.ChildChain.Integration.HappyPathTest do
 
     # piggyback only to the first transaction's output & wait for finalization
     {:ok, %{"status" => "0x1", "blockNumber" => eth_height}} =
-      Eth.RootChainHelper.piggyback_in_flight_exit(in_flight_tx2_rawbytes, 4, alice.addr)
+      Eth.RootChainHelper.piggyback_in_flight_exit_on_output(in_flight_tx2_rawbytes, 0, alice.addr)
       |> Eth.DevHelpers.transact_sync!()
 
     Eth.DevHelpers.wait_for_root_chain_block(eth_height + exiters_finality_margin)

--- a/apps/omg_db/lib/db.ex
+++ b/apps/omg_db/lib/db.ex
@@ -37,7 +37,6 @@ defmodule OMG.DB do
   @callback exit_info({pos_integer, non_neg_integer, non_neg_integer}) :: {:ok, map} | {:error, atom}
   @callback spent_blknum(utxo_pos_db_t()) :: {:ok, pos_integer} | {:error, atom}
   @callback block_hashes(integer()) :: list()
-  @callback last_deposit_child_blknum() :: list()
   @callback child_top_block_number() :: {:ok, non_neg_integer()}
 
   # callbacks useful for injecting a specific server implementation
@@ -53,7 +52,6 @@ defmodule OMG.DB do
               {:ok, map} | {:error, atom}
   @callback spent_blknum(utxo_pos_db_t(), GenServer.server()) :: {:ok, pos_integer} | {:error, atom}
   @callback block_hashes(integer(), GenServer.server()) :: list()
-  @callback last_deposit_child_blknum(GenServer.server()) :: list()
   @callback child_top_block_number(GenServer.server()) :: {:ok, non_neg_integer()}
   @optional_callbacks child_spec: 1,
                       initiation_multiupdate: 1,
@@ -67,7 +65,6 @@ defmodule OMG.DB do
                       exit_info: 2,
                       spent_blknum: 2,
                       block_hashes: 2,
-                      last_deposit_child_blknum: 1,
                       child_top_block_number: 1
 
   def start_link(args), do: driver().start_link(args)
@@ -120,8 +117,6 @@ defmodule OMG.DB do
   def block_hashes(block_numbers_to_fetch), do: driver().block_hashes(block_numbers_to_fetch)
   def block_hashes(block_numbers_to_fetch, server), do: driver().block_hashes(block_numbers_to_fetch, server)
 
-  def last_deposit_child_blknum, do: driver().last_deposit_child_blknum()
-
   def child_top_block_number, do: driver().child_top_block_number
 
   def get_single_value(parameter_name), do: driver().get_single_value(parameter_name)
@@ -134,8 +129,6 @@ defmodule OMG.DB do
     [
       # child chain - used at block forming
       :child_top_block_number,
-      # watcher and child chain
-      :last_deposit_child_blknum,
       # watcher
       :last_block_getter_eth_height,
       # watcher and child chain

--- a/apps/omg_db/lib/omg_db/rocks_db.ex
+++ b/apps/omg_db/lib/omg_db/rocks_db.ex
@@ -106,10 +106,6 @@ if Code.ensure_loaded?(:rocksdb) do
       GenServer.call(server_name, {:block_hashes, block_numbers_to_fetch})
     end
 
-    def last_deposit_child_blknum(server_name \\ @server_name) do
-      GenServer.call(server_name, :last_deposit_child_blknum)
-    end
-
     def child_top_block_number(server_name \\ @server_name) do
       GenServer.call(server_name, :child_top_block_number)
     end

--- a/apps/omg_eth/lib/eth.ex
+++ b/apps/omg_eth/lib/eth.ex
@@ -186,7 +186,7 @@ defmodule OMG.Eth do
           topics: ["#{topic}"]
         })
 
-      {:ok, filter_not_removed(logs)}
+      {:ok, logs |> filter_not_removed() |> put_signature(signature)}
     catch
       _ -> {:error, :failed_to_get_ethereum_events}
     end
@@ -296,19 +296,18 @@ defmodule OMG.Eth do
     tuple_arg_names |> Enum.zip(tuple_args) |> Map.new()
   end
 
-  defp common_parse_event(result, %{
-         "blockNumber" => eth_height,
-         "transactionHash" => root_chain_txhash,
-         "logIndex" => log_index
-       }) do
-    Map.merge(
-      result,
-      %{
-        eth_height: int_from_hex(eth_height),
-        root_chain_txhash: from_hex(root_chain_txhash),
-        log_index: int_from_hex(log_index)
-      }
-    )
+  # here we merge the result of event parsing so far (holding the fields)
+  defp common_parse_event(
+         result,
+         %{"blockNumber" => eth_height, "transactionHash" => root_chain_txhash, "logIndex" => log_index} = event
+       ) do
+    # NOTE: we're using `put_new` here, because `merge` would allow us to overwrite data fields in case of conflict
+    result
+    |> Map.put_new(:eth_height, int_from_hex(eth_height))
+    |> Map.put_new(:root_chain_txhash, from_hex(root_chain_txhash))
+    |> Map.put_new(:log_index, int_from_hex(log_index))
+    # just copy `event_signature` over, if it's present (could use tidying up)
+    |> Map.put_new(:event_signature, event[:event_signature])
   end
 
   defp get_signer_passphrase("0x00a329c0648769a73afac7f9381e08fb43dbea72") do
@@ -326,4 +325,6 @@ defmodule OMG.Eth do
         {:ok, value}
     end
   end
+
+  defp put_signature(events, signature), do: Enum.map(events, &Map.put(&1, :event_signature, signature))
 end

--- a/apps/omg_eth/lib/eth.ex
+++ b/apps/omg_eth/lib/eth.ex
@@ -271,6 +271,24 @@ defmodule OMG.Eth do
     if unpack_tuple_args, do: parse_tuple_args(call_data_raw, unpack_tuple_args), else: call_data_raw
   end
 
+  @doc """
+  Enrichs the decoded log data from the Eth node, by getting the respective transaction's function call to the contract
+  and dissecting it using the name, args and argument types as specified. The call data is put under `:call_data`.
+
+  Passes on the optional arguments into `Eth.get_call_data`
+  """
+  @spec log_with_call_data(
+          %{required(:root_chain_txhash) => binary, optional(atom) => any},
+          binary,
+          list(atom),
+          list(binary),
+          keyword()
+        ) :: map()
+  def log_with_call_data(log, function_name, args, types, opts \\ []) do
+    call_data = get_call_data(log.root_chain_txhash, function_name, args, types, opts)
+    Map.put(log, :call_data, call_data)
+  end
+
   # interprets an argument called `args` in the call_data (arguments) and reinterprets the arguments according to names
   # given
   defp parse_tuple_args(call_data, tuple_arg_names) do

--- a/apps/omg_eth/lib/omg_eth/root_chain.ex
+++ b/apps/omg_eth/lib/omg_eth/root_chain.ex
@@ -104,17 +104,23 @@ defmodule OMG.Eth.RootChain do
 
     # solidity does not return arrays of structs
     return_struct = [
+      :bool,
+      {:uint, 64},
       {:uint, 256},
       {:uint, 256},
-      {:uint, 256},
+      # NOTE: there are these two more fields in the return but they can be ommitted???
+      # withdraw_data_struct,
+      # withdraw_data_struct,
       :address,
+      {:uint, 256},
       {:uint, 256}
     ]
 
     Eth.call_contract(contract, "inFlightExits(uint160)", [in_flight_exit_id], return_struct)
   end
 
-  # TODO: we're storing exit_ids for SEs, we should do the same for IFEs and remove this
+  # TODO: we're storing exit_ids for SEs, we should do the same for IFEs and remove this (requires exit_id to be
+  #       emitted from the start IFE event
   def get_in_flight_exit_id(tx_bytes, contract \\ %{}) do
     contract = maybe_fetch_addr!(contract, :payment_exit_game)
     Eth.call_contract(contract, "getInFlightExitId(bytes)", [tx_bytes], [{:uint, 160}])

--- a/apps/omg_eth/lib/omg_eth/root_chain.ex
+++ b/apps/omg_eth/lib/omg_eth/root_chain.ex
@@ -362,12 +362,13 @@ defmodule OMG.Eth.RootChain do
 
     case Eth.get_ethereum_events(block_from, block_to, signature, contract) do
       {:ok, logs} ->
+        args = [:args]
+        types = ["(uint192,bytes,bytes,bytes)"]
+        tuple_arg_names = [:utxo_pos, :output_tx, :output_guard_preimage, :output_tx_inclusion_proof]
+
         exits =
           Enum.map(logs, fn log ->
             decode_exit_started = decode_exit_started(log)
-            args = [:args]
-            types = ["(uint192,bytes,bytes,bytes)"]
-            tuple_arg_names = [:utxo_pos, :output_tx, :output_guard_preimage, :output_tx_inclusion_proof]
 
             call_data =
               Eth.get_call_data(decode_exit_started.root_chain_txhash, "startStandardExit", args, types,
@@ -392,16 +393,33 @@ defmodule OMG.Eth.RootChain do
     signature = "InFlightExitStarted(address,bytes32)"
 
     case Eth.get_ethereum_events(block_from, block_to, signature, contract) do
+      # FIXME: split into functions, here and elsewhere
       {:ok, logs} ->
-        args = [:in_flight_tx, :inputs_txs, :input_inclusion_proofs, :in_flight_tx_sigs]
-        types = ["bytes", "bytes", "bytes", "bytes"]
+        args = [:args]
+        types = ["(bytes,bytes[],uint256[],uint256[],bytes[],bytes[],bytes[],bytes[],bytes[])"]
+
+        tuple_arg_names = [
+          :in_flight_tx,
+          :inputs_txs,
+          :input_tx_types,
+          :input_utxos_pos,
+          :output_guard_preimages_for_inputs,
+          :input_inclusion_proofs,
+          :in_flight_tx_confirm_sigs,
+          :in_flight_tx_sigs,
+          :optional_args
+        ]
 
         result =
           Enum.map(logs, fn log ->
-            transaction_hash = from_hex(log["transactionHash"])
-            start_in_flight_exit = Eth.get_call_data(transaction_hash, "startInFlightExit", args, types)
             decode_in_flight_exit = decode_in_flight_exit(log)
-            Map.put(decode_in_flight_exit, :call_data, start_in_flight_exit)
+
+            call_data =
+              Eth.get_call_data(decode_in_flight_exit.root_chain_txhash, "startInFlightExit", args, types,
+                unpack_tuple_args: tuple_arg_names
+              )
+
+            Map.put(decode_in_flight_exit, :call_data, call_data)
           end)
 
         {:ok, result}

--- a/apps/omg_eth/lib/omg_eth/root_chain.ex
+++ b/apps/omg_eth/lib/omg_eth/root_chain.ex
@@ -206,9 +206,11 @@ defmodule OMG.Eth.RootChain do
     case Eth.get_ethereum_events(block_from, block_to, signature, contract) do
       {:ok, logs} ->
         args = [:args]
-        types = ["(bytes,uint16,bytes,uint16,bytes,uint256,bytes,bytes,bytes,bytes)"]
+        types = ["(bytes,uint256,bytes,uint16,bytes,uint16,bytes,uint256,bytes,bytes,bytes,bytes)"]
 
         tuple_arg_names = [
+          :input_tx_bytes,
+          :input_utxo_pos,
           :in_flight_tx,
           :in_flight_input_index,
           :competing_tx,

--- a/apps/omg_eth/lib/omg_eth/root_chain.ex
+++ b/apps/omg_eth/lib/omg_eth/root_chain.ex
@@ -406,7 +406,7 @@ defmodule OMG.Eth.RootChain do
 
         tuple_arg_names = [
           :in_flight_tx,
-          :inputs_txs,
+          :input_txs,
           :input_tx_types,
           :input_utxos_pos,
           :output_guard_preimages_for_inputs,

--- a/apps/omg_eth/lib/omg_eth/root_chain.ex
+++ b/apps/omg_eth/lib/omg_eth/root_chain.ex
@@ -22,8 +22,6 @@ defmodule OMG.Eth.RootChain do
   alias OMG.Eth
   import OMG.Eth.Encoding, only: [to_hex: 1, from_hex: 1, int_from_hex: 1]
 
-  @deposit_created_event_signature "DepositCreated(address,uint256,address,uint256)"
-
   @type optional_addr_t() :: %{atom => Eth.address()} | %{atom => nil}
   # FIXME, revert and refresh, after the EEL pipes are fixed
   @type in_flight_exit_piggybacked_event() :: %{
@@ -143,10 +141,12 @@ defmodule OMG.Eth.RootChain do
     contract_eth = maybe_fetch_addr!(contract, :eth_vault)
     contract_erc20 = maybe_fetch_addr!(contract, :erc20_vault)
 
+    event_signature = "DepositCreated(address,uint256,address,uint256)"
+
     with {:ok, logs_eth} <-
-           Eth.get_ethereum_events(block_from, block_to, @deposit_created_event_signature, contract_eth),
+           Eth.get_ethereum_events(block_from, block_to, event_signature, contract_eth),
          {:ok, logs_erc20} <-
-           Eth.get_ethereum_events(block_from, block_to, @deposit_created_event_signature, contract_erc20),
+           Eth.get_ethereum_events(block_from, block_to, event_signature, contract_erc20),
          all_sorted_logs =
            [logs_eth, logs_erc20]
            |> Enum.concat()

--- a/apps/omg_eth/test/support/root_chain_helper.ex
+++ b/apps/omg_eth/test/support/root_chain_helper.ex
@@ -274,14 +274,14 @@ defmodule OMG.Eth.RootChainHelper do
     opts = defaults |> Keyword.merge(opts)
 
     contract = RootChain.maybe_fetch_addr!(contract, :payment_exit_game)
-    signature = "challengeInFlightExitInputSpent(bytes,uint8,bytes,uint8,bytes)"
+    signature = "challengeInFlightExitInputSpent((bytes,uint16,bytes,uint16,bytes,bytes))"
+
+    # NOTE: hardcoded for now, we're speaking to a particular exit game so this is fixed
+    optional_bytes = ""
 
     args = [
-      in_flight_txbytes,
-      in_flight_input_index,
-      spending_txbytes,
-      spending_tx_input_index,
-      spending_tx_sig
+      {in_flight_txbytes, in_flight_input_index, spending_txbytes, spending_tx_input_index, spending_tx_sig,
+       optional_bytes}
     ]
 
     Eth.contract_transact(from, contract, signature, args, opts)
@@ -303,15 +303,14 @@ defmodule OMG.Eth.RootChainHelper do
     opts = defaults |> Keyword.merge(opts)
 
     contract = RootChain.maybe_fetch_addr!(contract, :payment_exit_game)
-    signature = "challengeInFlightExitOutputSpent(bytes,uint256,bytes,bytes,uint8,bytes)"
+    signature = "challengeInFlightExitOutputSpent((bytes,bytes,uint256,bytes,uint16,bytes,bytes))"
+
+    # NOTE: hardcoded for now, we're speaking to a particular exit game so this is fixed
+    optional_bytes = ""
 
     args = [
-      in_flight_txbytes,
-      in_flight_output_pos,
-      in_flight_tx_inclusion_proof,
-      spending_txbytes,
-      spending_tx_input_index,
-      spending_tx_sig
+      {in_flight_txbytes, in_flight_tx_inclusion_proof, in_flight_output_pos, spending_txbytes, spending_tx_input_index,
+       spending_tx_sig, optional_bytes}
     ]
 
     Eth.contract_transact(from, contract, signature, args, opts)

--- a/apps/omg_eth/test/support/root_chain_helper.ex
+++ b/apps/omg_eth/test/support/root_chain_helper.ex
@@ -225,16 +225,17 @@ defmodule OMG.Eth.RootChainHelper do
     opts = defaults |> Keyword.merge(opts)
 
     contract = RootChain.maybe_fetch_addr!(contract, :payment_exit_game)
-    signature = "challengeInFlightExitNotCanonical(bytes,uint8,bytes,uint8,uint256,bytes,bytes)"
+
+    signature =
+      "challengeInFlightExitNotCanonical((bytes,uint16,bytes,uint16,bytes,uint256,bytes,bytes,bytes,bytes))"
+
+    # NOTE: hardcoded for now, we're speaking to a particular exit game so this is fixed
+    optional_bytes = ""
 
     args = [
-      in_flight_txbytes,
-      in_flight_input_index,
-      competing_txbytes,
-      competing_input_index,
-      competing_tx_pos,
-      competing_proof,
-      competing_sig
+      {in_flight_txbytes, in_flight_input_index, competing_txbytes,
+       competing_input_index, optional_bytes, competing_tx_pos, competing_proof, competing_sig, optional_bytes,
+       optional_bytes}
     ]
 
     Eth.contract_transact(from, contract, signature, args, opts)

--- a/apps/omg_eth/test/support/root_chain_helper.ex
+++ b/apps/omg_eth/test/support/root_chain_helper.ex
@@ -37,12 +37,14 @@ defmodule OMG.Eth.RootChainHelper do
   @gas_deposit 180_000
   @gas_deposit_from 250_000
   @gas_init 1_000_000
-  @standard_exit_bond 14_000_000_000_000_000
-  @piggyback_bond 31_415_926_535
-  @gas_respond_to_non_canonical_challenge 1_000_000
-
   @gas_start_in_flight_exit 2_000_000
+  @gas_respond_to_non_canonical_challenge 1_000_000
   @gas_challenge_in_flight_exit_not_canonical 1_000_000
+
+  @standard_exit_bond 14_000_000_000_000_000
+  @ife_bond 37_000_000_000_000_000
+  @piggyback_bond 28_000_000_000_000_000
+
   @type in_flight_exit_piggybacked_event() :: %{owner: <<_::160>>, tx_hash: <<_::256>>, output_index: non_neg_integer}
 
   def start_exit(utxo_pos, tx_bytes, proof, from, contract \\ %{}, opts \\ []) do
@@ -148,6 +150,7 @@ defmodule OMG.Eth.RootChainHelper do
   def in_flight_exit(
         in_flight_tx,
         input_txs,
+        input_utxos_pos,
         input_txs_inclusion_proofs,
         in_flight_tx_sigs,
         from,
@@ -156,14 +159,37 @@ defmodule OMG.Eth.RootChainHelper do
       ) do
     defaults =
       @tx_defaults
-      |> Keyword.put(:value, @standard_exit_bond)
+      |> Keyword.put(:value, @ife_bond)
       |> Keyword.put(:gas, @gas_start_in_flight_exit)
 
     opts = defaults |> Keyword.merge(opts)
+    # FIXME don't miss removing this
+    # struct StartExitArgs {
+    #     bytes inFlightTx;
+    #     bytes[] inputTxs;
+    #     uint256[] inputTxTypes;
+    #     uint256[] inputUtxosPos;
+    #     bytes[] outputGuardPreimagesForInputs;
+    #     bytes[] inputTxsInclusionProofs;
+    #     bytes[] inputTxsConfirmSigs;
+    #     bytes[] inFlightTxWitnesses;
+    #     bytes[] inputSpendingConditionOptionalArgs;
+    # }
+
+    # NOTE: hardcoded for now, we're speaking to a particular exit game so this is fixed
+    optional_bytes_array = List.duplicate("", Enum.count(input_txs))
+    # NOTE: this in particular will go away, since separate specification of input tx types isn't necessary
+    # c.f.: https://github.com/omisego/plasma-contracts/issues/338
+    input_tx_types = List.duplicate(1, Enum.count(input_txs))
 
     contract = RootChain.maybe_fetch_addr!(contract, :payment_exit_game)
-    signature = "startInFlightExit(bytes,bytes,bytes,bytes)"
-    args = [in_flight_tx, input_txs, input_txs_inclusion_proofs, in_flight_tx_sigs]
+    signature = "startInFlightExit((bytes,bytes[],uint256[],uint256[],bytes[],bytes[],bytes[],bytes[],bytes[]))"
+
+    args = [
+      {in_flight_tx, input_txs, input_tx_types, input_utxos_pos, optional_bytes_array, input_txs_inclusion_proofs,
+       optional_bytes_array, in_flight_tx_sigs, optional_bytes_array}
+    ]
+
     Eth.contract_transact(from, contract, signature, args, opts)
   end
 

--- a/apps/omg_eth/test/support/root_chain_helper.ex
+++ b/apps/omg_eth/test/support/root_chain_helper.ex
@@ -210,6 +210,8 @@ defmodule OMG.Eth.RootChainHelper do
 
   # credo:disable-for-next-line Credo.Check.Refactor.FunctionArity
   def challenge_in_flight_exit_not_canonical(
+        input_tx_bytes,
+        input_utxo_pos,
         in_flight_txbytes,
         in_flight_input_index,
         competing_txbytes,
@@ -227,13 +229,13 @@ defmodule OMG.Eth.RootChainHelper do
     contract = RootChain.maybe_fetch_addr!(contract, :payment_exit_game)
 
     signature =
-      "challengeInFlightExitNotCanonical((bytes,uint16,bytes,uint16,bytes,uint256,bytes,bytes,bytes,bytes))"
+      "challengeInFlightExitNotCanonical((bytes,uint256,bytes,uint16,bytes,uint16,bytes,uint256,bytes,bytes,bytes,bytes))"
 
     # NOTE: hardcoded for now, we're speaking to a particular exit game so this is fixed
     optional_bytes = ""
 
     args = [
-      {in_flight_txbytes, in_flight_input_index, competing_txbytes,
+      {input_tx_bytes, input_utxo_pos, in_flight_txbytes, in_flight_input_index, competing_txbytes,
        competing_input_index, optional_bytes, competing_tx_pos, competing_proof, competing_sig, optional_bytes,
        optional_bytes}
     ]

--- a/apps/omg_eth/test/support/root_chain_helper.ex
+++ b/apps/omg_eth/test/support/root_chain_helper.ex
@@ -266,6 +266,8 @@ defmodule OMG.Eth.RootChainHelper do
         spending_txbytes,
         spending_tx_input_index,
         spending_tx_sig,
+        input_txbytes,
+        input_utxo_pos,
         from,
         contract \\ %{},
         opts \\ []
@@ -274,14 +276,14 @@ defmodule OMG.Eth.RootChainHelper do
     opts = defaults |> Keyword.merge(opts)
 
     contract = RootChain.maybe_fetch_addr!(contract, :payment_exit_game)
-    signature = "challengeInFlightExitInputSpent((bytes,uint16,bytes,uint16,bytes,bytes))"
+    signature = "challengeInFlightExitInputSpent((bytes,uint16,bytes,uint16,bytes,bytes,uint256,bytes))"
 
     # NOTE: hardcoded for now, we're speaking to a particular exit game so this is fixed
     optional_bytes = ""
 
     args = [
       {in_flight_txbytes, in_flight_input_index, spending_txbytes, spending_tx_input_index, spending_tx_sig,
-       optional_bytes}
+       input_txbytes, input_utxo_pos, optional_bytes}
     ]
 
     Eth.contract_transact(from, contract, signature, args, opts)

--- a/apps/omg_eth/test/support/root_chain_helper.ex
+++ b/apps/omg_eth/test/support/root_chain_helper.ex
@@ -163,18 +163,6 @@ defmodule OMG.Eth.RootChainHelper do
       |> Keyword.put(:gas, @gas_start_in_flight_exit)
 
     opts = defaults |> Keyword.merge(opts)
-    # FIXME don't miss removing this
-    # struct StartExitArgs {
-    #     bytes inFlightTx;
-    #     bytes[] inputTxs;
-    #     uint256[] inputTxTypes;
-    #     uint256[] inputUtxosPos;
-    #     bytes[] outputGuardPreimagesForInputs;
-    #     bytes[] inputTxsInclusionProofs;
-    #     bytes[] inputTxsConfirmSigs;
-    #     bytes[] inFlightTxWitnesses;
-    #     bytes[] inputSpendingConditionOptionalArgs;
-    # }
 
     # NOTE: hardcoded for now, we're speaking to a particular exit game so this is fixed
     optional_bytes_array = List.duplicate("", Enum.count(input_txs))

--- a/apps/omg_utils/test/omg_utils/http_rpc/encoding_test.exs
+++ b/apps/omg_utils/test/omg_utils/http_rpc/encoding_test.exs
@@ -1,0 +1,32 @@
+# Copyright 2019 OmiseGO Pte Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defmodule OMG.Utils.HttpRPC.EncodingTest do
+  use ExUnit.Case, async: true
+
+  alias OMG.Utils.HttpRPC.Encoding
+
+  test "decodes all up/down/mixed case values" do
+    assert [{:ok, <<222, 173, 190, 239>>}, {:ok, <<222, 173, 190, 239>>}, {:ok, <<222, 173, 190, 239>>}] ==
+             Enum.map(["0xdeadbeef", "0xDEADBEEF", "0xDeadBeeF"], &Encoding.from_hex/1)
+  end
+
+  test "doesn't decode invalid hex" do
+    assert {:error, :invalid_hex} == Encoding.from_hex("deadbeef")
+  end
+
+  test "encodes stuff" do
+    assert "0xdeadbeef" == Encoding.to_hex(<<222, 173, 190, 239>>)
+  end
+end

--- a/apps/omg_utils/test/omg_utils/http_rpc/response_test.exs
+++ b/apps/omg_utils/test/omg_utils/http_rpc/response_test.exs
@@ -15,10 +15,8 @@
 defmodule OMG.Utils.HttpRPC.ResponseTest do
   use ExUnit.Case, async: true
 
-  alias OMG.Utils.HttpRPC.Encoding
   alias OMG.Utils.HttpRPC.Response
   alias OMG.Watcher.DB
-  alias OMG.Watcher.TestHelper
 
   @cleaned_tx %{
     blknum: nil,
@@ -157,49 +155,6 @@ defmodule OMG.Utils.HttpRPC.ResponseTest do
 
     # meta-key is removed from sanitized response
     assert response |> Map.get(:skip_hex_encode) |> is_nil()
-  end
-
-  test "decode16: decodes only specified fields" do
-    expected_map = %{"key_1" => "value_1", "key_2" => "value_2", "key_3" => "value_3"}
-
-    encoded_map = expected_map |> Response.sanitize()
-    decoded_map = TestHelper.decode16(encoded_map, ["key_2"])
-
-    assert decoded_map["key_1"] == expected_map["key_1"] |> Encoding.to_hex()
-    assert decoded_map["key_2"] == expected_map["key_2"]
-    assert decoded_map["key_3"] == expected_map["key_3"] |> Encoding.to_hex()
-  end
-
-  test "decode16: called with empty map returns empty map" do
-    assert %{} == TestHelper.decode16(%{}, ["key_2"])
-    assert %{} == TestHelper.decode16(%{}, [])
-  end
-
-  test "decode16: decodes all up/down/mixed case values" do
-    assert %{
-             "key_1" => <<222, 173, 190, 239>>,
-             "key_2" => <<222, 173, 190, 239>>,
-             "key_3" => <<222, 173, 190, 239>>
-           } ==
-             TestHelper.decode16(
-               %{
-                 "key_1" => "0xdeadbeef",
-                 "key_2" => "0xDEADBEEF",
-                 "key_3" => "0xDeadBeeF"
-               },
-               ["key_1", "key_2", "key_3"]
-             )
-  end
-
-  test "decode16: is safe and don't process not hex-encoded values" do
-    expected = %{
-      "not_bin1" => 0,
-      "not_bin2" => :atom,
-      "not_hex" => "string",
-      "not_value" => nil
-    }
-
-    assert expected == TestHelper.decode16(expected, ["not_bin1", "not_bin2", "not_hex", "not_value", "not_exists"])
   end
 
   defp unload_ecto do

--- a/apps/omg_watcher/lib/omg_watcher/api/in_flight_exit.ex
+++ b/apps/omg_watcher/lib/omg_watcher/api/in_flight_exit.ex
@@ -34,7 +34,6 @@ defmodule OMG.Watcher.API.InFlightExit do
   @doc """
   Returns arguments for plasma contract function that starts in-flight exit for a given transaction.
   """
-  # FIXME: don't forget to update the swagger docs
   @spec get_in_flight_exit(binary) :: {:ok, in_flight_exit()} | {:error, atom}
   def get_in_flight_exit(txbytes) do
     with {:ok, tx} <- Transaction.Signed.decode(txbytes),

--- a/apps/omg_watcher/lib/omg_watcher/api/in_flight_exit.ex
+++ b/apps/omg_watcher/lib/omg_watcher/api/in_flight_exit.ex
@@ -24,9 +24,6 @@ defmodule OMG.Watcher.API.InFlightExit do
 
   require Utxo
 
-  # FIXME: why are zero-signatures still popping up, clean this up
-  @zero_sig <<0::size(65)-unit(8)>>
-
   @type in_flight_exit() :: %{
           in_flight_tx: binary(),
           input_txs: list(binary()),
@@ -43,7 +40,6 @@ defmodule OMG.Watcher.API.InFlightExit do
     with {:ok, tx} <- Transaction.Signed.decode(txbytes),
          {:ok, {proofs, input_txs, input_utxos_pos}} <- find_input_data(tx) do
       %Transaction.Signed{sigs: sigs} = tx
-      non_zero_sigs = Enum.filter(sigs, &(&1 != @zero_sig))
 
       {:ok,
        %{
@@ -51,7 +47,7 @@ defmodule OMG.Watcher.API.InFlightExit do
          input_txs: input_txs,
          input_utxos_pos: input_utxos_pos,
          input_txs_inclusion_proofs: proofs,
-         in_flight_tx_sigs: non_zero_sigs
+         in_flight_tx_sigs: sigs
        }}
     end
   end

--- a/apps/omg_watcher/lib/omg_watcher/exit_processor.ex
+++ b/apps/omg_watcher/lib/omg_watcher/exit_processor.ex
@@ -249,16 +249,13 @@ defmodule OMG.Watcher.ExitProcessor do
         fn %{call_data: %{in_flight_tx: bytes}} ->
           {:ok, contract_ife_id} = Eth.RootChain.get_in_flight_exit_id(bytes)
           {:ok, status} = Eth.RootChain.get_in_flight_exit(contract_ife_id)
-          {raw_contract_ife_status_to_timestamp(status), contract_ife_id}
+          {status, contract_ife_id}
         end
       )
 
     {new_state, db_updates} = Core.new_in_flight_exits(state, events, ife_contract_statuses)
     {:reply, {:ok, db_updates}, new_state}
   end
-
-  # FIXME: move
-  defp raw_contract_ife_status_to_timestamp({_, timestamp, _, _, _, _, _}), do: timestamp
 
   def handle_call({:finalize_exits, exits}, _from, state) do
     _ = if not Enum.empty?(exits), do: Logger.info("Recognized finalizations: #{inspect(exits)}")

--- a/apps/omg_watcher/lib/omg_watcher/exit_processor.ex
+++ b/apps/omg_watcher/lib/omg_watcher/exit_processor.ex
@@ -306,15 +306,19 @@ defmodule OMG.Watcher.ExitProcessor do
   def handle_call({:finalize_in_flight_exits, finalizations}, _from, state) do
     _ = if not Enum.empty?(finalizations), do: Logger.info("Recognized ife finalizations: #{inspect(finalizations)}")
 
-    {:ok, exits} = Core.prepare_utxo_exits_for_in_flight_exit_finalizations(state, finalizations)
+    # necessary, so that the processor knows the current state of inclusion of exiting IFE txs
+    state2 = update_with_ife_txs_from_blocks(state)
+
+    {:ok, exiting_positions} = Core.prepare_utxo_exits_for_in_flight_exit_finalizations(state2, finalizations)
 
     # NOTE: it's not straightforward to track from utxo position returned when exiting utxo in State to ife id
     # See issue #671 https://github.com/omisego/elixir-omg/issues/671
-    {invalidities, state_db_updates} = Enum.reduce(exits, {%{}, []}, &collect_invalidities_and_state_db_updates/2)
+    {invalidities, state_db_updates} =
+      Enum.reduce(exiting_positions, {%{}, []}, &collect_invalidities_and_state_db_updates/2)
 
-    {:ok, state, db_updates} = Core.finalize_in_flight_exits(state, finalizations, invalidities)
+    {:ok, state3, db_updates} = Core.finalize_in_flight_exits(state2, finalizations, invalidities)
 
-    {:reply, {:ok, state_db_updates ++ db_updates}, state}
+    {:reply, {:ok, state_db_updates ++ db_updates}, state3}
   end
 
   def handle_call(:check_validity, _from, state) do
@@ -472,22 +476,17 @@ defmodule OMG.Watcher.ExitProcessor do
   end
 
   defp collect_invalidities_and_state_db_updates(
-         {ife_id, {input_exits, output_exits}},
+         {ife_id, exiting_positions},
          {invalidities_by_ife_id, state_db_updates}
        ) do
-    # we can't call `State.exit_utxos(input_exits ++ output_exits)`
-    # because the types of these enumerable items are distinct
-    {:ok, input_exits_state_updates, {_, input_invalidities}} = State.exit_utxos(input_exits)
-    {:ok, output_exits_state_updates, {_, output_invalidities}} = State.exit_utxos(output_exits)
-
-    exit_invalidities = input_invalidities ++ output_invalidities
+    {:ok, exits_state_updates, {_, invalidities}} = State.exit_utxos(exiting_positions)
 
     _ =
-      if not Enum.empty?(exit_invalidities),
-        do: Logger.warn("Invalid in-flight exit finalization: #{inspect(exit_invalidities)}")
+      if not Enum.empty?(invalidities), do: Logger.warn("Invalid in-flight exit finalization: #{inspect(invalidities)}")
 
-    invalidities_by_ife_id = Map.put(invalidities_by_ife_id, ife_id, exit_invalidities)
-    state_db_updates = input_exits_state_updates ++ output_exits_state_updates ++ state_db_updates
+    invalidities_by_ife_id = Map.put(invalidities_by_ife_id, ife_id, invalidities)
+    state_db_updates = exits_state_updates ++ state_db_updates
+
     {invalidities_by_ife_id, state_db_updates}
   end
 end

--- a/apps/omg_watcher/lib/omg_watcher/exit_processor.ex
+++ b/apps/omg_watcher/lib/omg_watcher/exit_processor.ex
@@ -248,14 +248,17 @@ defmodule OMG.Watcher.ExitProcessor do
         events,
         fn %{call_data: %{in_flight_tx: bytes}} ->
           {:ok, contract_ife_id} = Eth.RootChain.get_in_flight_exit_id(bytes)
-          {:ok, {timestamp, _, _, _, _}} = Eth.RootChain.get_in_flight_exit(contract_ife_id)
-          {timestamp, contract_ife_id}
+          {:ok, status} = Eth.RootChain.get_in_flight_exit(contract_ife_id)
+          {raw_contract_ife_status_to_timestamp(status), contract_ife_id}
         end
       )
 
     {new_state, db_updates} = Core.new_in_flight_exits(state, events, ife_contract_statuses)
     {:reply, {:ok, db_updates}, new_state}
   end
+
+  # FIXME: move
+  defp raw_contract_ife_status_to_timestamp({_, timestamp, _, _, _, _, _}), do: timestamp
 
   def handle_call({:finalize_exits, exits}, _from, state) do
     _ = if not Enum.empty?(exits), do: Logger.info("Recognized finalizations: #{inspect(exits)}")

--- a/apps/omg_watcher/lib/omg_watcher/exit_processor/core.ex
+++ b/apps/omg_watcher/lib/omg_watcher/exit_processor/core.ex
@@ -54,6 +54,8 @@ defmodule OMG.Watcher.ExitProcessor.Core do
   @max_inputs Transaction.Payment.max_inputs()
   @max_outputs Transaction.Payment.max_outputs()
 
+  @type new_in_flight_exit_status_t() :: {tuple(), pos_integer()}
+
   @type piggyback_input_index_t() :: 0..unquote(@max_inputs - 1)
   @type piggyback_output_index_t() :: 0..unquote(@max_outputs - 1)
 
@@ -178,7 +180,8 @@ defmodule OMG.Watcher.ExitProcessor.Core do
   @doc """
   Add new in flight exits from Ethereum events into tracked state.
   """
-  @spec new_in_flight_exits(t(), list(map()), list(map())) :: {t(), list()} | {:error, :unexpected_events}
+  @spec new_in_flight_exits(t(), list(map()), list(new_in_flight_exit_status_t())) ::
+          {t(), list()} | {:error, :unexpected_events}
   def new_in_flight_exits(state, new_ifes_events, contract_statuses)
 
   def new_in_flight_exits(_state, new_ifes_events, contract_statuses)

--- a/apps/omg_watcher/lib/omg_watcher/exit_processor/core.ex
+++ b/apps/omg_watcher/lib/omg_watcher/exit_processor/core.ex
@@ -76,8 +76,10 @@ defmodule OMG.Watcher.ExitProcessor.Core do
           sla_margin: non_neg_integer(),
           exits: %{Utxo.Position.t() => ExitInfo.t()},
           in_flight_exits: %{Transaction.tx_hash() => InFlightExitInfo.t()},
-          # TODO intended to store both SE and IFE keys by `exit_id`. Not sure, reconsider this when doing IFEs
-          exit_ids: %{non_neg_integer() => Utxo.Position.t() | Transaction.tx_hash()},
+          # NOTE: maps only standard exit_ids to the natural keys of standard exits (input pointers/utxo_pos)
+          #       rethink the approach to the keys in the data structures - how to manage exit_ids? should the contract
+          #       serve more data (e.g. input pointers/tx hashes) where it would normally only serve exit_ids?
+          exit_ids: %{non_neg_integer() => Utxo.Position.t()},
           competitors: %{Transaction.tx_hash() => CompetitorInfo.t()}
         }
 

--- a/apps/omg_watcher/lib/omg_watcher/exit_processor/in_flight_exit_info.ex
+++ b/apps/omg_watcher/lib/omg_watcher/exit_processor/in_flight_exit_info.ex
@@ -117,8 +117,7 @@ defmodule OMG.Watcher.ExitProcessor.InFlightExitInfo do
 
   defp prepare_tx(tx_bytes, tx_signatures) do
     with {:ok, raw_tx} <- Transaction.decode(tx_bytes) do
-      chopped_sigs = for <<chunk::size(65)-unit(8) <- tx_signatures>>, do: <<chunk::size(65)-unit(8)>>
-      tx = %Transaction.Signed{raw_tx: raw_tx, sigs: chopped_sigs}
+      tx = %Transaction.Signed{raw_tx: raw_tx, sigs: tx_signatures}
       {:ok, tx}
     end
   end

--- a/apps/omg_watcher/lib/omg_watcher/exit_processor/in_flight_exit_info.ex
+++ b/apps/omg_watcher/lib/omg_watcher/exit_processor/in_flight_exit_info.ex
@@ -51,7 +51,7 @@ defmodule OMG.Watcher.ExitProcessor.InFlightExitInfo do
     :oldest_competitor,
     :eth_height,
     :relevant_from_blknum,
-    # piggybacking
+    # piggybacking & finalization
     exit_map: Map.new(),
     is_canonical: true,
     is_active: true

--- a/apps/omg_watcher/lib/omg_watcher/exit_processor/in_flight_exit_info.ex
+++ b/apps/omg_watcher/lib/omg_watcher/exit_processor/in_flight_exit_info.ex
@@ -50,6 +50,8 @@ defmodule OMG.Watcher.ExitProcessor.InFlightExitInfo do
     :contract_id,
     :oldest_competitor,
     :eth_height,
+    :input_txs,
+    :input_utxos_pos,
     :relevant_from_blknum,
     # piggybacking & finalization
     exit_map: Map.new(),
@@ -74,6 +76,8 @@ defmodule OMG.Watcher.ExitProcessor.InFlightExitInfo do
           contract_id: ife_contract_id(),
           oldest_competitor: Utxo.Position.t() | nil,
           eth_height: pos_integer(),
+          input_txs: list(Transaction.Protocol.t()),
+          input_utxos_pos: list(Utxo.Position.t()),
           relevant_from_blknum: pos_integer(),
           exit_map: %{
             {:input | :output, non_neg_integer()} => %{
@@ -86,13 +90,23 @@ defmodule OMG.Watcher.ExitProcessor.InFlightExitInfo do
         }
 
   def new_kv(
-        %{eth_height: eth_height, call_data: %{in_flight_tx: tx_bytes, in_flight_tx_sigs: signatures}},
+        %{
+          eth_height: eth_height,
+          call_data: %{
+            in_flight_tx: tx_bytes,
+            in_flight_tx_sigs: signatures,
+            input_txs: input_txs,
+            input_utxos_pos: input_utxos_pos
+          }
+        },
         {timestamp, contract_ife_id} = contract_status
       ) do
     do_new(tx_bytes, signatures, contract_status,
       contract_id: <<contract_ife_id::192>>,
       timestamp: timestamp,
-      eth_height: eth_height
+      eth_height: eth_height,
+      input_txs: input_txs,
+      input_utxos_pos: Enum.map(input_utxos_pos, &Utxo.Position.decode!/1)
     )
   end
 
@@ -134,6 +148,8 @@ defmodule OMG.Watcher.ExitProcessor.InFlightExitInfo do
            contract_id: contract_id,
            oldest_competitor: oldest_competitor,
            eth_height: eth_height,
+           input_txs: input_txs,
+           input_utxos_pos: input_utxos_pos,
            relevant_from_blknum: relevant_from_blknum,
            exit_map: exit_map,
            is_canonical: is_canonical,
@@ -141,7 +157,8 @@ defmodule OMG.Watcher.ExitProcessor.InFlightExitInfo do
          }}
       )
       when is_binary(contract_id) and
-             is_integer(timestamp) and is_integer(eth_height) and is_integer(relevant_from_blknum) and
+             is_integer(timestamp) and is_integer(eth_height) and is_list(input_txs) and is_list(input_utxos_pos) and
+             is_integer(relevant_from_blknum) and
              is_map(exit_map) and is_boolean(is_canonical) and is_boolean(is_active) do
     :ok = assert_utxo_pos_type(tx_pos)
     :ok = assert_utxo_pos_type(oldest_competitor)
@@ -153,6 +170,8 @@ defmodule OMG.Watcher.ExitProcessor.InFlightExitInfo do
       contract_id: contract_id,
       oldest_competitor: oldest_competitor,
       eth_height: eth_height,
+      input_txs: input_txs,
+      input_utxos_pos: input_utxos_pos,
       relevant_from_blknum: relevant_from_blknum,
       exit_map: exit_map,
       is_canonical: is_canonical,
@@ -177,6 +196,8 @@ defmodule OMG.Watcher.ExitProcessor.InFlightExitInfo do
            contract_id: contract_id,
            oldest_competitor: oldest_competitor,
            eth_height: eth_height,
+           input_txs: input_txs,
+           input_utxos_pos: input_utxos_pos,
            relevant_from_blknum: relevant_from_blknum,
            exit_map: exit_map,
            is_canonical: is_canonical,
@@ -184,7 +205,8 @@ defmodule OMG.Watcher.ExitProcessor.InFlightExitInfo do
          }}
       )
       when is_map(signed_tx_map) and is_binary(contract_id) and
-             is_integer(timestamp) and is_integer(eth_height) and is_integer(relevant_from_blknum) and
+             is_integer(timestamp) and is_integer(eth_height) and is_list(input_txs) and is_list(input_utxos_pos) and
+             is_integer(relevant_from_blknum) and
              is_map(exit_map) and is_boolean(is_canonical) and is_boolean(is_active) do
     :ok = assert_utxo_pos_type(tx_pos)
     :ok = assert_utxo_pos_type(oldest_competitor)
@@ -197,6 +219,8 @@ defmodule OMG.Watcher.ExitProcessor.InFlightExitInfo do
       contract_id: contract_id,
       oldest_competitor: oldest_competitor,
       eth_height: eth_height,
+      input_txs: input_txs,
+      input_utxos_pos: input_utxos_pos,
       relevant_from_blknum: relevant_from_blknum,
       exit_map: exit_map,
       is_canonical: is_canonical,

--- a/apps/omg_watcher/lib/omg_watcher/exit_processor/piggyback.ex
+++ b/apps/omg_watcher/lib/omg_watcher/exit_processor/piggyback.ex
@@ -31,6 +31,7 @@ defmodule OMG.Watcher.ExitProcessor.Piggyback do
   """
 
   alias OMG.State.Transaction
+  alias OMG.Utxo
   alias OMG.Watcher.Event
   alias OMG.Watcher.ExitProcessor
   alias OMG.Watcher.ExitProcessor.Core
@@ -52,7 +53,9 @@ defmodule OMG.Watcher.ExitProcessor.Piggyback do
           in_flight_input_index: 0..3,
           spending_txbytes: Transaction.tx_bytes(),
           spending_input_index: 0..3,
-          spending_sig: <<_::520>>
+          spending_sig: <<_::520>>,
+          input_tx: Transaction.tx_bytes(),
+          input_utxo_pos: Utxo.Position.t()
         }
 
   @type output_challenge_data :: %{
@@ -191,7 +194,9 @@ defmodule OMG.Watcher.ExitProcessor.Piggyback do
       in_flight_input_index: input_index,
       spending_txbytes: Transaction.raw_txbytes(proof.known_tx.signed_tx),
       spending_input_index: proof.known_spent_index,
-      spending_sig: Enum.at(proof.known_tx.signed_tx.sigs, proof.known_spent_index)
+      spending_sig: Enum.at(proof.known_tx.signed_tx.sigs, proof.known_spent_index),
+      input_tx: Enum.at(ife.input_txs, input_index),
+      input_utxo_pos: Enum.at(ife.input_utxos_pos, input_index)
     }
   end
 

--- a/apps/omg_watcher/test/omg_watcher/exit_processor/canonicity_test.exs
+++ b/apps/omg_watcher/test/omg_watcher/exit_processor/canonicity_test.exs
@@ -531,6 +531,17 @@ defmodule OMG.Watcher.ExitProcessor.CanonicityTest do
                %ExitProcessor.Request{blknum_now: @late_blknum} |> Core.determine_utxo_existence_to_get(processor)
     end
 
+    test "returns input txs and input utxo positions for canonicity challenges",
+         %{processor_filled: processor, transactions: [tx | _], competing_tx: comp} do
+      txbytes = txbytes(tx)
+      processor = processor |> start_ife_from(comp)
+
+      request = %ExitProcessor.Request{blknum_now: 1000, eth_height_now: 5}
+
+      assert {:ok, %{input_tx: "input_tx", input_utxo_pos: Utxo.position(1, 0, 0)}} =
+               Core.get_competitor_for_ife(request, processor, txbytes)
+    end
+
     test "by not asking for spends on no ifes",
          %{processor_empty: processor} do
       assert %{spends_to_get: []} =

--- a/apps/omg_watcher/test/omg_watcher/exit_processor/canonicity_test.exs
+++ b/apps/omg_watcher/test/omg_watcher/exit_processor/canonicity_test.exs
@@ -34,7 +34,6 @@ defmodule OMG.Watcher.ExitProcessor.CanonicityTest do
 
   @eth OMG.Eth.RootChain.eth_pseudo_address()
   @late_blknum 10_000
-  @exit_id 1
 
   describe "sanity checks" do
     test "can process empty challenges and responses", %{processor_empty: empty, processor_filled: filled} do
@@ -502,7 +501,7 @@ defmodule OMG.Watcher.ExitProcessor.CanonicityTest do
 
     test "by not asking for utxo spends concerning non-active ifes",
          %{processor_empty: processor, transactions: [tx | _]} do
-      processor = processor |> start_ife_from(tx, status: {0, @exit_id})
+      processor = processor |> start_ife_from(tx, status: :inactive)
 
       assert %{utxos_to_check: []} =
                %ExitProcessor.Request{blknum_now: @late_blknum} |> Core.determine_utxo_existence_to_get(processor)
@@ -515,7 +514,7 @@ defmodule OMG.Watcher.ExitProcessor.CanonicityTest do
 
       processor =
         processor
-        |> start_ife_from(tx, status: {1, ife_id})
+        |> start_ife_from(tx, exit_id: ife_id)
         |> piggyback_ife_from(tx_hash, 1, :input)
         |> piggyback_ife_from(tx_hash, 2, :input)
 

--- a/apps/omg_watcher/test/omg_watcher/exit_processor/canonicity_test.exs
+++ b/apps/omg_watcher/test/omg_watcher/exit_processor/canonicity_test.exs
@@ -511,14 +511,13 @@ defmodule OMG.Watcher.ExitProcessor.CanonicityTest do
     test "by not asking for utxo existence concerning finalized ifes",
          %{processor_empty: processor, transactions: [tx | _]} do
       tx_hash = Transaction.raw_txhash(tx)
-
-      piggybacks = [
-        %{tx_hash: tx_hash, output_index: 1, omg_data: %{piggyback_type: :input}},
-        %{tx_hash: tx_hash, output_index: 2, omg_data: %{piggyback_type: :input}}
-      ]
-
       ife_id = 123
-      {processor, _} = processor |> start_ife_from(tx, status: {1, ife_id}) |> Core.new_piggybacks(piggybacks)
+
+      processor =
+        processor
+        |> start_ife_from(tx, status: {1, ife_id})
+        |> piggyback_ife_from(tx_hash, 1, :input)
+        |> piggyback_ife_from(tx_hash, 2, :input)
 
       finalizations = [
         %{in_flight_exit_id: ife_id, output_index: 1, omg_data: %{piggyback_type: :input}},

--- a/apps/omg_watcher/test/omg_watcher/exit_processor/canonicity_test.exs
+++ b/apps/omg_watcher/test/omg_watcher/exit_processor/canonicity_test.exs
@@ -511,10 +511,20 @@ defmodule OMG.Watcher.ExitProcessor.CanonicityTest do
     test "by not asking for utxo existence concerning finalized ifes",
          %{processor_empty: processor, transactions: [tx | _]} do
       tx_hash = Transaction.raw_txhash(tx)
-      piggybacks = [%{tx_hash: tx_hash, output_index: 1}, %{tx_hash: tx_hash, output_index: 2}]
+
+      piggybacks = [
+        %{tx_hash: tx_hash, output_index: 1, omg_data: %{piggyback_type: :input}},
+        %{tx_hash: tx_hash, output_index: 2, omg_data: %{piggyback_type: :input}}
+      ]
+
       ife_id = 123
       {processor, _} = processor |> start_ife_from(tx, status: {1, ife_id}) |> Core.new_piggybacks(piggybacks)
-      finalizations = [%{in_flight_exit_id: ife_id, output_index: 1}, %{in_flight_exit_id: ife_id, output_index: 2}]
+
+      finalizations = [
+        %{in_flight_exit_id: ife_id, output_index: 1, omg_data: %{piggyback_type: :input}},
+        %{in_flight_exit_id: ife_id, output_index: 2, omg_data: %{piggyback_type: :input}}
+      ]
+
       {:ok, processor, _} = Core.finalize_in_flight_exits(processor, finalizations, %{})
 
       assert %{utxos_to_check: []} =

--- a/apps/omg_watcher/test/omg_watcher/exit_processor/core/state_interaction_test.exs
+++ b/apps/omg_watcher/test/omg_watcher/exit_processor/core/state_interaction_test.exs
@@ -39,7 +39,7 @@ defmodule OMG.Watcher.ExitProcessor.Core.StateInteractionTest do
   setup do
     {:ok, processor_empty} = Core.init([], [], [])
     {:ok, child_block_interval} = OMG.Eth.RootChain.get_child_block_interval()
-    {:ok, state_empty} = State.Core.extract_initial_state([], 0, 0, child_block_interval)
+    {:ok, state_empty} = State.Core.extract_initial_state([], 0, child_block_interval)
 
     {:ok, %{alice: TestHelper.generate_entity(), processor_empty: processor_empty, state_empty: state_empty}}
   end

--- a/apps/omg_watcher/test/omg_watcher/exit_processor/core/state_interaction_test.exs
+++ b/apps/omg_watcher/test/omg_watcher/exit_processor/core/state_interaction_test.exs
@@ -173,15 +173,12 @@ defmodule OMG.Watcher.ExitProcessor.Core.StateInteractionTest do
     tx_hash2 = State.Transaction.raw_txhash(ife_exit_tx2)
     ife_id2 = 2
 
-    {processor, _} =
+    processor =
       processor
       |> start_ife_from(ife_exit_tx1, status: {1, ife_id1})
       |> start_ife_from(ife_exit_tx2, status: {1, ife_id2})
-      # FIXME: refactor to leverage helpers more
-      |> Core.new_piggybacks([
-        %{tx_hash: tx_hash1, output_index: 0, omg_data: %{piggyback_type: :output}},
-        %{tx_hash: tx_hash2, output_index: 0, omg_data: %{piggyback_type: :input}}
-      ])
+      |> piggyback_ife_from(tx_hash1, 0, :output)
+      |> piggyback_ife_from(tx_hash2, 0, :input)
 
     finalizations = [
       %{in_flight_exit_id: ife_id1, output_index: 0, omg_data: %{piggyback_type: :output}},
@@ -207,10 +204,10 @@ defmodule OMG.Watcher.ExitProcessor.Core.StateInteractionTest do
     tx_hash = State.Transaction.raw_txhash(ife_exit_tx)
     ife_id = 1
 
-    {processor, _} =
+    processor =
       processor
       |> start_ife_from(ife_exit_tx, status: {1, ife_id})
-      |> Core.new_piggybacks([%{tx_hash: tx_hash, output_index: 0, omg_data: %{piggyback_type: :output}}])
+      |> piggyback_ife_from(tx_hash, 0, :output)
 
     finalizations = [%{in_flight_exit_id: ife_id, output_index: 0, omg_data: %{piggyback_type: :output}}]
     ife_id = <<ife_id::192>>

--- a/apps/omg_watcher/test/omg_watcher/exit_processor/core/state_interaction_test.exs
+++ b/apps/omg_watcher/test/omg_watcher/exit_processor/core/state_interaction_test.exs
@@ -177,9 +177,16 @@ defmodule OMG.Watcher.ExitProcessor.Core.StateInteractionTest do
       processor
       |> start_ife_from(ife_exit_tx1, status: {1, ife_id1})
       |> start_ife_from(ife_exit_tx2, status: {1, ife_id2})
-      |> Core.new_piggybacks([%{tx_hash: tx_hash1, output_index: 4}, %{tx_hash: tx_hash2, output_index: 0}])
+      # FIXME: refactor to leverage helpers more
+      |> Core.new_piggybacks([
+        %{tx_hash: tx_hash1, output_index: 0, omg_data: %{piggyback_type: :output}},
+        %{tx_hash: tx_hash2, output_index: 0, omg_data: %{piggyback_type: :input}}
+      ])
 
-    finalizations = [%{in_flight_exit_id: ife_id1, output_index: 4}, %{in_flight_exit_id: ife_id2, output_index: 0}]
+    finalizations = [
+      %{in_flight_exit_id: ife_id1, output_index: 0, omg_data: %{piggyback_type: :output}},
+      %{in_flight_exit_id: ife_id2, output_index: 0, omg_data: %{piggyback_type: :input}}
+    ]
 
     ife_id1 = <<ife_id1::192>>
     ife_id2 = <<ife_id2::192>>
@@ -203,9 +210,9 @@ defmodule OMG.Watcher.ExitProcessor.Core.StateInteractionTest do
     {processor, _} =
       processor
       |> start_ife_from(ife_exit_tx, status: {1, ife_id})
-      |> Core.new_piggybacks([%{tx_hash: tx_hash, output_index: 4}])
+      |> Core.new_piggybacks([%{tx_hash: tx_hash, output_index: 0, omg_data: %{piggyback_type: :output}}])
 
-    finalizations = [%{in_flight_exit_id: ife_id, output_index: 4}]
+    finalizations = [%{in_flight_exit_id: ife_id, output_index: 0, omg_data: %{piggyback_type: :output}}]
     ife_id = <<ife_id::192>>
 
     {:ok, %{^ife_id => {_input_exits, output_exits}}} =

--- a/apps/omg_watcher/test/omg_watcher/exit_processor/core/state_interaction_test.exs
+++ b/apps/omg_watcher/test/omg_watcher/exit_processor/core/state_interaction_test.exs
@@ -177,8 +177,8 @@ defmodule OMG.Watcher.ExitProcessor.Core.StateInteractionTest do
 
     processor =
       processor
-      |> start_ife_from(ife_exit_tx1, status: {1, ife_id1})
-      |> start_ife_from(ife_exit_tx2, status: {1, ife_id2})
+      |> start_ife_from(ife_exit_tx1, exit_id: ife_id1)
+      |> start_ife_from(ife_exit_tx2, exit_id: ife_id2)
       |> piggyback_ife_from(tx_hash1, 0, :output)
       |> piggyback_ife_from(tx_hash2, 0, :input)
       |> Core.find_ifes_in_blocks(request)
@@ -210,7 +210,7 @@ defmodule OMG.Watcher.ExitProcessor.Core.StateInteractionTest do
 
     processor =
       processor
-      |> start_ife_from(ife_exit_tx, status: {1, ife_id})
+      |> start_ife_from(ife_exit_tx, exit_id: ife_id)
       |> piggyback_ife_from(tx_hash, 0, :output)
       |> Core.find_ifes_in_blocks(request)
 
@@ -243,7 +243,7 @@ defmodule OMG.Watcher.ExitProcessor.Core.StateInteractionTest do
 
     processor =
       processor
-      |> start_ife_from(ife_exit_tx, status: {1, ife_id})
+      |> start_ife_from(ife_exit_tx, exit_id: ife_id)
       |> piggyback_ife_from(tx_hash, 0, :output)
       |> Core.find_ifes_in_blocks(request)
 

--- a/apps/omg_watcher/test/omg_watcher/exit_processor/core/state_interaction_test.exs
+++ b/apps/omg_watcher/test/omg_watcher/exit_processor/core/state_interaction_test.exs
@@ -142,7 +142,7 @@ defmodule OMG.Watcher.ExitProcessor.Core.StateInteractionTest do
     assert Utxo.position(1, 0, 0) not in spends_to_get
 
     # spend and see that Core now requests the relevant utxo checks and spends to get
-    {:ok, _, state} = State.Core.exec(state, comp, %{@eth => 0})
+    {:ok, _, state} = State.Core.exec(state, comp, :no_fees_required)
     {:ok, {block, _, _}, state} = State.Core.form_block(1000, state)
 
     assert %{utxos_to_check: utxos_to_check, utxo_exists_result: utxo_exists_result, spends_to_get: spends_to_get} =
@@ -157,21 +157,23 @@ defmodule OMG.Watcher.ExitProcessor.Core.StateInteractionTest do
 
   test "can work with State to exit utxos from in-flight transactions",
        %{processor_empty: processor, state_empty: state, alice: alice} do
-    state =
-      state
-      |> TestHelper.do_deposit(alice, %{amount: 10, currency: @eth, blknum: 1})
-      |> TestHelper.do_deposit(alice, %{amount: 20, currency: @eth, blknum: 2})
-
-    # canonical
+    # canonical & included
     ife_exit_tx1 = TestHelper.create_recovered([{1, 0, 0, alice}], @eth, [{alice, 10}])
-    {:ok, {tx_hash1, _, _}, state} = State.Core.exec(state, ife_exit_tx1, %{@eth => 0})
-    {:ok, _, state} = State.Core.form_block(1000, state)
     ife_id1 = 1
-
     # non-canonical
     ife_exit_tx2 = TestHelper.create_recovered([{2, 0, 0, alice}], @eth, [{alice, 20}])
     tx_hash2 = State.Transaction.raw_txhash(ife_exit_tx2)
     ife_id2 = 2
+
+    {:ok, {tx_hash1, _, _}, state} =
+      state
+      |> TestHelper.do_deposit(alice, %{amount: 10, currency: @eth, blknum: 1})
+      |> TestHelper.do_deposit(alice, %{amount: 10, currency: @eth, blknum: 2})
+      |> State.Core.exec(ife_exit_tx1, :no_fees_required)
+
+    {:ok, {block, _, _}, state} = State.Core.form_block(1000, state)
+
+    request = %ExitProcessor.Request{blknum_now: 5000, eth_height_now: 5, ife_input_spending_blocks_result: [block]}
 
     processor =
       processor
@@ -179,6 +181,7 @@ defmodule OMG.Watcher.ExitProcessor.Core.StateInteractionTest do
       |> start_ife_from(ife_exit_tx2, status: {1, ife_id2})
       |> piggyback_ife_from(tx_hash1, 0, :output)
       |> piggyback_ife_from(tx_hash2, 0, :input)
+      |> Core.find_ifes_in_blocks(request)
 
     finalizations = [
       %{in_flight_exit_id: ife_id1, output_index: 0, omg_data: %{piggyback_type: :output}},
@@ -188,34 +191,69 @@ defmodule OMG.Watcher.ExitProcessor.Core.StateInteractionTest do
     ife_id1 = <<ife_id1::192>>
     ife_id2 = <<ife_id2::192>>
 
-    {:ok, %{^ife_id1 => {_input_exits1, output_exits1}, ^ife_id2 => {input_exits2, _output_exits2}}} =
+    {:ok, %{^ife_id1 => exiting_positions1, ^ife_id2 => exiting_positions2}} =
       Core.prepare_utxo_exits_for_in_flight_exit_finalizations(processor, finalizations)
 
-    assert {:ok, {[{:delete, :utxo, _}], {[Utxo.position(1000, 0, 0)], []}}, _} =
-             State.Core.exit_utxos(output_exits1, state)
-
-    assert {:ok, {[{:delete, :utxo, _}], {[Utxo.position(2, 0, 0)], []}}, _} =
-             State.Core.exit_utxos(input_exits2, state)
+    assert {:ok,
+            {[{:delete, :utxo, _}, {:delete, :utxo, _}], {[Utxo.position(1000, 0, 0), Utxo.position(2, 0, 0)], []}},
+            _} = State.Core.exit_utxos(exiting_positions1 ++ exiting_positions2, state)
   end
 
-  test "acts on invalidities reported when exiting utxos in State",
+  test "tolerates piggybacked outputs exiting if they're concerning non-included IFE txs",
        %{processor_empty: processor, state_empty: state, alice: alice} do
     ife_exit_tx = TestHelper.create_recovered([{1, 0, 0, alice}], @eth, [{alice, 10}])
     tx_hash = State.Transaction.raw_txhash(ife_exit_tx)
     ife_id = 1
 
+    # ife tx cannot be found in blocks, hence `ife_input_spending_blocks_result: []`
+    request = %ExitProcessor.Request{blknum_now: 5000, eth_height_now: 5, ife_input_spending_blocks_result: []}
+
     processor =
       processor
       |> start_ife_from(ife_exit_tx, status: {1, ife_id})
       |> piggyback_ife_from(tx_hash, 0, :output)
+      |> Core.find_ifes_in_blocks(request)
 
     finalizations = [%{in_flight_exit_id: ife_id, output_index: 0, omg_data: %{piggyback_type: :output}}]
     ife_id = <<ife_id::192>>
 
-    {:ok, %{^ife_id => {_input_exits, output_exits}}} =
+    {:ok, %{^ife_id => exiting_positions}} =
       Core.prepare_utxo_exits_for_in_flight_exit_finalizations(processor, finalizations)
 
-    {:ok, {_, {[], [_] = invalidities}}, _} = State.Core.exit_utxos(output_exits, state)
+    {:ok, {_, {[], [] = invalidities}}, _} = State.Core.exit_utxos(exiting_positions, state)
+
+    assert {:ok, processor, [_]} = Core.finalize_in_flight_exits(processor, finalizations, %{ife_id => invalidities})
+    assert [] = Core.get_active_in_flight_exits(processor)
+  end
+
+  test "acts on invalidities reported when exiting utxos in State",
+       %{processor_empty: processor, state_empty: state, alice: alice} do
+    # canonical & included
+    ife_exit_tx = TestHelper.create_recovered([{1, 0, 0, alice}], @eth, [{alice, 10}])
+    # double-spending the piggybacked ouptut
+    spending_tx = TestHelper.create_recovered([{1000, 0, 0, alice}], @eth, [{alice, 10}])
+    ife_id = 1
+
+    state = TestHelper.do_deposit(state, alice, %{amount: 10, currency: @eth, blknum: 1})
+    {:ok, {tx_hash, _, _}, state} = State.Core.exec(state, ife_exit_tx, :no_fees_required)
+    {:ok, {_, _, _}, state} = State.Core.exec(state, spending_tx, :no_fees_required)
+    {:ok, {block, _, _}, state} = State.Core.form_block(1000, state)
+
+    request = %ExitProcessor.Request{blknum_now: 5000, eth_height_now: 5, ife_input_spending_blocks_result: [block]}
+
+    processor =
+      processor
+      |> start_ife_from(ife_exit_tx, status: {1, ife_id})
+      |> piggyback_ife_from(tx_hash, 0, :output)
+      |> Core.find_ifes_in_blocks(request)
+
+    finalizations = [%{in_flight_exit_id: ife_id, output_index: 0, omg_data: %{piggyback_type: :output}}]
+    ife_id = <<ife_id::192>>
+
+    {:ok, %{^ife_id => exiting_positions}} =
+      Core.prepare_utxo_exits_for_in_flight_exit_finalizations(processor, finalizations)
+
+    {:ok, {_, {[], [_] = invalidities}}, _} = State.Core.exit_utxos(exiting_positions, state)
 
     assert {:ok, processor, [_]} = Core.finalize_in_flight_exits(processor, finalizations, %{ife_id => invalidities})
     assert [_] = Core.get_active_in_flight_exits(processor)

--- a/apps/omg_watcher/test/omg_watcher/exit_processor/core_test.exs
+++ b/apps/omg_watcher/test/omg_watcher/exit_processor/core_test.exs
@@ -152,17 +152,10 @@ defmodule OMG.Watcher.ExitProcessor.CoreTest do
       processor = processor |> start_ife_from(tx)
       assert [%{piggybacked_inputs: [], piggybacked_outputs: []}] = Core.get_active_in_flight_exits(processor)
 
-      processor = piggyback_ife_from(processor, txhash, 0, :input)
-
+      processor = processor |> piggyback_ife_from(txhash, 0, :input)
       assert [%{piggybacked_inputs: [0], piggybacked_outputs: []}] = Core.get_active_in_flight_exits(processor)
 
-      # FIXME: refactor to leverage piggyback_ife_from more
-      {processor, _} =
-        Core.new_piggybacks(processor, [
-          %{tx_hash: txhash, output_index: 0, omg_data: %{piggyback_type: :output}},
-          %{tx_hash: txhash, output_index: 1, omg_data: %{piggyback_type: :output}}
-        ])
-
+      processor = processor |> piggyback_ife_from(txhash, 0, :output) |> piggyback_ife_from(txhash, 1, :output)
       assert [%{piggybacked_inputs: [0], piggybacked_outputs: [0, 1]}] = Core.get_active_in_flight_exits(processor)
     end
 

--- a/apps/omg_watcher/test/omg_watcher/exit_processor/core_test.exs
+++ b/apps/omg_watcher/test/omg_watcher/exit_processor/core_test.exs
@@ -69,10 +69,10 @@ defmodule OMG.Watcher.ExitProcessor.CoreTest do
     end
 
     test "in flight exits sanity checks",
-         %{processor_empty: state, in_flight_exit_events: events, contract_ife_statuses: statuses} do
+         %{processor_empty: state, in_flight_exit_events: events} do
       assert {state, []} == Core.new_in_flight_exits(state, [], [])
       assert {:error, :unexpected_events} == Core.new_in_flight_exits(state, Enum.slice(events, 0, 1), [])
-      assert {:error, :unexpected_events} == Core.new_in_flight_exits(state, [], Enum.slice(statuses, 0, 1))
+      assert {:error, :unexpected_events} == Core.new_in_flight_exits(state, [], [{:anything, 1}])
     end
 
     test "knows exits by exit_id the moment they start",
@@ -117,8 +117,10 @@ defmodule OMG.Watcher.ExitProcessor.CoreTest do
 
   describe "active SE/IFE listing (only IFEs for now)" do
     test "properly processes new in flight exits, returns all of them on request",
-         %{processor_empty: processor, in_flight_exit_events: events, contract_ife_statuses: statuses} do
+         %{processor_empty: processor, in_flight_exit_events: events} do
       assert [] == Core.get_active_in_flight_exits(processor)
+      # some statuses as received from the contract
+      statuses = [{active_ife_status(), 1}, {active_ife_status(), 2}]
 
       {processor, _} = Core.new_in_flight_exits(processor, events, statuses)
       ifes_response = Core.get_active_in_flight_exits(processor)

--- a/apps/omg_watcher/test/omg_watcher/exit_processor/core_test.exs
+++ b/apps/omg_watcher/test/omg_watcher/exit_processor/core_test.exs
@@ -152,12 +152,16 @@ defmodule OMG.Watcher.ExitProcessor.CoreTest do
       processor = processor |> start_ife_from(tx)
       assert [%{piggybacked_inputs: [], piggybacked_outputs: []}] = Core.get_active_in_flight_exits(processor)
 
-      processor = piggyback_ife_from(processor, txhash, 0)
+      processor = piggyback_ife_from(processor, txhash, 0, :input)
 
       assert [%{piggybacked_inputs: [0], piggybacked_outputs: []}] = Core.get_active_in_flight_exits(processor)
 
+      # FIXME: refactor to leverage piggyback_ife_from more
       {processor, _} =
-        Core.new_piggybacks(processor, [%{tx_hash: txhash, output_index: 4}, %{tx_hash: txhash, output_index: 5}])
+        Core.new_piggybacks(processor, [
+          %{tx_hash: txhash, output_index: 0, omg_data: %{piggyback_type: :output}},
+          %{tx_hash: txhash, output_index: 1, omg_data: %{piggyback_type: :output}}
+        ])
 
       assert [%{piggybacked_inputs: [0], piggybacked_outputs: [0, 1]}] = Core.get_active_in_flight_exits(processor)
     end

--- a/apps/omg_watcher/test/omg_watcher/exit_processor/finalizations_test.exs
+++ b/apps/omg_watcher/test/omg_watcher/exit_processor/finalizations_test.exs
@@ -60,7 +60,7 @@ defmodule OMG.Watcher.ExitProcessor.FinalizationsTest do
 
       processor =
         processor
-        |> start_ife_from(tx1, status: {1, ife_id1})
+        |> start_ife_from(tx1, exit_id: ife_id1)
         |> piggyback_ife_from(tx_hash1, 0, :input)
         |> piggyback_ife_from(tx_hash1, 1, :input)
         |> piggyback_ife_from(tx_hash1, 0, :output)
@@ -94,7 +94,7 @@ defmodule OMG.Watcher.ExitProcessor.FinalizationsTest do
 
       processor =
         processor
-        |> start_ife_from(tx1, status: {1, ife_id1})
+        |> start_ife_from(tx1, exit_id: ife_id1)
         |> piggyback_ife_from(tx_hash1, 0, :output)
         |> piggyback_ife_from(tx_hash1, 1, :output)
         |> Core.find_ifes_in_blocks(request)
@@ -127,8 +127,8 @@ defmodule OMG.Watcher.ExitProcessor.FinalizationsTest do
 
       processor =
         processor
-        |> start_ife_from(tx1, status: {1, ife_id1})
-        |> start_ife_from(tx2, status: {1, ife_id2})
+        |> start_ife_from(tx1, exit_id: ife_id1)
+        |> start_ife_from(tx2, exit_id: ife_id2)
         |> Core.find_ifes_in_blocks(request)
         |> piggyback_ife_from(tx_hash1, 0, :input)
         |> piggyback_ife_from(tx_hash1, 1, :input)
@@ -168,7 +168,7 @@ defmodule OMG.Watcher.ExitProcessor.FinalizationsTest do
 
       processor =
         processor
-        |> start_ife_from(tx, status: {1, ife_id})
+        |> start_ife_from(tx, exit_id: ife_id)
         |> piggyback_ife_from(tx_hash, 1, :input)
 
       finalization1 = %{in_flight_exit_id: ife_id, output_index: 1, omg_data: %{piggyback_type: :input}}
@@ -191,7 +191,7 @@ defmodule OMG.Watcher.ExitProcessor.FinalizationsTest do
 
       processor =
         processor
-        |> start_ife_from(tx, status: {1, ife_id})
+        |> start_ife_from(tx, exit_id: ife_id)
         |> piggyback_ife_from(tx_hash, 0, :input)
         |> piggyback_ife_from(tx_hash, 1, :input)
 
@@ -217,7 +217,7 @@ defmodule OMG.Watcher.ExitProcessor.FinalizationsTest do
 
       processor =
         processor
-        |> start_ife_from(tx, status: {1, ife_id})
+        |> start_ife_from(tx, exit_id: ife_id)
         |> piggyback_ife_from(tx_hash, 0, :output)
         |> piggyback_ife_from(tx_hash, 1, :output)
 
@@ -239,7 +239,7 @@ defmodule OMG.Watcher.ExitProcessor.FinalizationsTest do
 
       processor =
         processor
-        |> start_ife_from(tx, status: {1, ife_id})
+        |> start_ife_from(tx, exit_id: ife_id)
         |> piggyback_ife_from(tx_hash, 1, :input)
         |> piggyback_ife_from(tx_hash, 2, :input)
 
@@ -269,7 +269,7 @@ defmodule OMG.Watcher.ExitProcessor.FinalizationsTest do
 
       processor =
         processor
-        |> start_ife_from(tx, status: {1, ife_id})
+        |> start_ife_from(tx, exit_id: ife_id)
         |> piggyback_ife_from(tx_hash, 1, :input)
 
       finalization = %{in_flight_exit_id: ife_id, output_index: 1, omg_data: %{piggyback_type: :input}}
@@ -286,8 +286,8 @@ defmodule OMG.Watcher.ExitProcessor.FinalizationsTest do
 
       processor =
         processor
-        |> start_ife_from(tx1, status: {1, ife_id1})
-        |> start_ife_from(tx2, status: {1, ife_id2})
+        |> start_ife_from(tx1, exit_id: ife_id1)
+        |> start_ife_from(tx2, exit_id: ife_id2)
         |> piggyback_ife_from(tx_hash1, 1, :input)
 
       finalization = %{in_flight_exit_id: ife_id1, output_index: 1, omg_data: %{piggyback_type: :input}}
@@ -309,7 +309,7 @@ defmodule OMG.Watcher.ExitProcessor.FinalizationsTest do
 
       processor =
         processor
-        |> start_ife_from(tx, status: {1, ife_id})
+        |> start_ife_from(tx, exit_id: ife_id)
         |> piggyback_ife_from(tx_hash, 1, :input)
 
       finalization1 = %{in_flight_exit_id: ife_id, output_index: 1, omg_data: %{piggyback_type: :input}}

--- a/apps/omg_watcher/test/omg_watcher/exit_processor/finalizations_test.exs
+++ b/apps/omg_watcher/test/omg_watcher/exit_processor/finalizations_test.exs
@@ -54,12 +54,15 @@ defmodule OMG.Watcher.ExitProcessor.FinalizationsTest do
         processor
         |> start_ife_from(tx1, status: {1, ife_id1})
         |> start_ife_from(tx2, status: {1, ife_id2})
-        |> piggyback_ife_from(tx_hash1, 0)
-        |> piggyback_ife_from(tx_hash1, 1)
-        |> piggyback_ife_from(tx_hash2, 4)
-        |> piggyback_ife_from(tx_hash2, 5)
+        |> piggyback_ife_from(tx_hash1, 0, :input)
+        |> piggyback_ife_from(tx_hash1, 1, :input)
+        |> piggyback_ife_from(tx_hash2, 0, :output)
+        |> piggyback_ife_from(tx_hash2, 1, :output)
 
-      finalizations = [%{in_flight_exit_id: ife_id1, output_index: 0}, %{in_flight_exit_id: ife_id2, output_index: 4}]
+      finalizations = [
+        %{in_flight_exit_id: ife_id1, output_index: 0, omg_data: %{piggyback_type: :input}},
+        %{in_flight_exit_id: ife_id2, output_index: 0, omg_data: %{piggyback_type: :output}}
+      ]
 
       assert {:ok, %{}} = Core.prepare_utxo_exits_for_in_flight_exit_finalizations(processor, [])
 
@@ -68,14 +71,14 @@ defmodule OMG.Watcher.ExitProcessor.FinalizationsTest do
 
       tx1_first_input = tx1 |> Transaction.get_inputs() |> hd()
       ife1_exits = {[tx1_first_input], []}
-      ife2_exits = {[], [%{tx_hash: tx_hash2, output_index: 4}]}
+      ife2_exits = {[], [%{tx_hash: tx_hash2, output_index: 0, omg_data: %{piggyback_type: :output}}]}
 
       assert {:ok, %{^ife_id1 => ^ife1_exits, ^ife_id2 => ^ife2_exits}} =
                Core.prepare_utxo_exits_for_in_flight_exit_finalizations(processor, finalizations)
     end
 
     test "fails when unknown in-flight exit is being finalized", %{processor_empty: processor} do
-      finalization = %{in_flight_exit_id: @exit_id, output_index: 1}
+      finalization = %{in_flight_exit_id: @exit_id, output_index: 1, omg_data: %{piggyback_type: :input}}
 
       {:unknown_in_flight_exit, unknown_exits} =
         Core.prepare_utxo_exits_for_in_flight_exit_finalizations(processor, [finalization])
@@ -91,12 +94,14 @@ defmodule OMG.Watcher.ExitProcessor.FinalizationsTest do
       processor =
         processor
         |> start_ife_from(tx, status: {1, ife_id})
-        |> piggyback_ife_from(tx_hash, 1)
+        |> piggyback_ife_from(tx_hash, 1, :input)
 
-      finalization1 = %{in_flight_exit_id: ife_id, output_index: 1}
-      finalization2 = %{in_flight_exit_id: ife_id, output_index: 2}
+      finalization1 = %{in_flight_exit_id: ife_id, output_index: 1, omg_data: %{piggyback_type: :input}}
+      finalization2 = %{in_flight_exit_id: ife_id, output_index: 2, omg_data: %{piggyback_type: :input}}
 
-      expected_unknown_piggybacks = [%{in_flight_exit_id: <<ife_id::192>>, output_index: 2}]
+      expected_unknown_piggybacks = [
+        %{in_flight_exit_id: <<ife_id::192>>, output_index: 2, omg_data: %{piggyback_type: :input}}
+      ]
 
       {:unknown_piggybacks, ^expected_unknown_piggybacks} =
         Core.prepare_utxo_exits_for_in_flight_exit_finalizations(processor, [finalization1, finalization2])
@@ -112,14 +117,22 @@ defmodule OMG.Watcher.ExitProcessor.FinalizationsTest do
       processor =
         processor
         |> start_ife_from(tx, status: {1, ife_id})
-        |> piggyback_ife_from(tx_hash, 0)
-        |> piggyback_ife_from(tx_hash, 1)
+        |> piggyback_ife_from(tx_hash, 0, :input)
+        |> piggyback_ife_from(tx_hash, 1, :input)
 
       assert {:ok, processor, [{:put, :in_flight_exit_info, _}]} =
-               Core.finalize_in_flight_exits(processor, [%{in_flight_exit_id: ife_id, output_index: 0}], %{})
+               Core.finalize_in_flight_exits(
+                 processor,
+                 [%{in_flight_exit_id: ife_id, output_index: 0, omg_data: %{piggyback_type: :input}}],
+                 %{}
+               )
 
       assert {:ok, _, [{:put, :in_flight_exit_info, _}]} =
-               Core.finalize_in_flight_exits(processor, [%{in_flight_exit_id: ife_id, output_index: 1}], %{})
+               Core.finalize_in_flight_exits(
+                 processor,
+                 [%{in_flight_exit_id: ife_id, output_index: 1, omg_data: %{piggyback_type: :input}}],
+                 %{}
+               )
     end
 
     test "exits piggybacked transaction outputs",
@@ -130,15 +143,15 @@ defmodule OMG.Watcher.ExitProcessor.FinalizationsTest do
       processor =
         processor
         |> start_ife_from(tx, status: {1, ife_id})
-        |> piggyback_ife_from(tx_hash, 4)
-        |> piggyback_ife_from(tx_hash, 5)
+        |> piggyback_ife_from(tx_hash, 0, :output)
+        |> piggyback_ife_from(tx_hash, 1, :output)
 
       assert {:ok, _, [{:put, :in_flight_exit_info, _}]} =
                Core.finalize_in_flight_exits(
                  processor,
                  [
-                   %{in_flight_exit_id: ife_id, output_index: 5},
-                   %{in_flight_exit_id: ife_id, output_index: 4}
+                   %{in_flight_exit_id: ife_id, output_index: 1, omg_data: %{piggyback_type: :output}},
+                   %{in_flight_exit_id: ife_id, output_index: 0, omg_data: %{piggyback_type: :output}}
                  ],
                  %{}
                )
@@ -152,16 +165,24 @@ defmodule OMG.Watcher.ExitProcessor.FinalizationsTest do
       processor =
         processor
         |> start_ife_from(tx, status: {1, ife_id})
-        |> piggyback_ife_from(tx_hash, 1)
-        |> piggyback_ife_from(tx_hash, 2)
+        |> piggyback_ife_from(tx_hash, 1, :input)
+        |> piggyback_ife_from(tx_hash, 2, :input)
 
       {:ok, processor, _} =
-        Core.finalize_in_flight_exits(processor, [%{in_flight_exit_id: ife_id, output_index: 1}], %{})
+        Core.finalize_in_flight_exits(
+          processor,
+          [%{in_flight_exit_id: ife_id, output_index: 1, omg_data: %{piggyback_type: :input}}],
+          %{}
+        )
 
       [_] = Core.get_active_in_flight_exits(processor)
 
       {:ok, processor, _} =
-        Core.finalize_in_flight_exits(processor, [%{in_flight_exit_id: ife_id, output_index: 2}], %{})
+        Core.finalize_in_flight_exits(
+          processor,
+          [%{in_flight_exit_id: ife_id, output_index: 2, omg_data: %{piggyback_type: :input}}],
+          %{}
+        )
 
       assert [] == Core.get_active_in_flight_exits(processor)
     end
@@ -174,9 +195,9 @@ defmodule OMG.Watcher.ExitProcessor.FinalizationsTest do
       processor =
         processor
         |> start_ife_from(tx, status: {1, ife_id})
-        |> piggyback_ife_from(tx_hash, 1)
+        |> piggyback_ife_from(tx_hash, 1, :input)
 
-      finalization = %{in_flight_exit_id: ife_id, output_index: 1}
+      finalization = %{in_flight_exit_id: ife_id, output_index: 1, omg_data: %{piggyback_type: :input}}
       {:ok, processor, _} = Core.finalize_in_flight_exits(processor, [finalization], %{})
       {:ok, ^processor, []} = Core.finalize_in_flight_exits(processor, [finalization], %{})
     end
@@ -192,15 +213,15 @@ defmodule OMG.Watcher.ExitProcessor.FinalizationsTest do
         processor
         |> start_ife_from(tx1, status: {1, ife_id1})
         |> start_ife_from(tx2, status: {1, ife_id2})
-        |> piggyback_ife_from(tx_hash1, 1)
+        |> piggyback_ife_from(tx_hash1, 1, :input)
 
-      finalization = %{in_flight_exit_id: ife_id1, output_index: 1}
+      finalization = %{in_flight_exit_id: ife_id1, output_index: 1, omg_data: %{piggyback_type: :input}}
       {:ok, processor, _} = Core.finalize_in_flight_exits(processor, [finalization], %{})
       [%{txhash: ^tx_hash2}] = Core.get_active_in_flight_exits(processor)
     end
 
     test "fails when unknown in-flight exit is being finalized", %{processor_empty: processor} do
-      finalization = %{in_flight_exit_id: @exit_id, output_index: 1}
+      finalization = %{in_flight_exit_id: @exit_id, output_index: 1, omg_data: %{piggyback_type: :input}}
 
       {:unknown_in_flight_exit, unknown_exits} = Core.finalize_in_flight_exits(processor, [finalization], %{})
       assert unknown_exits == MapSet.new([<<@exit_id::192>>])
@@ -214,12 +235,14 @@ defmodule OMG.Watcher.ExitProcessor.FinalizationsTest do
       processor =
         processor
         |> start_ife_from(tx, status: {1, ife_id})
-        |> piggyback_ife_from(tx_hash, 1)
+        |> piggyback_ife_from(tx_hash, 1, :input)
 
-      finalization1 = %{in_flight_exit_id: ife_id, output_index: 1}
-      finalization2 = %{in_flight_exit_id: ife_id, output_index: 2}
+      finalization1 = %{in_flight_exit_id: ife_id, output_index: 1, omg_data: %{piggyback_type: :input}}
+      finalization2 = %{in_flight_exit_id: ife_id, output_index: 2, omg_data: %{piggyback_type: :input}}
 
-      expected_unknown_piggybacks = [%{in_flight_exit_id: <<ife_id::192>>, output_index: 2}]
+      expected_unknown_piggybacks = [
+        %{in_flight_exit_id: <<ife_id::192>>, output_index: 2, omg_data: %{piggyback_type: :input}}
+      ]
 
       {:unknown_piggybacks, ^expected_unknown_piggybacks} =
         Core.finalize_in_flight_exits(processor, [finalization1, finalization2], %{})

--- a/apps/omg_watcher/test/omg_watcher/exit_processor/persistence_test.exs
+++ b/apps/omg_watcher/test/omg_watcher/exit_processor/persistence_test.exs
@@ -141,8 +141,12 @@ defmodule OMG.Watcher.ExitProcessor.PersistenceTest do
       }
     }
 
-    piggybacks1 = [%{tx_hash: hash, output_index: 0}, %{tx_hash: hash, output_index: 4}]
-    piggybacks2 = [%{tx_hash: hash, output_index: 5}]
+    piggybacks1 = [
+      %{tx_hash: hash, output_index: 0, omg_data: %{piggyback_type: :input}},
+      %{tx_hash: hash, output_index: 0, omg_data: %{piggyback_type: :output}}
+    ]
+
+    piggybacks2 = [%{tx_hash: hash, output_index: 1, omg_data: %{piggyback_type: :output}}]
 
     processor
     |> persist_new_ifes([tx], [[alice.priv]], db_pid)
@@ -159,18 +163,25 @@ defmodule OMG.Watcher.ExitProcessor.PersistenceTest do
     tx = Transaction.Payment.new([{2, 1, 0}], [{alice.addr, @eth, 1}, {alice.addr, @eth, 2}])
     hash = Transaction.raw_txhash(tx)
 
-    piggybacks1 = [%{tx_hash: hash, output_index: 0}, %{tx_hash: hash, output_index: 4}]
-    piggybacks2 = [%{tx_hash: hash, output_index: 5}]
+    piggybacks1 = [
+      %{tx_hash: hash, output_index: 0, omg_data: %{piggyback_type: :input}},
+      %{tx_hash: hash, output_index: 0, omg_data: %{piggyback_type: :output}}
+    ]
+
+    piggybacks2 = [%{tx_hash: hash, output_index: 1, omg_data: %{piggyback_type: :output}}]
 
     processor
     |> persist_new_ifes([tx], [[alice.priv]], db_pid)
     |> persist_new_piggybacks(piggybacks1, db_pid)
     |> persist_new_piggybacks(piggybacks2, db_pid)
-    |> persist_finalize_ifes([%{in_flight_exit_id: @non_zero_exit_id, output_index: 0}], db_pid)
+    |> persist_finalize_ifes(
+      [%{in_flight_exit_id: @non_zero_exit_id, output_index: 0, omg_data: %{piggyback_type: :input}}],
+      db_pid
+    )
     |> persist_finalize_ifes(
       [
-        %{in_flight_exit_id: @non_zero_exit_id, output_index: 4},
-        %{in_flight_exit_id: @non_zero_exit_id, output_index: 5}
+        %{in_flight_exit_id: @non_zero_exit_id, output_index: 0, omg_data: %{piggyback_type: :output}},
+        %{in_flight_exit_id: @non_zero_exit_id, output_index: 1, omg_data: %{piggyback_type: :output}}
       ],
       db_pid
     )

--- a/apps/omg_watcher/test/omg_watcher/exit_processor/persistence_test.exs
+++ b/apps/omg_watcher/test/omg_watcher/exit_processor/persistence_test.exs
@@ -119,7 +119,7 @@ defmodule OMG.Watcher.ExitProcessor.PersistenceTest do
       Transaction.Payment.new([{2, 1, 0}, {2, 2, 1}], [{alice.addr, @eth, 1}, {carol.addr, @eth, 2}])
     ]
 
-    contract_statuses = [{1, @non_zero_exit_id}, {0, @zero_exit_id}]
+    contract_statuses = [{active_ife_status(), @non_zero_exit_id}, {inactive_ife_status(), @zero_exit_id}]
 
     processor
     |> persist_new_ifes(txs, [[alice.priv], [alice.priv, carol.priv]], contract_statuses, db_pid)
@@ -227,7 +227,7 @@ defmodule OMG.Watcher.ExitProcessor.PersistenceTest do
       |> Enum.map(fn {tx, keys} -> {tx, DevCrypto.sign(tx, keys)} end)
       |> Enum.map(fn {tx, signed_tx} -> ife_event(tx, sigs: signed_tx.sigs) end)
 
-    statuses = statuses || List.duplicate({1, @non_zero_exit_id}, length(in_flight_exit_events))
+    statuses = statuses || List.duplicate({active_ife_status(), @non_zero_exit_id}, length(in_flight_exit_events))
     {processor, db_updates} = Core.new_in_flight_exits(processor, in_flight_exit_events, statuses)
     persist_common(processor, db_updates, db_pid)
   end

--- a/apps/omg_watcher/test/omg_watcher/exit_processor/piggyback_test.exs
+++ b/apps/omg_watcher/test/omg_watcher/exit_processor/piggyback_test.exs
@@ -593,6 +593,17 @@ defmodule OMG.Watcher.ExitProcessor.PiggybackTest do
 
       assert_proof_sound(inclusion_proof)
     end
+
+    test "returns input txs and input utxo positions for invalid input piggyback challenges",
+         %{processor_filled: state, transactions: [tx | _], competing_tx: comp, ife_tx_hashes: [ife_id | _]} do
+      txbytes = txbytes(tx)
+      state = state |> start_ife_from(comp) |> piggyback_ife_from(ife_id, 0, :input)
+
+      request = %ExitProcessor.Request{blknum_now: 1000, eth_height_now: 5}
+
+      assert {:ok, %{input_tx: "input_tx", input_utxo_pos: Utxo.position(1, 0, 0)}} =
+               Core.get_input_challenge_data(request, state, txbytes, 0)
+    end
   end
 
   describe "produces challenges for bad piggybacks" do

--- a/apps/omg_watcher/test/omg_watcher/integration/in_flight_exit_test.exs
+++ b/apps/omg_watcher/test/omg_watcher/integration/in_flight_exit_test.exs
@@ -20,12 +20,14 @@ defmodule OMG.Watcher.Integration.InFlightExitTest do
   use Plug.Test
 
   alias OMG.Eth
+  alias OMG.Integration.DepositHelper
   alias OMG.State.Transaction
+  alias OMG.Utxo
   alias OMG.Watcher.Event
   alias OMG.Watcher.Integration.TestHelper, as: IntegrationTest
   alias OMG.Watcher.TestHelper
 
-  alias OMG.Integration.DepositHelper
+  require Utxo
 
   @timeout 40_000
   @eth OMG.Eth.RootChain.eth_pseudo_address()
@@ -212,6 +214,8 @@ defmodule OMG.Watcher.Integration.InFlightExitTest do
 
     {:ok, %{"status" => "0x1", "blockNumber" => challenge_eth_height}} =
       OMG.Eth.RootChainHelper.challenge_in_flight_exit_not_canonical(
+        get_competitor_response["input_tx"],
+        get_competitor_response["input_utxo_pos"],
         get_competitor_response["in_flight_txbytes"],
         get_competitor_response["in_flight_input_index"],
         get_competitor_response["competing_txbytes"],
@@ -271,6 +275,8 @@ defmodule OMG.Watcher.Integration.InFlightExitTest do
 
     {:ok, %{"status" => "0x1", "blockNumber" => challenge_eth_height}} =
       OMG.Eth.RootChainHelper.challenge_in_flight_exit_not_canonical(
+        Transaction.Payment.new([], [{alice.addr, @eth, 10}]) |> Transaction.raw_txbytes(),
+        Utxo.position(deposit_blknum, 0, 0) |> Utxo.Position.encode(),
         raw_tx1_bytes,
         0,
         raw_tx2_bytes,

--- a/apps/omg_watcher/test/omg_watcher/integration/in_flight_exit_test.exs
+++ b/apps/omg_watcher/test/omg_watcher/integration/in_flight_exit_test.exs
@@ -115,6 +115,8 @@ defmodule OMG.Watcher.Integration.InFlightExitTest do
         proof1["spending_txbytes"],
         proof1["spending_input_index"],
         proof1["spending_sig"],
+        proof1["input_tx"],
+        proof1["input_utxo_pos"],
         alice.addr
       )
       |> Eth.DevHelpers.transact_sync!()

--- a/apps/omg_watcher/test/omg_watcher/integration/in_flight_exit_test.exs
+++ b/apps/omg_watcher/test/omg_watcher/integration/in_flight_exit_test.exs
@@ -35,9 +35,6 @@ defmodule OMG.Watcher.Integration.InFlightExitTest do
   # bumping the timeout to two minutes for the tests here, as they do a lot of transactions to Ethereum to test
   @moduletag timeout: 180_000
 
-  # TODO: unskip, IFEs don't work yet
-  @moduletag :skip
-
   @tag fixtures: [:watcher, :alice, :bob, :child_chain]
   test "piggyback in flight exit", %{alice: alice, bob: bob} do
     {:ok, _} = Eth.DevHelpers.import_unlock_fund(alice)
@@ -91,10 +88,12 @@ defmodule OMG.Watcher.Integration.InFlightExitTest do
     {:ok, {_, _, exitmap, _, _}} = OMG.Eth.RootChain.get_in_flight_exit(ife_id)
     assert exitmap != 0
     # IFE tx 3
+    # FIXME: can use the DRYed version of this call?
     {:ok, %{"status" => "0x1"}} =
       OMG.Eth.RootChainHelper.in_flight_exit(
         in_flight_tx["in_flight_tx"],
         in_flight_tx["input_txs"],
+        in_flight_tx["input_utxos_pos"],
         in_flight_tx["input_txs_inclusion_proofs"],
         in_flight_tx["in_flight_tx_sigs"],
         bob.addr
@@ -362,6 +361,7 @@ defmodule OMG.Watcher.Integration.InFlightExitTest do
     OMG.Eth.RootChainHelper.in_flight_exit(
       get_in_flight_exit_response["in_flight_tx"],
       get_in_flight_exit_response["input_txs"],
+      get_in_flight_exit_response["input_utxos_pos"],
       get_in_flight_exit_response["input_txs_inclusion_proofs"],
       get_in_flight_exit_response["in_flight_tx_sigs"],
       exiting_user.addr

--- a/apps/omg_watcher/test/omg_watcher/integration/in_flight_exit_test.exs
+++ b/apps/omg_watcher/test/omg_watcher/integration/in_flight_exit_test.exs
@@ -72,7 +72,7 @@ defmodule OMG.Watcher.Integration.InFlightExitTest do
     txbytes1 = Transaction.raw_txbytes(tx_submit1)
     {:ok, ife_id} = OMG.Eth.RootChain.get_in_flight_exit_id(txbytes1)
     # sanity check
-    {:ok, {_, _, 0, _, _}} = OMG.Eth.RootChain.get_in_flight_exit(ife_id)
+    {:ok, {_, _, 0, _, _, _, _}} = OMG.Eth.RootChain.get_in_flight_exit(ife_id)
 
     # PB 1
     {:ok, %{"status" => "0x1"}} =
@@ -85,7 +85,7 @@ defmodule OMG.Watcher.Integration.InFlightExitTest do
       |> Eth.DevHelpers.transact_sync!()
 
     # sanity check
-    {:ok, {_, _, exitmap, _, _}} = OMG.Eth.RootChain.get_in_flight_exit(ife_id)
+    {:ok, {_, _, exitmap, _, _, _, _}} = OMG.Eth.RootChain.get_in_flight_exit(ife_id)
     assert exitmap != 0
     # IFE tx 3
     # FIXME: can use the DRYed version of this call?
@@ -131,7 +131,7 @@ defmodule OMG.Watcher.Integration.InFlightExitTest do
       |> Eth.DevHelpers.transact_sync!()
 
     # sanity check
-    {:ok, {_, _, exitmap1, _, _}} = OMG.Eth.RootChain.get_in_flight_exit(ife_id)
+    {:ok, {_, _, exitmap1, _, _, _, _}} = OMG.Eth.RootChain.get_in_flight_exit(ife_id)
     assert exitmap1 != exitmap
     assert exitmap1 != 0
 
@@ -157,7 +157,7 @@ defmodule OMG.Watcher.Integration.InFlightExitTest do
       |> Eth.DevHelpers.transact_sync!()
 
     # observe the result - piggybacks are gone
-    assert {:ok, {_, _, 0, _, _}} = OMG.Eth.RootChain.get_in_flight_exit(ife_id)
+    assert {:ok, {_, _, 0, _, _, _, _}} = OMG.Eth.RootChain.get_in_flight_exit(ife_id)
   end
 
   @tag fixtures: [:watcher, :alice, :bob, :child_chain, :token, :alice_deposits]

--- a/apps/omg_watcher/test/support/exit_processor/case.ex
+++ b/apps/omg_watcher/test/support/exit_processor/case.ex
@@ -58,7 +58,7 @@ defmodule OMG.Watcher.ExitProcessor.Case do
       |> Enum.zip([1, 4])
       |> Enum.reduce(processor_empty, fn {tx, idx}, processor ->
         # use the idx as both two distinct ethereum heights and two distinct exit_ids arriving from the root chain
-        processor |> start_ife_from(tx, eth_height: idx, exit_id: idx)
+        start_ife_from(processor, tx, eth_height: idx, exit_id: idx)
       end)
 
     {:ok,

--- a/apps/omg_watcher/test/support/exit_processor/case.ex
+++ b/apps/omg_watcher/test/support/exit_processor/case.ex
@@ -51,8 +51,6 @@ defmodule OMG.Watcher.ExitProcessor.Case do
     in_flight_exit_events =
       transactions |> Enum.zip([2, 4]) |> Enum.map(fn {tx, eth_height} -> ife_event(tx, eth_height: eth_height) end)
 
-    contract_ife_statuses = 1..length(transactions) |> Enum.map(fn i -> {i, i} end)
-
     ife_tx_hashes = transactions |> Enum.map(&Transaction.raw_txhash/1)
 
     processor_filled =
@@ -60,7 +58,7 @@ defmodule OMG.Watcher.ExitProcessor.Case do
       |> Enum.zip([1, 4])
       |> Enum.reduce(processor_empty, fn {tx, idx}, processor ->
         # use the idx as both two distinct ethereum heights and two distinct exit_ids arriving from the root chain
-        processor |> start_ife_from(tx, eth_height: idx, status: {1, idx})
+        processor |> start_ife_from(tx, eth_height: idx, exit_id: idx)
       end)
 
     {:ok,
@@ -73,7 +71,6 @@ defmodule OMG.Watcher.ExitProcessor.Case do
        unrelated_tx: unrelated_tx,
        processor_empty: processor_empty,
        in_flight_exit_events: in_flight_exit_events,
-       contract_ife_statuses: contract_ife_statuses,
        ife_tx_hashes: ife_tx_hashes,
        processor_filled: processor_filled,
        invalid_piggyback_on_input:

--- a/apps/omg_watcher/test/support/exit_processor/case.ex
+++ b/apps/omg_watcher/test/support/exit_processor/case.ex
@@ -89,7 +89,11 @@ defmodule OMG.Watcher.ExitProcessor.Case do
       ife_input_spending_blocks_result: [Block.hashed_txs_at([tx], 3000)]
     }
 
-    state = state |> start_ife_from(competing_tx) |> piggyback_ife_from(ife_id, 0) |> Core.find_ifes_in_blocks(request)
+    state =
+      state
+      |> start_ife_from(competing_tx)
+      |> piggyback_ife_from(ife_id, 0, :input)
+      |> Core.find_ifes_in_blocks(request)
 
     %{
       state: state,
@@ -120,7 +124,11 @@ defmodule OMG.Watcher.ExitProcessor.Case do
     }
 
     # 3. stuff happens in the contract; output #4 is a double-spend; #5 is OK
-    state = state |> piggyback_ife_from(ife_id, 4) |> piggyback_ife_from(ife_id, 5) |> Core.find_ifes_in_blocks(request)
+    state =
+      state
+      |> piggyback_ife_from(ife_id, 0, :output)
+      |> piggyback_ife_from(ife_id, 1, :output)
+      |> Core.find_ifes_in_blocks(request)
 
     %{
       state: state,

--- a/apps/omg_watcher/test/support/exit_processor/test_helper.ex
+++ b/apps/omg_watcher/test/support/exit_processor/test_helper.ex
@@ -76,7 +76,7 @@ defmodule OMG.Watcher.ExitProcessor.TestHelper do
     eth_height = Keyword.get(opts, :eth_height, 2)
 
     %{
-      call_data: %{in_flight_tx: Transaction.raw_txbytes(tx), in_flight_tx_sigs: Enum.join(sigs)},
+      call_data: %{in_flight_tx: Transaction.raw_txbytes(tx), in_flight_tx_sigs: sigs},
       eth_height: eth_height
     }
   end

--- a/apps/omg_watcher/test/support/exit_processor/test_helper.ex
+++ b/apps/omg_watcher/test/support/exit_processor/test_helper.ex
@@ -62,8 +62,12 @@ defmodule OMG.Watcher.ExitProcessor.TestHelper do
     processor
   end
 
-  def piggyback_ife_from(%Core{} = processor, tx_hash, output_index) do
-    {processor, _} = Core.new_piggybacks(processor, [%{tx_hash: tx_hash, output_index: output_index}])
+  def piggyback_ife_from(%Core{} = processor, tx_hash, output_index, piggyback_type) do
+    {processor, _} =
+      Core.new_piggybacks(processor, [
+        %{tx_hash: tx_hash, output_index: output_index, omg_data: %{piggyback_type: piggyback_type}}
+      ])
+
     processor
   end
 

--- a/apps/omg_watcher/test/support/exit_processor/test_helper.ex
+++ b/apps/omg_watcher/test/support/exit_processor/test_helper.ex
@@ -57,10 +57,15 @@ defmodule OMG.Watcher.ExitProcessor.TestHelper do
 
   def start_ife_from(%Core{} = processor, tx, opts \\ []) do
     exit_id = Keyword.get(opts, :exit_id, @exit_id)
-    status = Keyword.get(opts, :status, {1, exit_id})
-    {processor, _} = Core.new_in_flight_exits(processor, [ife_event(tx, opts)], [status])
+    # `nil`s are unused portions of the returns data from the contract
+    status = Keyword.get(opts, :status, active_ife_status())
+    status = if status == :inactive, do: inactive_ife_status(), else: status
+    {processor, _} = Core.new_in_flight_exits(processor, [ife_event(tx, opts)], [{status, exit_id}])
     processor
   end
+
+  def active_ife_status(), do: {nil, 1, nil, nil, nil, nil, nil}
+  def inactive_ife_status(), do: {nil, 0, nil, nil, nil, nil, nil}
 
   def piggyback_ife_from(%Core{} = processor, tx_hash, output_index, piggyback_type) do
     {processor, _} =

--- a/apps/omg_watcher/test/support/exit_processor/test_helper.ex
+++ b/apps/omg_watcher/test/support/exit_processor/test_helper.ex
@@ -73,10 +73,17 @@ defmodule OMG.Watcher.ExitProcessor.TestHelper do
 
   def ife_event(tx, opts \\ []) do
     sigs = Keyword.get(opts, :sigs) || sigs(tx)
+    input_utxos_pos = Transaction.get_inputs(tx) |> Enum.map(&Utxo.Position.encode/1)
+    input_txs = Keyword.get(opts, :input_txs) || List.duplicate("input_tx", length(input_utxos_pos))
     eth_height = Keyword.get(opts, :eth_height, 2)
 
     %{
-      call_data: %{in_flight_tx: Transaction.raw_txbytes(tx), in_flight_tx_sigs: sigs},
+      call_data: %{
+        in_flight_tx: Transaction.raw_txbytes(tx),
+        input_txs: input_txs,
+        input_utxos_pos: input_utxos_pos,
+        in_flight_tx_sigs: sigs
+      },
       eth_height: eth_height
     }
   end

--- a/apps/omg_watcher/test/support/exit_processor/test_helper.ex
+++ b/apps/omg_watcher/test/support/exit_processor/test_helper.ex
@@ -57,13 +57,14 @@ defmodule OMG.Watcher.ExitProcessor.TestHelper do
 
   def start_ife_from(%Core{} = processor, tx, opts \\ []) do
     exit_id = Keyword.get(opts, :exit_id, @exit_id)
-    # `nil`s are unused portions of the returns data from the contract
     status = Keyword.get(opts, :status, active_ife_status())
     status = if status == :inactive, do: inactive_ife_status(), else: status
     {processor, _} = Core.new_in_flight_exits(processor, [ife_event(tx, opts)], [{status, exit_id}])
     processor
   end
 
+  # See `OMG.Eth.RootChain.get_in_flight_exit/2` for reference of where this comes from
+  # `nil`s are unused portions of the returns data from the contract
   def active_ife_status(), do: {nil, 1, nil, nil, nil, nil, nil}
   def inactive_ife_status(), do: {nil, 0, nil, nil, nil, nil, nil}
 

--- a/apps/omg_watcher/test/support/test_helper.ex
+++ b/apps/omg_watcher/test/support/test_helper.ex
@@ -89,8 +89,6 @@ defmodule OMG.Watcher.TestHelper do
   @spec decode16(map(), list()) :: map()
   def decode16(data, keys) do
     keys
-    # FIXME: remove? this allows for errors, but there's a test of `decode16` that actually tests this behavior
-    |> Enum.filter(&Map.has_key?(data, &1))
     |> Enum.into(%{}, &decode16_for_key(data, &1))
     |> (&Map.merge(data, &1)).()
   end
@@ -107,21 +105,12 @@ defmodule OMG.Watcher.TestHelper do
           |> Enum.map(fn {:ok, bin} -> bin end)
 
         {key, bin_list}
-
-      # FIXME: remove? this allows for errors, but there's a test of `decode16` that actually tests this behavior
-      other_value ->
-        {key, other_value}
     end
   end
 
-  # FIXME: remove? this allows for errors, but there's a test of `decode16` that actually tests this behavior
   defp decode_if_possible(value) do
-    value
-    |> Encoding.from_hex()
-    |> case do
-      {:ok, bin} -> bin
-      {:error, :invalid_hex} -> value
-    end
+    {:ok, bin} = Encoding.from_hex(value)
+    bin
   end
 
   def get_balance(address, token) do
@@ -150,7 +139,7 @@ defmodule OMG.Watcher.TestHelper do
 
   def get_exit_data(encoded_position) do
     data = success?("utxo.get_exit_data", %{utxo_pos: encoded_position})
-    decode16(data, ["txbytes", "proof", "sigs"])
+    decode16(data, ["txbytes", "proof"])
   end
 
   def get_exit_challenge(blknum, txindex, oindex) do
@@ -194,7 +183,6 @@ defmodule OMG.Watcher.TestHelper do
 
     decode16(proof_data, [
       "in_flight_txbytes",
-      "in_flight_input_index",
       "spending_txbytes",
       "spending_input_index",
       "spending_sig",

--- a/apps/omg_watcher/test/support/test_helper.ex
+++ b/apps/omg_watcher/test/support/test_helper.ex
@@ -197,7 +197,8 @@ defmodule OMG.Watcher.TestHelper do
       "in_flight_input_index",
       "spending_txbytes",
       "spending_input_index",
-      "spending_sig"
+      "spending_sig",
+      "input_tx"
     ])
   end
 

--- a/apps/omg_watcher/test/support/test_helper.ex
+++ b/apps/omg_watcher/test/support/test_helper.ex
@@ -170,7 +170,7 @@ defmodule OMG.Watcher.TestHelper do
   def get_in_flight_exit_competitors(transaction) do
     competitor_data = success?("in_flight_exit.get_competitor", %{txbytes: Encoding.to_hex(transaction)})
 
-    decode16(competitor_data, ["in_flight_txbytes", "competing_txbytes", "competing_sig", "competing_proof"])
+    decode16(competitor_data, ["in_flight_txbytes", "competing_txbytes", "competing_sig", "competing_proof", "input_tx"])
   end
 
   def get_prove_canonical(transaction) do

--- a/apps/omg_watcher_rpc/lib/web/views/in_flight_exit.ex
+++ b/apps/omg_watcher_rpc/lib/web/views/in_flight_exit.ex
@@ -30,6 +30,7 @@ defmodule OMG.WatcherRPC.Web.View.InFlightExit do
   def render("competitor.json", %{response: competitor}) do
     competitor
     |> Map.update!(:competing_tx_pos, &Utxo.Position.encode/1)
+    |> Map.update!(:input_utxo_pos, &Utxo.Position.encode/1)
     |> Response.serialize()
   end
 

--- a/apps/omg_watcher_rpc/lib/web/views/in_flight_exit.ex
+++ b/apps/omg_watcher_rpc/lib/web/views/in_flight_exit.ex
@@ -41,6 +41,7 @@ defmodule OMG.WatcherRPC.Web.View.InFlightExit do
 
   def render("get_input_challenge_data.json", %{response: challenge_data}) do
     challenge_data
+    |> Map.update!(:input_utxo_pos, &Utxo.Position.encode/1)
     |> Response.serialize()
   end
 

--- a/apps/omg_watcher_rpc/priv/swagger/security_critical_api_specs/in_flight_exit/response_schemas.yaml
+++ b/apps/omg_watcher_rpc/priv/swagger/security_critical_api_specs/in_flight_exit/response_schemas.yaml
@@ -9,9 +9,14 @@ GetInFlightExitDataResponseSchema:
     example:
       data:
         in_flight_tx: '0xf3170101c0940000...'
-        input_txs: '0xa3470101c0940000...'
-        input_txs_inclusion_proofs : '0xcedb8b31d1e4...'
-        in_flight_tx_sigs : '0x6bfb9b2dbe32...'
+        input_txs:
+        - '0xa3470101c0940000...'
+        input_txs_inclusion_proofs:
+        - '0xcedb8b31d1e4...'
+        in_flight_tx_sigs:
+        - '0x6bfb9b2dbe32...'
+        input_utxos_pos:
+        - 300010002001
 
 GetCompetitorResponseSchema:
   allOf:
@@ -30,6 +35,8 @@ GetCompetitorResponseSchema:
         competing_sig: '0xa3470101c0940000...'
         competing_tx_pos: 26000003920000
         competing_proof: '0xcedb8b31d1e4...'
+        input_tx: '0xaaa70101c0940000...'
+        input_utxo_pos: 300010002001
 
 ProveCanonicalResponseSchema:
   allOf:
@@ -60,6 +67,8 @@ InputChallengeDataResponseSchema:
         spending_txbytes: '0x5df13a6bee20000...'
         spending_input_index: 1
         spending_sig: '0xa3470101c0940000...'
+        input_tx: '0xaaa70101c0940000...'
+        input_utxo_pos: 300010002001
 
 OutputChallengeDataResponseSchema:
   allOf:

--- a/apps/omg_watcher_rpc/priv/swagger/security_critical_api_specs/in_flight_exit/schemas.yaml
+++ b/apps/omg_watcher_rpc/priv/swagger/security_critical_api_specs/in_flight_exit/schemas.yaml
@@ -5,14 +5,25 @@ InFlightExitDataSchema:
       type: string
       format: binary
     input_txs:
-      type: string
-      format: binary
+      type: array
+      items:
+        type: string
+        format: binary
     input_txs_inclusion_proofs:
-      type: string
-      format: binary
+      type: array
+      items:
+        type: string
+        format: binary
     in_flight_tx_sigs:
-      type: string
-      format: binary
+      type: array
+      items:
+        type: string
+        format: binary
+    input_utxos_pos:
+      type: array
+      items:
+        type: integer
+        format: int256
 
 CompetitorSchema:
   description: The object schema for a competitor
@@ -38,6 +49,12 @@ CompetitorSchema:
     competing_proof:
       type: string
       format: binary
+    input_tx:
+      type: string
+      format: binary
+    input_utxo_pos:
+      type: integer
+      format: int256
 
 ProveCanonicalSchema:
   description: The object schema for a canonical proof
@@ -71,6 +88,12 @@ InputChallengeDataSchema:
     spending_sig:
       type: string
       format: binary
+    input_tx:
+      type: string
+      format: binary
+    input_utxo_pos:
+      type: integer
+      format: int256
 
 OutputChallengeDataSchema:
   description: The object schema for an output challenge data

--- a/apps/omg_watcher_rpc/priv/swagger/security_critical_api_specs/status/response_schemas.yaml
+++ b/apps/omg_watcher_rpc/priv/swagger/security_critical_api_specs/status/response_schemas.yaml
@@ -15,7 +15,8 @@ StatusResponseSchema:
         last_mined_child_block_number: 11000
         last_seen_eth_block_timestamp: 1558535190
         last_seen_eth_block_number: 4427041
-        contract_addr: '0x44de0ec539b8c4a4b530c78620fe8320167f2f74'
+        contract_addr:
+          plasma_framework: '0x44de0ec539b8c4a4b530c78620fe8320167f2f74'
         eth_syncing: true
         byzantine_events:
         -

--- a/apps/omg_watcher_rpc/priv/swagger/security_critical_api_specs/status/schemas.yaml
+++ b/apps/omg_watcher_rpc/priv/swagger/security_critical_api_specs/status/schemas.yaml
@@ -21,8 +21,12 @@ StatusSchema:
       type: integer
       format: int64
     contract_addr:
-      type: string
-      format: binary
+      type: object
+      additionalProperties: true
+      properties:
+        plasma_framework:
+          type: string
+          format: binary
     eth_syncing:
       type: boolean
     byzantine_events:

--- a/apps/omg_watcher_rpc/priv/swagger/security_critical_api_specs/utxo/response_schemas.yaml
+++ b/apps/omg_watcher_rpc/priv/swagger/security_critical_api_specs/utxo/response_schemas.yaml
@@ -13,6 +13,7 @@ GetUtxoChallengeResponseSchema:
         input_index: 0
         sig: '0x6bfb9b2dbe32...'
         txbytes: '0x3eb6ae5b06f3...'
+        exiting_tx: '0x6d6bda6bd6d6...'
 
 GetUtxoExitResponseSchema:
   description: The response schema for utxo exit data

--- a/apps/omg_watcher_rpc/priv/swagger/security_critical_api_specs/utxo/schemas.yaml
+++ b/apps/omg_watcher_rpc/priv/swagger/security_critical_api_specs/utxo/schemas.yaml
@@ -13,6 +13,9 @@ GetUtxoChallengeSchema:
     txbytes:
       type: string
       format: binary
+    exiting_tx:
+      type: string
+      format: binary
 
 GetUtxoExitSchema:
   type: object
@@ -24,8 +27,5 @@ GetUtxoExitSchema:
       type: string
       format: binary
     proof:
-      type: string
-      format: binary
-    sigs:
       type: string
       format: binary

--- a/apps/omg_watcher_rpc/test/omg_watcher_rpc/web/controllers/in_flight_exit_test.exs
+++ b/apps/omg_watcher_rpc/test/omg_watcher_rpc/web/controllers/in_flight_exit_test.exs
@@ -18,9 +18,9 @@ defmodule OMG.WatcherRPC.Web.Controller.InFlightExitTest do
   use OMG.Fixtures
   use OMG.Watcher.Fixtures
 
-  alias OMG.Utxo
   alias OMG.State.Transaction
   alias OMG.Utils.HttpRPC.Encoding
+  alias OMG.Utxo
   alias OMG.Watcher.TestHelper
 
   require Utxo

--- a/apps/omg_watcher_rpc/test/omg_watcher_rpc/web/controllers/in_flight_exit_test.exs
+++ b/apps/omg_watcher_rpc/test/omg_watcher_rpc/web/controllers/in_flight_exit_test.exs
@@ -18,43 +18,63 @@ defmodule OMG.WatcherRPC.Web.Controller.InFlightExitTest do
   use OMG.Fixtures
   use OMG.Watcher.Fixtures
 
+  alias OMG.Utxo
   alias OMG.State.Transaction
   alias OMG.Utils.HttpRPC.Encoding
   alias OMG.Watcher.TestHelper
+
+  require Utxo
+
   @eth OMG.Eth.RootChain.eth_pseudo_address()
 
   describe "getting in-flight exits" do
     @tag fixtures: [:web_endpoint, :db_initialized, :bob, :alice]
     test "returns properly formatted in-flight exit data", %{bob: bob, alice: alice} do
       test_in_flight_exit_data = fn inputs, expected_input_txs ->
-        in_flight_txbytes =
+        in_flight_txbytes_raw =
           inputs
           |> OMG.TestHelper.create_encoded(@eth, [{bob, 100}])
-          |> Encoding.to_hex()
+
+        in_flight_txbytes = Encoding.to_hex(in_flight_txbytes_raw)
 
         # `2 + ` for prepending `0x` in HEX encoded binaries
-        proofs_size = 2 + 1024 * length(inputs)
-        sigs_size = 2 + 130 * length(inputs)
+        proofs_size = 2 + 16 * 32 * 2
+        sigs_size = 2 + 130
+
+        in_flight_raw_txbytes =
+          in_flight_txbytes_raw |> Transaction.Signed.decode!() |> Transaction.raw_txbytes() |> Encoding.to_hex()
 
         # checking just lengths in majority as we prepare verify correctness in the contract in integration tests
         assert %{
-                 "in_flight_tx" => _in_flight_tx,
+                 "in_flight_tx" => ^in_flight_raw_txbytes,
                  "input_txs" => input_txs,
+                 "input_utxos_pos" => input_utxos_pos,
                  # encoded proofs, 1024 bytes each
-                 "input_txs_inclusion_proofs" => <<_proof::bytes-size(proofs_size)>>,
+                 "input_txs_inclusion_proofs" => proofs,
                  # encoded signatures, 130 bytes each
-                 "in_flight_tx_sigs" => <<_bytes::bytes-size(sigs_size)>>
+                 "in_flight_tx_sigs" => sigs
+                 # FIXME: leverage the test helper for hex and stuff
                } = TestHelper.success?("/in_flight_exit.get_data", %{"txbytes" => in_flight_txbytes})
-
-        {:ok, input_txs} = Encoding.from_hex(input_txs)
 
         input_txs =
           input_txs
-          |> ExRLP.decode()
-          |> Enum.filter(&(&1 != ""))
-          |> Enum.map(&ExRLP.encode/1)
+          |> Enum.map(&Encoding.from_hex/1)
+          |> Enum.map(fn {:ok, decoded} -> decoded end)
           |> Enum.map(&Transaction.decode!/1)
 
+        assert Enum.count(input_txs) == Enum.count(inputs)
+        assert Enum.count(input_utxos_pos) == Enum.count(inputs)
+        assert Enum.count(proofs) == Enum.count(inputs)
+        assert Enum.count(sigs) == Enum.count(inputs)
+
+        input_utxos_pos
+        |> Enum.map(&Utxo.Position.decode!/1)
+        |> Enum.zip(inputs)
+        # assert true because we just want to pattern match both positions against each other
+        |> Enum.each(fn {Utxo.position(blknum, txindex, oindex), {blknum, txindex, oindex, _}} -> assert true end)
+
+        Enum.each(proofs, fn proof -> assert byte_size(proof) == proofs_size end)
+        Enum.each(sigs, fn sig -> assert byte_size(sig) == sigs_size end)
         assert input_txs == expected_input_txs
       end
 


### PR DESCRIPTION
EDIT: pdobacz: for full PR description see below. The opening comment is Paweł's original draft PR's comment :point_down: 

Beginning of the journey to integrate ALD's inflight exits

Changes between old IFE events and ALD's ones -> check this [gist](https://gist.github.com/pnowosie/18c8cdf10fffa123f4aaeaa0ce203689)

I managed:
- [root_chain.ex](https://github.com/omisego/elixir-omg/pull/1032/commits/698b1d423397de876eb66a829b160b433b09c0f2) - which fetches lists of new events for both `inputs/outputs` and concatenate them
- started to change [inflight_exit_info](https://github.com/omisego/elixir-omg/pull/1032/commits/afd038e2e8150b8f54e0dfce68d89287692ead6a) where `output_index` is expressed as a 
tuple: `{:input | :output, oindex}`