### PR TITLE
Experiment with UTXO subsets to get closer to zero-downtime

### DIFF
--- a/apps/omg/lib/omg/state.ex
+++ b/apps/omg/lib/omg/state.ex
@@ -21,6 +21,7 @@ defmodule OMG.State do
   alias OMG.DB
   alias OMG.Eth
   alias OMG.Fees
+  alias OMG.InputPointer
   alias OMG.State.Core
   alias OMG.State.Transaction
   alias OMG.State.Transaction.Validator
@@ -90,19 +91,17 @@ defmodule OMG.State do
     # Get data essential for the State and Blockgetter. And it takes a while. TODO - measure it!
     # Our approach is simply blocking the supervision boot tree
     # until we've processed history.
-    {:ok, utxos_query_result} = DB.utxos()
     {:ok, height_query_result} = DB.get_single_value(:child_top_block_number)
     {:ok, last_deposit_query_result} = DB.get_single_value(:last_deposit_child_blknum)
-    {:ok, [utxos_query_result, height_query_result, last_deposit_query_result], {:continue, :setup}}
+    {:ok, [height_query_result, last_deposit_query_result], {:continue, :setup}}
   end
 
-  def handle_continue(:setup, [utxos_query_result, height_query_result, last_deposit_query_result]) do
+  def handle_continue(:setup, [height_query_result, last_deposit_query_result]) do
     {:ok, child_block_interval} = Eth.RootChain.get_child_block_interval()
 
     {:ok, state} =
       with {:ok, _data} = result <-
              Core.extract_initial_state(
-               utxos_query_result,
                height_query_result,
                last_deposit_query_result,
                child_block_interval
@@ -139,13 +138,37 @@ defmodule OMG.State do
   Checks (stateful validity) and executes a spend transaction. Assuming stateless validity!
   """
   def handle_call({:exec, tx, fees}, _from, state) do
-    case Core.exec(state, tx, fees) do
-      {:ok, tx_result, new_state} ->
-        {:reply, {:ok, tx_result}, new_state}
+    utxos_query_result =
+      tx |> Transaction.get_inputs() |> Enum.reject(&Core.utxo_exists?(&1, state)) |> Enum.map(&utxo_from_db/1)
+
+    state
+    # FIXME: put the above logic into a `Core.get_exec_db_queries` w/ unit tests
+    # FIXME: testy, testy
+    # FIXME: what if utxo is not found? it must be handled properly and tested
+    |> Core.with_utxos(utxos_query_result)
+    |> Core.exec(tx, fees)
+    # FIXME must write pending txs to disk every time an exec goes through. Form block must flush those
+    #       think how to read them back for full block accountability on fail-overs and upgrades
+    #       IDEA: write pending tx on every `exec` and keep it in state too. On every `form_block`,
+    #             check in-memory pending state:
+    #             If it's empty, then read from DB (it's a failover, so I've not been in the master)
+    #             If it isn't empty, just use it, (normal operation, I've been in the master)
+    # FIXME cleany, cleany
+    |> case do
+      {:ok, tx_result, %Core{utxo_db_updates: db_updates} = new_state} ->
+        :ok = DB.multi_update(db_updates)
+        # FIXME move elsewhere?
+        {:reply, {:ok, tx_result}, %Core{new_state | utxo_db_updates: []}}
 
       {tx_result, new_state} ->
         {:reply, tx_result, new_state}
     end
+  end
+
+  # FIXME: move
+  defp utxo_from_db(input_pointer) do
+    {:ok, utxo_kv} = DB.utxo(InputPointer.Protocol.to_db_key(input_pointer))
+    utxo_kv
   end
 
   @doc """

--- a/apps/omg/lib/omg/state/core.ex
+++ b/apps/omg/lib/omg/state/core.ex
@@ -18,7 +18,7 @@ defmodule OMG.State.Core do
   All spend transactions, deposits and exits should sync on this for validity of moving funds.
   """
 
-  defstruct [:height, :last_deposit_child_blknum, :utxos, pending_txs: [], tx_index: 0, utxo_db_updates: []]
+  defstruct [:height, :last_deposit_child_blknum, utxos: %{}, pending_txs: [], tx_index: 0, utxo_db_updates: []]
 
   alias OMG.Block
   alias OMG.Crypto
@@ -101,33 +101,26 @@ defmodule OMG.State.Core do
   Recovers the ledger's state from data delivered by the `OMG.DB`
   """
   @spec extract_initial_state(
-          utxos_query_result :: [list({OMG.DB.utxo_pos_db_t(), OMG.Utxo.t()})],
           height_query_result :: non_neg_integer() | :not_found,
           last_deposit_child_blknum_query_result :: non_neg_integer() | :not_found,
           child_block_interval :: pos_integer()
         ) :: {:ok, t()} | {:error, :last_deposit_not_found | :top_block_number_not_found}
   def extract_initial_state(
-        utxos_query_result,
         height_query_result,
         last_deposit_child_blknum_query_result,
         child_block_interval
       )
-      when is_list(utxos_query_result) and is_integer(height_query_result) and
+      when is_integer(height_query_result) and
              is_integer(last_deposit_child_blknum_query_result) and is_integer(child_block_interval) do
     # extract height, last deposit height and utxos from query result
     height = height_query_result + child_block_interval
 
-    state = %__MODULE__{
-      height: height,
-      last_deposit_child_blknum: last_deposit_child_blknum_query_result,
-      utxos: UtxoSet.init(utxos_query_result)
-    }
+    state = %__MODULE__{height: height, last_deposit_child_blknum: last_deposit_child_blknum_query_result}
 
     {:ok, state}
   end
 
   def extract_initial_state(
-        _utxos_query_result,
         _height_query_result,
         :not_found,
         _child_block_interval
@@ -136,13 +129,17 @@ defmodule OMG.State.Core do
   end
 
   def extract_initial_state(
-        _utxos_query_result,
         :not_found,
         _last_deposit_child_blknum_query_result,
         _child_block_interval
       ) do
     {:error, :top_block_number_not_found}
   end
+
+  @spec with_utxos(t(), list({OMG.DB.utxo_pos_db_t(), OMG.Utxo.t()})) :: t()
+  # FIXME: the merge should probably be done by UtxoSet
+  def with_utxos(%Core{utxos: utxos} = state, utxos_query_result),
+    do: %{state | utxos: Map.merge(utxos, UtxoSet.init(utxos_query_result))}
 
   @doc """
   Includes the transaction into the state when valid, rejects otherwise.

--- a/apps/omg/mix.exs
+++ b/apps/omg/mix.exs
@@ -26,7 +26,6 @@ defmodule OMG.MixProject do
 
   # Specifies which paths to compile per environment.
   defp elixirc_paths(:prod), do: ["lib"]
-  defp elixirc_paths(:dev), do: ["lib"]
   defp elixirc_paths(_), do: ["lib", "test/support"]
 
   defp deps do

--- a/apps/omg/test/fixtures.exs
+++ b/apps/omg/test/fixtures.exs
@@ -33,7 +33,7 @@ defmodule OMG.Fixtures do
 
   deffixture state_empty() do
     {:ok, child_block_interval} = OMG.Eth.RootChain.get_child_block_interval()
-    {:ok, state} = Core.extract_initial_state(0, 0, child_block_interval)
+    {:ok, state} = Core.extract_initial_state(0, 0, [], child_block_interval)
     state
   end
 

--- a/apps/omg/test/fixtures.exs
+++ b/apps/omg/test/fixtures.exs
@@ -33,7 +33,7 @@ defmodule OMG.Fixtures do
 
   deffixture state_empty() do
     {:ok, child_block_interval} = OMG.Eth.RootChain.get_child_block_interval()
-    {:ok, state} = Core.extract_initial_state([], 0, 0, child_block_interval)
+    {:ok, state} = Core.extract_initial_state(0, 0, child_block_interval)
     state
   end
 

--- a/apps/omg/test/omg/state/core_test.exs
+++ b/apps/omg/test/omg/state/core_test.exs
@@ -259,11 +259,11 @@ defmodule OMG.State.CoreTest do
   end
 
   test "extract_initial_state function returns error when passed last deposit as :not_found" do
-    assert {:error, :last_deposit_not_found} = Core.extract_initial_state([], 0, :not_found, @interval)
+    assert {:error, :last_deposit_not_found} = Core.extract_initial_state(0, :not_found, @interval)
   end
 
   test "extract_initial_state function returns error when passed top block number as :not_found" do
-    assert {:error, :top_block_number_not_found} = Core.extract_initial_state([], :not_found, 0, @interval)
+    assert {:error, :top_block_number_not_found} = Core.extract_initial_state(:not_found, 0, @interval)
   end
 
   @tag fixtures: [:alice, :bob, :state_empty]

--- a/apps/omg/test/omg/state/core_test.exs
+++ b/apps/omg/test/omg/state/core_test.exs
@@ -259,11 +259,11 @@ defmodule OMG.State.CoreTest do
   end
 
   test "extract_initial_state function returns error when passed last deposit as :not_found" do
-    assert {:error, :last_deposit_not_found} = Core.extract_initial_state(0, :not_found, @interval)
+    assert {:error, :last_deposit_not_found} = Core.extract_initial_state(0, :not_found, [], @interval)
   end
 
   test "extract_initial_state function returns error when passed top block number as :not_found" do
-    assert {:error, :top_block_number_not_found} = Core.extract_initial_state(:not_found, 0, @interval)
+    assert {:error, :top_block_number_not_found} = Core.extract_initial_state(:not_found, 0, [], @interval)
   end
 
   @tag fixtures: [:alice, :bob, :state_empty]
@@ -729,10 +729,11 @@ defmodule OMG.State.CoreTest do
     assert {@blknum1, true} = Core.get_status(state)
 
     # when we execute a tx it isn't at the beginning
-    {:ok, _, state} =
+    state =
       state
       |> do_deposit(alice, %{amount: 10, currency: @eth, blknum: 1})
       |> Core.exec(create_recovered([{1, 0, 0, alice}], @eth, [{alice, 10}]), :no_fees_required)
+      |> success?
 
     assert {@blknum1, false} = Core.get_status(state)
 
@@ -827,7 +828,7 @@ defmodule OMG.State.CoreTest do
   end
 
   defp success?(result) do
-    assert {:ok, _, state} = result
+    assert {:ok, _, state, _} = result
     state
   end
 

--- a/apps/omg/test/omg/state/persistence_test.exs
+++ b/apps/omg/test/omg/state/persistence_test.exs
@@ -164,10 +164,8 @@ defmodule OMG.State.PersistenceTest do
     {:ok, last_deposit_query_result} = OMG.DB.get_single_value(:last_deposit_child_blknum, db_pid)
     {:ok, utxos_query_result} = OMG.DB.utxos(db_pid)
 
-    {:ok, state} =
-      Core.extract_initial_state(utxos_query_result, height_query_result, last_deposit_query_result, @interval)
-
-    state
+    {:ok, state} = Core.extract_initial_state(height_query_result, last_deposit_query_result, @interval)
+    Core.with_utxos(state, utxos_query_result)
   end
 
   defp persist_deposit(state, deposits, db_pid) do

--- a/apps/omg/test/omg/state/transaction_test.exs
+++ b/apps/omg/test/omg/state/transaction_test.exs
@@ -328,7 +328,7 @@ defmodule OMG.State.TransactionTest do
 
   defp assert_tx_usable(signed, state_core) do
     {:ok, transaction} = signed |> Transaction.Signed.encode() |> Transaction.Recovered.recover_from()
-    assert {:ok, {_, _, _}, _state} = State.Core.exec(state_core, transaction, :no_fees_required)
+    assert {:ok, {_, _, _}, _state, _db_updates} = State.Core.exec(state_core, transaction, :no_fees_required)
   end
 
   defp parametrized_tester({inputs, outputs}) do

--- a/apps/omg_db/lib/db.ex
+++ b/apps/omg_db/lib/db.ex
@@ -36,6 +36,7 @@ defmodule OMG.DB do
   @callback competitors_info() :: {:ok, list(term)}
   @callback exit_info({pos_integer, non_neg_integer, non_neg_integer}) :: {:ok, map} | {:error, atom}
   @callback spent_blknum(utxo_pos_db_t()) :: {:ok, pos_integer} | {:error, atom}
+  @callback mempool_tx(non_neg_integer) :: {:ok, binary} | :not_found
   @callback block_hashes(integer()) :: list()
   @callback last_deposit_child_blknum() :: list()
   @callback child_top_block_number() :: {:ok, non_neg_integer()}
@@ -52,6 +53,7 @@ defmodule OMG.DB do
   @callback exit_info({pos_integer, non_neg_integer, non_neg_integer}, GenServer.server()) ::
               {:ok, map} | {:error, atom}
   @callback spent_blknum(utxo_pos_db_t(), GenServer.server()) :: {:ok, pos_integer} | {:error, atom}
+  @callback mempool_tx(non_neg_integer, GenServer.server()) :: {:ok, binary} | :not_found
   @callback block_hashes(integer(), GenServer.server()) :: list()
   @callback last_deposit_child_blknum(GenServer.server()) :: list()
   @callback child_top_block_number(GenServer.server()) :: {:ok, non_neg_integer()}
@@ -66,6 +68,7 @@ defmodule OMG.DB do
                       competitors_info: 1,
                       exit_info: 2,
                       spent_blknum: 2,
+                      mempool_tx: 2,
                       block_hashes: 2,
                       last_deposit_child_blknum: 1,
                       child_top_block_number: 1
@@ -116,6 +119,9 @@ defmodule OMG.DB do
 
   def spent_blknum(utxo_pos), do: driver().spent_blknum(utxo_pos)
   def spent_blknum(utxo_pos, server), do: driver().spent_blknum(utxo_pos, server)
+
+  def mempool_tx(tx_index), do: driver().mempool_tx(tx_index)
+  def mempool_tx(tx_index, server), do: driver().mempool_tx(tx_index, server)
 
   def block_hashes(block_numbers_to_fetch), do: driver().block_hashes(block_numbers_to_fetch)
   def block_hashes(block_numbers_to_fetch, server), do: driver().block_hashes(block_numbers_to_fetch, server)

--- a/apps/omg_db/lib/omg_db/rocks_db.ex
+++ b/apps/omg_db/lib/omg_db/rocks_db.ex
@@ -102,6 +102,11 @@ if Code.ensure_loaded?(:rocksdb) do
       GenServer.call(server_name, {:spent_blknum, utxo_pos})
     end
 
+    @spec mempool_tx(non_neg_integer(), atom) :: {:ok, binary} | :not_found
+    def mempool_tx(tx_index, server_name \\ @server_name) do
+      GenServer.call(server_name, {:mempool_tx, tx_index})
+    end
+
     def block_hashes(block_numbers_to_fetch, server_name \\ @server_name) do
       GenServer.call(server_name, {:block_hashes, block_numbers_to_fetch})
     end

--- a/apps/omg_db/lib/omg_db/rocksdb/core.ex
+++ b/apps/omg_db/lib/omg_db/rocksdb/core.ex
@@ -34,6 +34,8 @@ if Code.ensure_loaded?(:rocksdb) do
       utxo: "utxoi",
       # watcher and child chain
       exit_info: "exiti",
+      # watcher and child chain
+      mempool_tx: "mempo",
       # watcher only
       in_flight_exit_info: "infle",
       # watcher only
@@ -83,6 +85,7 @@ if Code.ensure_loaded?(:rocksdb) do
     defp key_for_item(:block, %{hash: hash} = _block), do: key(:block, hash)
     defp key_for_item(:utxo, {position, _utxo}), do: key(:utxo, position)
     defp key_for_item(:spend, {position, _blknum}), do: key(:spend, position)
+    defp key_for_item(:mempool_tx, {tx_index, _tx}), do: key(:mempool_tx, tx_index)
     defp key_for_item(:exit_info, {position, _exit_info}), do: key(:exit_info, position)
     defp key_for_item(:in_flight_exit_info, {position, _info}), do: key(:in_flight_exit_info, position)
     defp key_for_item(:competitor_info, {position, _info}), do: key(:competitor_info, position)

--- a/apps/omg_db/lib/omg_db/rocksdb/server.ex
+++ b/apps/omg_db/lib/omg_db/rocksdb/server.ex
@@ -93,6 +93,7 @@ if Code.ensure_loaded?(:rocksdb) do
 
     def handle_call({:exit_info, utxo_pos}, _from, state), do: do_exit_info(utxo_pos, state)
     def handle_call({:spent_blknum, utxo_pos}, _from, state), do: do_spent_blknum(utxo_pos, state)
+    def handle_call({:mempool_tx, tx_index}, _from, state), do: do_mempool_tx(tx_index, state)
 
     # WARNING, terminate below will be called only if :trap_exit is set to true
     def terminate(_reason, %__MODULE__{db_ref: db_ref}), do: :ok = :rocksdb.close(db_ref)
@@ -179,6 +180,16 @@ if Code.ensure_loaded?(:rocksdb) do
         |> Core.key(utxo_pos)
         |> get(state)
         |> Core.decode_value(:spend)
+
+      {:reply, result, state}
+    end
+
+    defp do_mempool_tx(tx_index, state) do
+      result =
+        :mempool_tx
+        |> Core.key(tx_index)
+        |> get(state)
+        |> Core.decode_value(:mempool_tx)
 
       {:reply, result, state}
     end

--- a/apps/omg_performance/config/dev.exs
+++ b/apps/omg_performance/config/dev.exs
@@ -1,3 +1,8 @@
 use Mix.Config
 
+config :omg_eth,
+  # Needed for test only to have some value of address when `:contract_address` is not set explicitly
+  # required by the EIP-712 struct hash code
+  contract_addr: %{plasma_framework: "0x0000000000000000000000000000000000000001"}
+
 config :omg_eth, node_logging_in_debug: false

--- a/apps/omg_performance/lib/performance.ex
+++ b/apps/omg_performance/lib/performance.ex
@@ -308,7 +308,10 @@ defmodule OMG.Performance do
     spenders
     |> Enum.with_index(1)
     |> Enum.map(fn {spender, index} ->
-      {:ok, _} = OMG.State.deposit([%{owner: spender.addr, currency: @eth, amount: ntx_to_send, blknum: index}])
+      {:ok, db_updates} =
+        OMG.State.deposit([%{owner: spender.addr, currency: @eth, amount: ntx_to_send, blknum: index}])
+
+      :ok = OMG.DB.multi_update(db_updates)
 
       utxo_pos = Utxo.position(index, 0, 0) |> Utxo.Position.encode()
       %{owner: spender, utxo_pos: utxo_pos, amount: ntx_to_send}

--- a/apps/omg_performance/mix.exs
+++ b/apps/omg_performance/mix.exs
@@ -25,7 +25,6 @@ defmodule OMG.Performance.MixProject do
 
   # we don't need the performance app in a production release
   defp elixirc_paths(:prod), do: []
-  defp elixirc_paths(:dev), do: []
   defp elixirc_paths(_), do: ["lib", "test/support"]
 
   defp deps do

--- a/apps/omg_utils/lib/omg_utils/http_rpc/response.ex
+++ b/apps/omg_utils/lib/omg_utils/http_rpc/response.ex
@@ -109,18 +109,7 @@ defmodule OMG.Utils.HttpRPC.Response do
   # not the most beatuful way of doing this but
   # because our "response serializer" is in utils there's no other way
   defp add_version(response) do
-    vsn =
-      case :code.is_loaded(OMG.ChildChainRPC) do
-        {:file, _} ->
-          {:ok, vsn} = :application.get_key(:omg_child_chain_rpc, :vsn)
-
-          vsn
-
-        _ ->
-          {:ok, vsn} = :application.get_key(:omg_watcher_rpc, :vsn)
-
-          vsn
-      end
+    vsn = []
 
     Map.merge(response, %{version: List.to_string(vsn) <> "+" <> @sha})
   end

--- a/apps/omg_watcher/test/omg_watcher/block_getter/core_test.exs
+++ b/apps/omg_watcher/test/omg_watcher/block_getter/core_test.exs
@@ -116,7 +116,7 @@ defmodule OMG.Watcher.BlockGetter.CoreTest do
             _} = Core.get_blocks_to_apply(state, [%{blknum: block.number, eth_height: synced_height}], synced_height)
 
     # check feasibility of transactions from block to consume at the OMG.State
-    assert {:ok, tx_result, _} = OMG.State.Core.exec(state_alice_deposit, tx, :no_fees_required)
+    assert {:ok, tx_result, _, _} = OMG.State.Core.exec(state_alice_deposit, tx, :no_fees_required)
 
     assert {:ok, ^state} = Core.validate_executions([{:ok, tx_result}], block, state)
 

--- a/apps/omg_watcher/test/omg_watcher/exit_processor/core/state_interaction_test.exs
+++ b/apps/omg_watcher/test/omg_watcher/exit_processor/core/state_interaction_test.exs
@@ -39,7 +39,7 @@ defmodule OMG.Watcher.ExitProcessor.Core.StateInteractionTest do
   setup do
     {:ok, processor_empty} = Core.init([], [], [])
     {:ok, child_block_interval} = OMG.Eth.RootChain.get_child_block_interval()
-    {:ok, state_empty} = State.Core.extract_initial_state(0, 0, child_block_interval)
+    {:ok, state_empty} = State.Core.extract_initial_state(0, 0, [], child_block_interval)
 
     {:ok, %{alice: TestHelper.generate_entity(), processor_empty: processor_empty, state_empty: state_empty}}
   end
@@ -142,7 +142,7 @@ defmodule OMG.Watcher.ExitProcessor.Core.StateInteractionTest do
     assert Utxo.position(1, 0, 0) not in spends_to_get
 
     # spend and see that Core now requests the relevant utxo checks and spends to get
-    {:ok, _, state} = State.Core.exec(state, comp, %{@eth => 0})
+    {:ok, _, state, _} = State.Core.exec(state, comp, %{@eth => 0})
     {:ok, {block, _, _}, state} = State.Core.form_block(1000, state)
 
     assert %{utxos_to_check: utxos_to_check, utxo_exists_result: utxo_exists_result, spends_to_get: spends_to_get} =
@@ -164,7 +164,7 @@ defmodule OMG.Watcher.ExitProcessor.Core.StateInteractionTest do
 
     # canonical
     ife_exit_tx1 = TestHelper.create_recovered([{1, 0, 0, alice}], @eth, [{alice, 10}])
-    {:ok, {tx_hash1, _, _}, state} = State.Core.exec(state, ife_exit_tx1, %{@eth => 0})
+    {:ok, {tx_hash1, _, _}, state, _} = State.Core.exec(state, ife_exit_tx1, %{@eth => 0})
     {:ok, _, state} = State.Core.form_block(1000, state)
     ife_id1 = 1
 

--- a/apps/omg_watcher/test/omg_watcher/exit_processor/core/state_interaction_test.exs
+++ b/apps/omg_watcher/test/omg_watcher/exit_processor/core/state_interaction_test.exs
@@ -39,7 +39,7 @@ defmodule OMG.Watcher.ExitProcessor.Core.StateInteractionTest do
   setup do
     {:ok, processor_empty} = Core.init([], [], [])
     {:ok, child_block_interval} = OMG.Eth.RootChain.get_child_block_interval()
-    {:ok, state_empty} = State.Core.extract_initial_state([], 0, 0, child_block_interval)
+    {:ok, state_empty} = State.Core.extract_initial_state(0, 0, child_block_interval)
 
     {:ok, %{alice: TestHelper.generate_entity(), processor_empty: processor_empty, state_empty: state_empty}}
   end


### PR DESCRIPTION
related to #849, could be a proposition/experiment of a 1st step towards.

**NOTE** this is super hacky and dirty. Done more as a past-time activity and satisfying curiosity.

## Overview

Using some out-of-internet time on the plane I experimented with child chain horizontal scaling using a "UTXO subset" approach.

In a nutshell, the approach makes `OMG.State` (the ledger) fetch UTXOs from DB on every transaction execution, instead of relying on what is held in the `OMG.State` process. Likewise, the UTXO set in the DB is updated on every transaction execution, instead of on every block forming.

### The Good

1. Performance doesn't drop too much (from ~1400 tps to ~1100-1200 on my laptop)
2. This should get us rid of the lengthy loading of UTXOs upon the start of Watcher/Child Chain. Among others it will alleviate considerably the problems with large UTXO set (not fully though!)
3. If Postgres-move comes, this here should be a friendly change
4. If we would be able to switch tx traffic from `chch-instance-1` to `chch-instance-2` on the block border (should be easy*), I think we can get close to **zero-downtime upgrades & fail-overs**. (~70% sure here). At least assuming a RocksDB (or any other kv store) database instance can be shared between those chch instances. If the latter is not possible, then anyway, this change here could be a first step refactor towards achieving this zero-downtime when Postgres is here
5. We still can leverage all the `OMG.State.Core` logic and its tests with close to no modification

### The Bad

1. Just like other horizontal-scaling movements, this could limit state-merklization-friendliness. (I posted details in https://github.com/omisego/elixir-omg/issues/849#issuecomment-545959636)
2. Makes the current UTXO set related metrics calculation useless (because the UTXO set in memory isn't all). Looks hard/awkward to solve without Postgres. We could try punting that somewhat, if we do those metrics just on the Watcher's `INFO` side, which already has all data in Postgres

-------------

*) "should be easy" - it's enough to start `BlockQueue` on the failover `chch-instance-2` only when we're sure that the failing `chch-instance-1` is done failing. Transaction would still be processed with no impact on the perceivable uptime


## Changes

- UTXO set in DB is updated on every tx, not on form block
- mempool txs are persisted in DB

## Testing

:eyes:
`mix test`
`mix test --only integration` works somewhat too, as long as invalid txs aren't involved.