### PR TITLE
refactor: tidy Transaction.Recovered.can_apply? a bit

### DIFF
--- a/apps/omg/lib/omg/state/transaction/validator.ex
+++ b/apps/omg/lib/omg/state/transaction/validator.ex
@@ -33,7 +33,7 @@ defmodule OMG.State.Transaction.Validator do
           | :fees_not_covered
           | :input_utxo_ahead_of_state
           | :too_many_transactions_in_block
-          | :unauthorized_spent
+          | :unauthorized_spend
           | :utxo_not_found
 
   @spec can_apply_spend(state :: Core.t(), tx :: Transaction.Recovered.t(), fees :: Fees.fee_t()) ::
@@ -74,12 +74,12 @@ defmodule OMG.State.Transaction.Validator do
 
   # Checks the outputs spent by this transaction have been authorized by correct witnesses
   @spec authorized?(list(Output.Protocol.t()), list(Transaction.Witness.t()), Transaction.Protocol.t()) ::
-          :ok | {:error, :unauthorized_spent}
+          :ok | {:error, :unauthorized_spend}
   defp authorized?(outputs_spent, witnesses, raw_tx) do
     outputs_spent
     |> Enum.with_index()
     |> Enum.map(fn {output_spent, idx} -> OMG.Output.Protocol.can_spend?(output_spent, witnesses[idx], raw_tx) end)
     |> Enum.all?()
-    |> if(do: :ok, else: {:error, :unauthorized_spent})
+    |> if(do: :ok, else: {:error, :unauthorized_spend})
   end
 end

--- a/apps/omg/lib/omg/state/transaction/validator.ex
+++ b/apps/omg/lib/omg/state/transaction/validator.ex
@@ -15,15 +15,17 @@
 defmodule OMG.State.Transaction.Validator do
   @moduledoc """
   Provides functions for stateful transaction validation for transaction processing in OMG.State.Core.
-
   """
 
   @maximum_block_size 65_536
+
   alias OMG.Fees
+  alias OMG.Output
   alias OMG.State.Core
   alias OMG.State.Transaction
   alias OMG.State.UtxoSet
   alias OMG.Utxo
+
   require Utxo
 
   @type exec_error ::
@@ -36,13 +38,18 @@ defmodule OMG.State.Transaction.Validator do
 
   @spec can_apply_spend(state :: Core.t(), tx :: Transaction.Recovered.t(), fees :: Fees.fee_t()) ::
           true | {{:error, exec_error()}, Core.t()}
-  def can_apply_spend(%Core{utxos: utxos} = state, %Transaction.Recovered{} = tx, fees) do
+  def can_apply_spend(
+        %Core{utxos: utxos} = state,
+        %Transaction.Recovered{signed_tx: %{raw_tx: raw_tx}, witnesses: witnesses} = tx,
+        fees
+      ) do
     inputs = Transaction.get_inputs(tx)
 
     with :ok <- validate_block_size(state),
          :ok <- inputs_not_from_future_block?(state, inputs),
          {:ok, outputs_spent} <- UtxoSet.get_by_inputs(utxos, inputs),
-         {:ok, implicit_paid_fee_by_currency} <- Transaction.Recovered.can_apply?(tx, outputs_spent),
+         :ok <- authorized?(outputs_spent, witnesses, raw_tx),
+         {:ok, implicit_paid_fee_by_currency} <- Transaction.Protocol.can_apply?(raw_tx, outputs_spent),
          true <- Fees.covered?(implicit_paid_fee_by_currency, fees) || {:error, :fees_not_covered} do
       true
     else
@@ -63,5 +70,16 @@ defmodule OMG.State.Transaction.Validator do
       |> Enum.all?(fn Utxo.position(input_blknum, _, _) -> blknum >= input_blknum end)
 
     if no_utxo_from_future_block, do: :ok, else: {:error, :input_utxo_ahead_of_state}
+  end
+
+  # Checks the outputs spent by this transaction have been authorized by correct witnesses
+  @spec authorized?(list(Output.Protocol.t()), list(Transaction.Witness.t()), Transaction.Protocol.t()) ::
+          :ok | {:error, :unauthorized_spent}
+  defp authorized?(outputs_spent, witnesses, raw_tx) do
+    outputs_spent
+    |> Enum.with_index()
+    |> Enum.map(fn {output_spent, idx} -> OMG.Output.Protocol.can_spend?(output_spent, witnesses[idx], raw_tx) end)
+    |> Enum.all?()
+    |> if(do: :ok, else: {:error, :unauthorized_spent})
   end
 end

--- a/apps/omg/test/omg/state/core_test.exs
+++ b/apps/omg/test/omg/state/core_test.exs
@@ -245,7 +245,7 @@ defmodule OMG.State.CoreTest do
     |> do_deposit(alice, %{amount: 10, currency: @eth, blknum: 1})
     |> do_deposit(bob, %{amount: 20, currency: @eth, blknum: 2})
     |> Core.exec(create_recovered([{1, 0, 0, bob}, {2, 0, 0, alice}], @eth, [{bob, 10}]), :no_fees_required)
-    |> fail?(:unauthorized_spent)
+    |> fail?(:unauthorized_spend)
   end
 
   @tag fixtures: [:alice, :bob, :state_empty]
@@ -278,10 +278,10 @@ defmodule OMG.State.CoreTest do
   test "can't spend other people's funds", %{alice: alice, bob: bob, state_alice_deposit: state} do
     state
     |> Core.exec(create_recovered([{1, 0, 0, bob}], @eth, [{bob, 8}, {alice, 3}]), :no_fees_required)
-    |> fail?(:unauthorized_spent)
+    |> fail?(:unauthorized_spend)
     |> same?(state)
     |> Core.exec(create_recovered([{1, 0, 0, bob}], @eth, [{alice, 10}]), :no_fees_required)
-    |> fail?(:unauthorized_spent)
+    |> fail?(:unauthorized_spend)
     |> same?(state)
   end
 
@@ -294,10 +294,10 @@ defmodule OMG.State.CoreTest do
 
     state
     |> Core.exec(create_recovered([{@blknum1, 0, 0, bob}, {@blknum1, 0, 1, bob}], @eth, []), :no_fees_required)
-    |> fail?(:unauthorized_spent)
+    |> fail?(:unauthorized_spend)
     |> same?(state)
     |> Core.exec(create_recovered([{@blknum1, 0, 0, alice}, {@blknum1, 0, 1, alice}], @eth, []), :no_fees_required)
-    |> fail?(:unauthorized_spent)
+    |> fail?(:unauthorized_spend)
     |> same?(state)
 
     state

--- a/docs/transaction_validation.md
+++ b/docs/transaction_validation.md
@@ -28,7 +28,7 @@ This document presents current way of stateless and stateful validation of
 2. Checking correctness of input positions
     * if the input is from the future block then `{:error, :input_utxo_ahead_of_state}`
     * if the input does not exists then `{:error, :utxo_not_found}`
-    * if the owner of input does not match with spender then `{:error, :unauthorized_spent}`
+    * if the owner of input does not match with spender then `{:error, :unauthorized_spend}`
 3. Checking if the amounts from the provided inputs adds up.
     * if not then `{:error, :amounts_do_not_add_up}`
 4. (if in child chain server tx submission pipeline): see if the transaction pays the correct fee.


### PR DESCRIPTION
Noticed this a while ago, an opportunity to refactor, clean & simplify

## Overview

Reduces the API of Transaction.Recovered, removes the confusing `can_apply?` duplication and keeps the flows simpler

## Changes

Moves `Transaction.Recovered.can_apply?` to `State.Validator` and rearranges the functions a little bit.

Also, since I'm touching these lines anyway, I decided to fix the typo `unauthorized_spent`.

## Testing

`mix test`