### PR TITLE
fix: standardise image hash

### DIFF
--- a/.circleci/ci_deploy.sh
+++ b/.circleci/ci_deploy.sh
@@ -45,7 +45,7 @@ gcloud auth activate-service-account --key-file="$GCPFILE"
 gcloud config set project "$GCP_ACCOUNT_ID"
 gcloud config set compute/zone ${GCP_ZONE}
 gcloud container clusters get-credentials ${GCP_CLUSTER_DEVELOPMENT}
-image_tag="$(printf "%s" "$CIRCLE_SHA1" | head -c 8)"
+image_tag="$(printf "%s" "$CIRCLE_SHA1" | head -c 7)"
 if [ "$DEPLOY" = "watcher" ]; then
 
     kubectl set image statefulset watcher watcher=omisego/watcher:${image_tag}

--- a/.circleci/ci_publish.sh
+++ b/.circleci/ci_publish.sh
@@ -29,7 +29,7 @@ fi
 ##
 
 if [ -n "$CIRCLE_SHA1" ]; then
-    _image_tag="$(printf "%s" "$CIRCLE_SHA1" | head -c 8)"
+    _image_tag="$(printf "%s" "$CIRCLE_SHA1" | head -c 7)"
 fi
 
 if [ -n "$CIRCLE_TAG" ]; then


### PR DESCRIPTION


## Overview

Aligning docker hash tag images with github 7 chars.

## Changes

Creating and tagging

## Testing

/
