### PR TITLE
Self-contained plasma-deployer with ganache-cli and API server

### DIFF
--- a/docker-compose-fixtures.yml
+++ b/docker-compose-fixtures.yml
@@ -1,22 +1,31 @@
 version: "3.4"
 services:
+
   ganache:
     image: trufflesuite/ganache-cli:latest
     command: ganache-cli -d -e 100000 -m "myth like bonus scare over problem client lizard pioneer submit female collect"
     ports:
       - "8545:8545"
       - "8546:8545"
+
   plasma-contracts:
     build:
       context: .
       dockerfile: plasma-contract.Dockerfile
-    command: /bin/sh -c "cd /home/node/plasma-contracts/plasma_framework && npx truffle migrate --network local"
+    command:
+      - /bin/sh
+      - -c
+      - |
+          cd /home/node/plasma-contracts/plasma_framework
+          npx truffle migrate --network local
+          cd build
+          echo '{"contracts":' > db.json && cat outputs.json >> db.json && echo '}' >> db.json
+          npx json-server -w db.json -p 8000 -H 0.0.0.0
+    ports:
+      - "8000:8000"
+    expose:
+      - "8000"
     environment:
       - ETH_CLIENT_HOST=ganache
       - ETH_CLIENT_PORT=8545
       - MIN_EXIT_PERIOD=20
-      - DEPLOYER_ADDRESS=0xFFcf8FDEE72ac11b5c542428B35EEF5769C409f0
-      - DEPLOYER_PRIVATEKEY=0x6cbed15c793ce57650b9877cf6fa156fbef513c4e6134f022a85b1ffdd59b2a1
-      - USE_EXISTING_AUTHORITY_ADDRESS=1
-      - AUTHORITY_ADDRESS=0x22d491Bde2303f2f43325b2108D26f1eAbA1e32b
-      - AUTHORITY_PRIVATEKEY=0x6370fd033278c143179d81c5526140625662b8daa446c22ee2d73db3707e620c

--- a/plasma-contract.Dockerfile
+++ b/plasma-contract.Dockerfile
@@ -12,6 +12,6 @@ RUN apk add --update \
 		git
 
 RUN git clone https://github.com/omisego/plasma-contracts.git
-RUN cd /home/node/plasma-contracts && git checkout fb7109a9e823b998c20484deac8609cda425218a 
+RUN cd /home/node/plasma-contracts && git reset --hard 2251299e7e99484c7f07333f6b59c9f7c4c9ab4f
 RUN cd /home/node/plasma-contracts && npm install
 RUN cd /home/node/plasma-contracts/plasma_framework && npm install


### PR DESCRIPTION
https://github.com/omisego/plasma-contracts/issues/400

## Overview

Adds an API-endpoint `plasma-contracts:8000/contracts` to retrieve the deployed contract addresses

## Changes

Edited `docker-compose-fixtures.yml` for deployment example

## Testing

```bash
docker-compose -f docker-compose-fixtures.yml up
```