### PR TITLE
refactor: clean TODOs - remove stale ones and fix easy ones

### DIFF
--- a/apps/omg/lib/omg/dev_crypto.ex
+++ b/apps/omg/lib/omg/dev_crypto.ex
@@ -64,7 +64,6 @@ defmodule OMG.DevCrypto do
   Produces a stand-alone, 65 bytes long, signature for a given transaction.
   """
   @spec signature(Transaction.Protocol.t(), Crypto.priv_key_t()) :: Crypto.sig_t()
-  def signature(_tx, <<>>), do: <<0::size(520)>>
   def signature(tx, priv), do: do_signature(tx, priv)
 
   defp do_signature(%{} = tx, priv) do

--- a/apps/omg/lib/omg/fees.ex
+++ b/apps/omg/lib/omg/fees.ex
@@ -63,12 +63,8 @@ defmodule OMG.Fees do
   @spec for_transaction(Transaction.Recovered.t(), fee_t()) :: fee_t()
   def for_transaction(transaction, fee_map) do
     case MergeTransactionValidator.is_merge_transaction?(transaction) do
-      true ->
-        :no_fees_required
-
-      # TODO: reducing fees to output currencies only is incorrect, let's deffer until fees get large
-      false ->
-        fee_map
+      true -> :no_fees_required
+      false -> fee_map
     end
   end
 end

--- a/apps/omg/lib/omg/state/transaction/signed.ex
+++ b/apps/omg/lib/omg/state/transaction/signed.ex
@@ -25,7 +25,6 @@ defmodule OMG.State.Transaction.Signed do
   alias OMG.TypedDataHash
 
   @type tx_bytes() :: binary()
-  @empty_signature <<0::size(520)>>
 
   defstruct [:raw_tx, :sigs]
 
@@ -80,9 +79,6 @@ defmodule OMG.State.Transaction.Signed do
 
   defp get_reversed_witnesses(raw_txhash, raw_tx, raw_witnesses) do
     raw_witnesses
-    # TODO: move this check out of here and make generic?
-    #       (or remove altogether - this covers the padding using empty signatures, which might be going away)
-    |> Enum.filter(fn raw_witness -> raw_witness != @empty_signature end)
     |> Enum.reduce_while({:ok, []}, fn raw_witness, acc -> get_witness(raw_txhash, raw_tx, raw_witness, acc) end)
   end
 

--- a/apps/omg/test/omg/fees_test.exs
+++ b/apps/omg/test/omg/fees_test.exs
@@ -55,16 +55,19 @@ defmodule OMG.FeesTest do
       refute Fees.covered?(%{other_currency => 100}, @fees)
     end
 
-    # TODO: Fix this test?
     @tag fixtures: [:alice, :bob]
-    test "returns true when one input is dedicated for fee payment", %{alice: alice, bob: bob} do
+    test "returns true when one input is dedicated for fee payment, and outputs are other tokens",
+         %{alice: alice, bob: bob} do
+      # a token that we don't allow to pay the fees in
       other_token = <<2::160>>
 
+      # it is presumed that one input is `other_token` (to cover outputs) and the other input is `@not_eth` to cover
+      # the fee only. Note that `@not_eth` doesn't appear in the outputs
       transaction =
         create_recovered([{1, 0, 0, alice}, {2, 0, 0, alice}], [{bob, other_token, 5}, {alice, other_token, 5}])
 
       fees = Fees.for_transaction(transaction, @fees)
-
+      # here we tell `Fees` that 5 `@not_eth` was sent to cover the fee
       assert Fees.covered?(%{@not_eth => 5, other_token => 0}, fees)
     end
   end

--- a/apps/omg/test/omg/state/transaction_test.exs
+++ b/apps/omg/test/omg/state/transaction_test.exs
@@ -78,7 +78,7 @@ defmodule OMG.State.TransactionTest do
       state_alice_deposit: state
     } do
       Transaction.Payment.new([{1, 0, 0}], [{bob.addr, @eth, 4}])
-      |> DevCrypto.sign([alice.priv, <<>>])
+      |> DevCrypto.sign([alice.priv])
       |> assert_tx_usable(state)
     end
 

--- a/apps/omg/test/support/test_helper.ex
+++ b/apps/omg/test/support/test_helper.ex
@@ -165,11 +165,6 @@ defmodule OMG.TestHelper do
     {:ok, full_path, file}
   end
 
-  defp get_private_keys(inputs) do
-    filler = List.duplicate(<<>>, 4 - length(inputs))
-
-    inputs
-    |> Enum.map(fn {_, _, _, owner} -> owner.priv end)
-    |> Enum.concat(filler)
-  end
+  defp get_private_keys(inputs),
+    do: Enum.map(inputs, fn {_, _, _, owner} -> owner.priv end)
 end

--- a/apps/omg_child_chain/test/omg_child_chain/integration/happy_path_test.exs
+++ b/apps/omg_child_chain/test/omg_child_chain/integration/happy_path_test.exs
@@ -47,14 +47,14 @@ defmodule OMG.ChildChain.Integration.HappyPathTest do
   } do
     raw_tx = Transaction.Payment.new([{deposit_blknum, 0, 0}], [{bob.addr, @eth, 7}, {alice.addr, @eth, 3}], <<0::256>>)
 
-    tx = raw_tx |> OMG.TestHelper.sign_encode([alice.priv, <<>>])
+    tx = raw_tx |> OMG.TestHelper.sign_encode([alice.priv])
     # spend the deposit
     assert {:ok, %{"blknum" => spend_child_block}} = submit_transaction(tx)
 
     token_raw_tx =
       Transaction.Payment.new([{token_deposit_blknum, 0, 0}], [{bob.addr, token, 8}, {alice.addr, token, 2}])
 
-    token_tx = token_raw_tx |> OMG.TestHelper.sign_encode([alice.priv, <<>>])
+    token_tx = token_raw_tx |> OMG.TestHelper.sign_encode([alice.priv])
     # spend the token deposit
     assert {:ok, %{"blknum" => spend_token_child_block}} = submit_transaction(token_tx)
 

--- a/apps/omg_eth/lib/omg_eth/release_tasks/set_contract.ex
+++ b/apps/omg_eth/lib/omg_eth/release_tasks/set_contract.ex
@@ -81,7 +81,6 @@ defmodule OMG.Eth.ReleaseTasks.SetContract do
   end
 
   defp apply_static_settings(network) do
-    # TODO: not so easy here - rethink how do we allow to set the contracts via the system ENV, for now assuming json
     network =
       case String.upcase(network) do
         "RINKEBY" = network ->

--- a/apps/omg_performance/lib/omg_performance/sender_server.ex
+++ b/apps/omg_performance/lib/omg_performance/sender_server.ex
@@ -128,7 +128,7 @@ defmodule OMG.Performance.SenderServer do
     # create and return signed transaction
     [{last_tx.blknum, last_tx.txindex, last_tx.oindex}]
     |> Transaction.Payment.new([{spender.addr, @eth, newamount}, {recipient.addr, @eth, to_spend}])
-    |> DevCrypto.sign([spender.priv, <<>>])
+    |> DevCrypto.sign([spender.priv])
   end
 
   # Submits new transaction to the blockchain server.

--- a/apps/omg_performance/test/omg_performance/integration/performance_test.exs
+++ b/apps/omg_performance/test/omg_performance/integration/performance_test.exs
@@ -35,7 +35,7 @@ defmodule OMG.PerformanceTest do
   end
 
   @tag fixtures: [:destdir]
-  test "Smoke test - run start_simple_perf and see if it don't crash", %{destdir: destdir} do
+  test "Smoke test - run start_simple_perf and see if it doesn't crash", %{destdir: destdir} do
     ntxs = 3000
     nsenders = 2
     assert :ok = OMG.Performance.start_simple_perftest(ntxs, nsenders, %{destdir: destdir})
@@ -45,7 +45,8 @@ defmodule OMG.PerformanceTest do
   end
 
   @tag fixtures: [:destdir, :contract, :omg_child_chain, :alice, :bob]
-  test "Smoke test - run start_extended_perf and see if it don't crash", %{
+  @tag timeout: 120_000
+  test "Smoke test - run start_extended_perf and see if it doesn't crash", %{
     destdir: destdir,
     contract: contract,
     alice: alice,
@@ -62,7 +63,7 @@ defmodule OMG.PerformanceTest do
   end
 
   @tag fixtures: [:destdir]
-  test "Smoke test - run start_simple_perf and see if it don't crash - with profiling", %{destdir: destdir} do
+  test "Smoke test - run start_simple_perf and see if it doesn't crash - with profiling", %{destdir: destdir} do
     ntxs = 3
     nsenders = 2
 
@@ -84,7 +85,7 @@ defmodule OMG.PerformanceTest do
   end
 
   @tag fixtures: [:destdir]
-  test "Smoke test - run start_simple_perf and see if it don't crash - overiding block creation", %{destdir: destdir} do
+  test "Smoke test - run start_simple_perf and see if it doesn't crash - overiding block creation", %{destdir: destdir} do
     ntxs = 3000
     nsenders = 2
     assert :ok = OMG.Performance.start_simple_perftest(ntxs, nsenders, %{destdir: destdir, block_every_ms: 3000})

--- a/apps/omg_watcher/lib/omg_watcher/exit_processor/core.ex
+++ b/apps/omg_watcher/lib/omg_watcher/exit_processor/core.ex
@@ -156,9 +156,8 @@ defmodule OMG.Watcher.ExitProcessor.Core do
     |> Enum.map(fn %{utxo_pos: utxo_pos} = _finalization_info -> Utxo.Position.decode!(utxo_pos) end)
   end
 
-  # TODO: syncing problem (look new exits)
   @doc """
-   Add new in flight exits from Ethereum events into tracked state.
+  Add new in flight exits from Ethereum events into tracked state.
   """
   @spec new_in_flight_exits(t(), list(map()), list(map())) :: {t(), list()} | {:error, :unexpected_events}
   def new_in_flight_exits(state, new_ifes_events, contract_statuses)

--- a/apps/omg_watcher/lib/omg_watcher/exit_processor/tools.ex
+++ b/apps/omg_watcher/lib/omg_watcher/exit_processor/tools.ex
@@ -43,9 +43,6 @@ defmodule OMG.Watcher.ExitProcessor.Tools do
   # (i.e. those not checked are assumed to be present)
   def only_utxos_checked_and_missing(utxo_positions, utxo_exists?) do
     # the default value below is true, so that the assumption is that utxo not checked is **present**
-    # TODO: rather inefficient, but no as inefficient as the nested `filter` calls in searching for competitors
-    #       consider optimizing using `MapSet`
-
     Enum.filter(utxo_positions, fn utxo_pos -> !Map.get(utxo_exists?, utxo_pos, true) end)
   end
 

--- a/apps/omg_watcher/test/omg_watcher/exit_processor/piggyback_test.exs
+++ b/apps/omg_watcher/test/omg_watcher/exit_processor/piggyback_test.exs
@@ -118,7 +118,7 @@ defmodule OMG.Watcher.ExitProcessor.PiggybackTest do
       tx = Transaction.Payment.new([{1, 0, 0}], [])
       txbytes = txbytes(tx)
       # superfluous signatures
-      %{sigs: sigs} = signed_tx = OMG.DevCrypto.sign(tx, [alice.priv, alice.priv, alice.priv])
+      %{sigs: sigs} = signed_tx = OMG.DevCrypto.sign(tx, [alice.priv])
       processor = processor |> start_ife_from(signed_tx, sigs: sigs)
 
       assert {:ok, [%Event.PiggybackAvailable{txbytes: ^txbytes}]} =

--- a/apps/omg_watcher_rpc/test/omg_watcher_rpc/web/controllers/in_flight_exit_test.exs
+++ b/apps/omg_watcher_rpc/test/omg_watcher_rpc/web/controllers/in_flight_exit_test.exs
@@ -34,7 +34,7 @@ defmodule OMG.WatcherRPC.Web.Controller.InFlightExitTest do
 
         # `2 + ` for prepending `0x` in HEX encoded binaries
         proofs_size = 2 + 1024 * length(inputs)
-        sigs_size = 2 + 130 * 4
+        sigs_size = 2 + 130 * length(inputs)
 
         # checking just lengths in majority as we prepare verify correctness in the contract in integration tests
         assert %{


### PR DESCRIPTION
## Overview

As title:
 - no need for padding with empty signatures
 - explain the test of one cornercase test in FeesTest
 - remove some completetly stale ones
 - prevent `performance_test.exs` from timeouting - they were just under the timeout threshold. It went over the threshold when going ALD

## Changes

...

## Testing

usual testing, `mix test` mainly