### PR TITLE
fix: prevent flaky byzantine events test, dirty

### DIFF
--- a/apps/omg_performance/lib/omg_performance/byzantine_events.ex
+++ b/apps/omg_performance/lib/omg_performance/byzantine_events.ex
@@ -98,6 +98,10 @@ defmodule OMG.Performance.ByzantineEvents do
 
   def watcher_synchronize(watcher_url \\ @watcher_url) do
     Eth.WaitFor.repeat_until_ok(fn -> watcher_synchronized?(watcher_url) end)
+    # NOTE: allowing some more time for the dust to settle on the synced Watcher
+    # otherwise some of the freshest UTXOs to exit will appear as missing on the Watcher
+    # related issue to remove this `sleep` and fix properly is https://github.com/omisego/elixir-omg/issues/1031
+    Process.sleep(2000)
   end
 
   defp valid_exit_data({:ok, response}), do: valid_exit_data(response)


### PR DESCRIPTION
Workaround for #1031, but not a fix to the root cause yet.

## Overview

Sleeping a while makes it pass rather reliably, but I'm leaving up to #1031 to investigate why.

Note the intention here is just to allow us to CI reliably for the time being. Proper fix is still required.

## Changes

Allows the dust to settle after the watcher having been synchronized using a `Process.sleep`

## Testing

```
mix test --only integration test/omg_performance/integration/byzantine_event_test.exs
```

many times