### PR TITLE
use different port for subscription worker

### DIFF
--- a/apps/omg_eth/test/omg_eth/subscription_worker_test.exs
+++ b/apps/omg_eth/test/omg_eth/subscription_worker_test.exs
@@ -99,7 +99,7 @@ defmodule OMG.Eth.SubscriptionWorkerTest do
 
       case Plug.Adapters.Cowboy.http(__MODULE__, [], opts) do
         {:error, :eaddrinuse} ->
-          start_server(Agent.get_and_update(:port_holder, fn state -> {state, state + 1} end), ref)
+          start_server(Agent.get_and_update(:subscription_port_holder, fn state -> {state, state + 1} end), ref)
 
         {:ok, _} ->
           "ws://localhost:#{port}/ws"

--- a/apps/omg_eth/test/omg_eth/subscription_worker_test.exs
+++ b/apps/omg_eth/test/omg_eth/subscription_worker_test.exs
@@ -25,7 +25,7 @@ defmodule OMG.Eth.SubscriptionWorkerTest do
   @moduletag :common
 
   setup do
-    _ = Agent.start_link(fn -> 55_555 end, name: :port_holder)
+    _ = Agent.start_link(fn -> 55_556 end, name: :subscription_port_holder)
     {:ok, {server_ref, websocket_url}} = WebSockexServerMock.start()
     _ = Application.ensure_all_started(:omg_bus)
     ws_url = Application.get_env(:omg_eth, :ws_url)
@@ -74,7 +74,7 @@ defmodule OMG.Eth.SubscriptionWorkerTest do
 
     def start() do
       ref = make_ref()
-      port = Agent.get_and_update(:port_holder, fn state -> {state, state + 1} end)
+      port = Agent.get_and_update(:subscription_port_holder, fn state -> {state, state + 1} end)
       websocket_url = start_server(port, ref)
       {:ok, {ref, websocket_url}}
     end

--- a/apps/omg_eth/test/omg_eth/subscription_worker_test.exs
+++ b/apps/omg_eth/test/omg_eth/subscription_worker_test.exs
@@ -25,7 +25,7 @@ defmodule OMG.Eth.SubscriptionWorkerTest do
   @moduletag :common
 
   setup do
-    _ = Agent.start_link(fn -> 55_556 end, name: :subscription_port_holder)
+    _ = Agent.start_link(fn -> 66_666 end, name: :subscription_port_holder)
     {:ok, {server_ref, websocket_url}} = WebSockexServerMock.start()
     _ = Application.ensure_all_started(:omg_bus)
     ws_url = Application.get_env(:omg_eth, :ws_url)

--- a/apps/omg_eth/test/omg_eth/subscription_worker_test.exs
+++ b/apps/omg_eth/test/omg_eth/subscription_worker_test.exs
@@ -25,7 +25,7 @@ defmodule OMG.Eth.SubscriptionWorkerTest do
   @moduletag :common
 
   setup do
-    _ = Agent.start_link(fn -> 66_666 end, name: :subscription_port_holder)
+    _ = Agent.start_link(fn -> 55_600 end, name: :subscription_port_holder)
     {:ok, {server_ref, websocket_url}} = WebSockexServerMock.start()
     _ = Application.ensure_all_started(:omg_bus)
     ws_url = Application.get_env(:omg_eth, :ws_url)


### PR DESCRIPTION
📋 Closes #1069

## Overview

Changes the port to avoid collision with other [websocketex agent mock](https://github.com/omisego/elixir-omg/blob/master/apps/omg_eth/test/omg_eth/ethereum_client_monitor_test.exs#L28).

## Changes

Changes the port so they don't collide.

## Testing

```
mix test --include common
```
