### PR TITLE
fix: plasma deployer fix and watcher without ALD for community

### DIFF
--- a/docker-compose-watcher.yml
+++ b/docker-compose-watcher.yml
@@ -16,7 +16,8 @@ services:
       retries: 5
 
   watcher:
-    image: omisego/watcher:latest
+    #last stable staging and production watcher without ALD
+    image: omisego/watcher:3fbb3f1e
     command: "full_local"
     environment:
       - ETHEREUM_RPC_URL=https://rinkeby.infura.io/v3/${INFURA_API_KEY}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,8 @@ services:
       retries: 5
 
   plasma-deployer:
-    image: omisego/plasma-deployer:c7266b7
+    # plasma-deployer points to fb7109a9e823b998c20484deac8609cda425218a, which is a branch of 7b8a2643568556c1d126749724666bc37edc8141
+    image: omisego/plasma-deployer:3314a71
     environment:
       - ETH_CLIENT_HOST=geth
     ports:


### PR DESCRIPTION

## Overview

Unbreak docker-compose to use the contracts + plasma-deployer from mix.lock plasma_contracts SHA.

## Changes

- Plasma-deployer
- Watcher for community to use the last master build before ALD 

## Testing
/
