### PR TITLE
Add titles to request body schemas for swagger

### DIFF
--- a/apps/omg_child_chain_rpc/priv/swagger/operator_api_specs.yaml
+++ b/apps/omg_child_chain_rpc/priv/swagger/operator_api_specs.yaml
@@ -32,7 +32,7 @@ paths:
         content:
           application/json:
             schema:
-              title: transaction_parameter
+              title: TransactionSubmitBodySchema
               type: object
               properties:
                 transaction:
@@ -150,7 +150,7 @@ paths:
         content:
           application/json:
             schema:
-              title: block_parameter
+              title: GetBlockBodySchema
               type: object
               properties:
                 hash:

--- a/apps/omg_child_chain_rpc/priv/swagger/operator_api_specs.yaml
+++ b/apps/omg_child_chain_rpc/priv/swagger/operator_api_specs.yaml
@@ -32,6 +32,7 @@ paths:
         content:
           application/json:
             schema:
+              title: transaction_parameter
               type: object
               properties:
                 transaction:
@@ -149,6 +150,7 @@ paths:
         content:
           application/json:
             schema:
+              title: block_parameter
               type: object
               properties:
                 hash:

--- a/apps/omg_child_chain_rpc/priv/swagger/operator_api_specs/block/request_bodies.yaml
+++ b/apps/omg_child_chain_rpc/priv/swagger/operator_api_specs/block/request_bodies.yaml
@@ -4,7 +4,7 @@ GetBlockBodySchema:
   content:
     application/json:
       schema:
-        title: 'block_parameter'
+        title: 'GetBlockBodySchema'
         type: object
         properties:
           hash:

--- a/apps/omg_child_chain_rpc/priv/swagger/operator_api_specs/block/request_bodies.yaml
+++ b/apps/omg_child_chain_rpc/priv/swagger/operator_api_specs/block/request_bodies.yaml
@@ -4,6 +4,7 @@ GetBlockBodySchema:
   content:
     application/json:
       schema:
+        title: 'block_parameter'
         type: object
         properties:
           hash:

--- a/apps/omg_child_chain_rpc/priv/swagger/operator_api_specs/transaction/request_bodies.yaml
+++ b/apps/omg_child_chain_rpc/priv/swagger/operator_api_specs/transaction/request_bodies.yaml
@@ -4,6 +4,7 @@ TransactionSubmitBodySchema:
   content:
     application/json:
       schema:
+        title: 'transaction_parameter'
         type: object
         properties:
           transaction:

--- a/apps/omg_child_chain_rpc/priv/swagger/operator_api_specs/transaction/request_bodies.yaml
+++ b/apps/omg_child_chain_rpc/priv/swagger/operator_api_specs/transaction/request_bodies.yaml
@@ -4,7 +4,7 @@ TransactionSubmitBodySchema:
   content:
     application/json:
       schema:
-        title: 'transaction_parameter'
+        title: 'TransactionSubmitBodySchema'
         type: object
         properties:
           transaction:

--- a/apps/omg_watcher_rpc/priv/swagger/informational_api_specs.yaml
+++ b/apps/omg_watcher_rpc/priv/swagger/informational_api_specs.yaml
@@ -32,7 +32,7 @@ paths:
         content:
           application/json:
             schema:
-              title: address_parameter
+              title: AddressBodySchema
               type: object
               properties:
                 address:
@@ -150,7 +150,7 @@ paths:
         content:
           application/json:
             schema:
-              title: address_parameter
+              title: AddressBodySchema
               type: object
               properties:
                 address:
@@ -285,7 +285,7 @@ paths:
         content:
           application/json:
             schema:
-              title: all_transaction_parameter
+              title: GetAllTransactionsBodySchema
               type: object
               properties:
                 address:
@@ -472,7 +472,7 @@ paths:
         content:
           application/json:
             schema:
-              title: all_transaction_parameter
+              title: GetAllTransactionsBodySchema
               type: object
               properties:
                 address:
@@ -660,6 +660,7 @@ paths:
         content:
           application/json:
             schema:
+              title: CreateTransactionsBodySchema
               type: object
               properties:
                 owner:
@@ -1148,6 +1149,7 @@ paths:
         content:
           application/json:
             schema:
+              title: GetTransactionBodySchema
               type: object
               properties:
                 id:
@@ -1366,6 +1368,7 @@ paths:
         content:
           application/json:
             schema:
+              title: TransactionSubmitTypedBodySchema
               allOf:
                 - type: object
                   properties:

--- a/apps/omg_watcher_rpc/priv/swagger/informational_api_specs.yaml
+++ b/apps/omg_watcher_rpc/priv/swagger/informational_api_specs.yaml
@@ -32,6 +32,7 @@ paths:
         content:
           application/json:
             schema:
+              title: address_parameter
               type: object
               properties:
                 address:
@@ -149,6 +150,7 @@ paths:
         content:
           application/json:
             schema:
+              title: address_parameter
               type: object
               properties:
                 address:
@@ -283,6 +285,7 @@ paths:
         content:
           application/json:
             schema:
+              title: all_transaction_parameter
               type: object
               properties:
                 address:
@@ -469,6 +472,7 @@ paths:
         content:
           application/json:
             schema:
+              title: all_transaction_parameter
               type: object
               properties:
                 address:

--- a/apps/omg_watcher_rpc/priv/swagger/informational_api_specs/account/request_bodies.yaml
+++ b/apps/omg_watcher_rpc/priv/swagger/informational_api_specs/account/request_bodies.yaml
@@ -4,6 +4,7 @@ AddressBodySchema:
   content:
     application/json:
       schema:
+        title: 'address_parameter'
         type: object
         properties:
           address:

--- a/apps/omg_watcher_rpc/priv/swagger/informational_api_specs/account/request_bodies.yaml
+++ b/apps/omg_watcher_rpc/priv/swagger/informational_api_specs/account/request_bodies.yaml
@@ -4,7 +4,7 @@ AddressBodySchema:
   content:
     application/json:
       schema:
-        title: 'address_parameter'
+        title: 'AddressBodySchema'
         type: object
         properties:
           address:

--- a/apps/omg_watcher_rpc/priv/swagger/informational_api_specs/block/request_bodies.yaml
+++ b/apps/omg_watcher_rpc/priv/swagger/informational_api_specs/block/request_bodies.yaml
@@ -4,7 +4,7 @@ AllBlocksBodySchema:
   content:
     application/json:
       schema:
-        title: 'block_range_parameter'
+        title: 'AllBlocksBodySchema'
         type: object
         properties:
           from_blknum:
@@ -24,7 +24,7 @@ GetBlockBodySchema:
   content:
     application/json:
       schema:
-        title: 'plasma_block_parameter'
+        title: 'GetBlockBodySchema'
         type: object
         properties:
           id:

--- a/apps/omg_watcher_rpc/priv/swagger/informational_api_specs/block/request_bodies.yaml
+++ b/apps/omg_watcher_rpc/priv/swagger/informational_api_specs/block/request_bodies.yaml
@@ -4,6 +4,7 @@ AllBlocksBodySchema:
   content:
     application/json:
       schema:
+        title: 'block_range_parameter'
         type: object
         properties:
           from_blknum:
@@ -23,6 +24,7 @@ GetBlockBodySchema:
   content:
     application/json:
       schema:
+        title: 'plasma_block_parameter'
         type: object
         properties:
           id:

--- a/apps/omg_watcher_rpc/priv/swagger/informational_api_specs/transaction/request_bodies.yaml
+++ b/apps/omg_watcher_rpc/priv/swagger/informational_api_specs/transaction/request_bodies.yaml
@@ -3,7 +3,7 @@ GetAllTransactionsBodySchema:
   content:
     application/json:
       schema:
-        title: 'all_transaction_parameter'
+        title: 'GetAllTransactionsBodySchema'
         type: object
         properties:
           address:
@@ -36,6 +36,7 @@ CreateTransactionsBodySchema:
   content:
     application/json:
       schema:
+        title: 'CreateTransactionsBodySchema'
         type: object
         properties:
           owner:
@@ -95,6 +96,7 @@ GetTransactionBodySchema:
   content:
     application/json:
       schema:
+        title: 'GetTransactionBodySchema'
         type: object
         properties:
           id:
@@ -111,6 +113,7 @@ TransactionSubmitTypedBodySchema:
   content:
     application/json:
       schema:
+        title: 'TransactionSubmitTypedBodySchema'
         allOf:
         - $ref: 'schemas.yaml#/Eip712SignRequestSchema'
         - type: object
@@ -173,7 +176,7 @@ GetTransactionByPosBodySchema:
   content:
     application/json:
       schema:
-        title: 'transaction_position_parameter'
+        title: 'GetTransactionByPosBodySchema'
         type: object
         properties:
           blknum:

--- a/apps/omg_watcher_rpc/priv/swagger/informational_api_specs/transaction/request_bodies.yaml
+++ b/apps/omg_watcher_rpc/priv/swagger/informational_api_specs/transaction/request_bodies.yaml
@@ -3,6 +3,7 @@ GetAllTransactionsBodySchema:
   content:
     application/json:
       schema:
+        title: 'all_transaction_parameter'
         type: object
         properties:
           address:
@@ -172,6 +173,7 @@ GetTransactionByPosBodySchema:
   content:
     application/json:
       schema:
+        title: 'transaction_position_parameter'
         type: object
         properties:
           blknum:

--- a/apps/omg_watcher_rpc/priv/swagger/security_critical_api_specs.yaml
+++ b/apps/omg_watcher_rpc/priv/swagger/security_critical_api_specs.yaml
@@ -468,7 +468,7 @@ paths:
         content:
           application/json:
             schema:
-              title: account_address_parameter
+              title: AddressBodySchema
               type: object
               properties:
                 address:
@@ -605,7 +605,7 @@ paths:
         content:
           application/json:
             schema:
-              title: uxto_parameter
+              title: UtxoPositionBodySchema
               type: object
               properties:
                 utxo_pos:
@@ -733,7 +733,7 @@ paths:
         content:
           application/json:
             schema:
-              title: uxto_parameter
+              title: UtxoPositionBodySchema
               type: object
               properties:
                 utxo_pos:
@@ -853,7 +853,7 @@ paths:
         content:
           application/json:
             schema:
-              title: submit_transaction_parameter
+              title: TransactionSubmitBodySchema
               type: object
               properties:
                 transaction:
@@ -973,7 +973,7 @@ paths:
         content:
           application/json:
             schema:
-              title: in_flight_exit_parameter
+              title: InFlightExitTxBytesBodySchema
               type: object
               properties:
                 txbytes:
@@ -1375,7 +1375,7 @@ paths:
         content:
           application/json:
             schema:
-              title: in_flight_exit_challenge_parameter
+              title: InFlightExitInputChallengeDataBodySchema
               type: object
               properties:
                 txbytes:
@@ -1516,7 +1516,7 @@ paths:
         content:
           application/json:
             schema:
-              title: in_flight_exit_output_challenge_parameter
+              title: InFlightExitOutputChallengeDataBodySchema
               type: object
               properties:
                 txbytes:

--- a/apps/omg_watcher_rpc/priv/swagger/security_critical_api_specs.yaml
+++ b/apps/omg_watcher_rpc/priv/swagger/security_critical_api_specs.yaml
@@ -468,6 +468,7 @@ paths:
         content:
           application/json:
             schema:
+              title: account_address_parameter
               type: object
               properties:
                 address:
@@ -604,6 +605,7 @@ paths:
         content:
           application/json:
             schema:
+              title: uxto_parameter
               type: object
               properties:
                 utxo_pos:
@@ -731,6 +733,7 @@ paths:
         content:
           application/json:
             schema:
+              title: uxto_parameter
               type: object
               properties:
                 utxo_pos:
@@ -850,6 +853,7 @@ paths:
         content:
           application/json:
             schema:
+              title: submit_transaction_parameter
               type: object
               properties:
                 transaction:
@@ -969,6 +973,7 @@ paths:
         content:
           application/json:
             schema:
+              title: in_flight_exit_parameter
               type: object
               properties:
                 txbytes:
@@ -1370,6 +1375,7 @@ paths:
         content:
           application/json:
             schema:
+              title: in_flight_exit_challenge_parameter
               type: object
               properties:
                 txbytes:
@@ -1510,6 +1516,7 @@ paths:
         content:
           application/json:
             schema:
+              title: in_flight_exit_output_challenge_parameter
               type: object
               properties:
                 txbytes:

--- a/apps/omg_watcher_rpc/priv/swagger/security_critical_api_specs/account/request_bodies.yaml
+++ b/apps/omg_watcher_rpc/priv/swagger/security_critical_api_specs/account/request_bodies.yaml
@@ -4,7 +4,7 @@ AddressBodySchema:
   content:
     application/json:
       schema:
-        title: 'account_address_parameter'
+        title: 'AddressBodySchema'
         type: object
         properties:
           address:

--- a/apps/omg_watcher_rpc/priv/swagger/security_critical_api_specs/account/request_bodies.yaml
+++ b/apps/omg_watcher_rpc/priv/swagger/security_critical_api_specs/account/request_bodies.yaml
@@ -4,6 +4,7 @@ AddressBodySchema:
   content:
     application/json:
       schema:
+        title: 'account_address_parameter'
         type: object
         properties:
           address:

--- a/apps/omg_watcher_rpc/priv/swagger/security_critical_api_specs/in_flight_exit/request_bodies.yaml
+++ b/apps/omg_watcher_rpc/priv/swagger/security_critical_api_specs/in_flight_exit/request_bodies.yaml
@@ -4,7 +4,7 @@ InFlightExitTxBytesBodySchema:
   content:
     application/json:
       schema:
-        title: 'in_flight_exit_parameter'
+        title: 'InFlightExitTxBytesBodySchema'
         type: object
         properties:
           txbytes:
@@ -21,7 +21,7 @@ InFlightExitInputChallengeDataBodySchema:
   content:
     application/json:
       schema:
-        title: 'in_flight_exit_challenge_parameter'
+        title: 'InFlightExitInputChallengeDataBodySchema'
         type: object
         properties:
           txbytes:
@@ -43,7 +43,7 @@ InFlightExitOutputChallengeDataBodySchema:
   content:
     application/json:
       schema:
-        title: 'in_flight_exit_output_challenge_parameter'
+        title: 'InFlightExitOutputChallengeDataBodySchema'
         type: object
         properties:
           txbytes:

--- a/apps/omg_watcher_rpc/priv/swagger/security_critical_api_specs/in_flight_exit/request_bodies.yaml
+++ b/apps/omg_watcher_rpc/priv/swagger/security_critical_api_specs/in_flight_exit/request_bodies.yaml
@@ -4,6 +4,7 @@ InFlightExitTxBytesBodySchema:
   content:
     application/json:
       schema:
+        title: 'in_flight_exit_parameter'
         type: object
         properties:
           txbytes:
@@ -20,6 +21,7 @@ InFlightExitInputChallengeDataBodySchema:
   content:
     application/json:
       schema:
+        title: 'in_flight_exit_challenge_parameter'
         type: object
         properties:
           txbytes:
@@ -41,6 +43,7 @@ InFlightExitOutputChallengeDataBodySchema:
   content:
     application/json:
       schema:
+        title: 'in_flight_exit_output_challenge_parameter'
         type: object
         properties:
           txbytes:

--- a/apps/omg_watcher_rpc/priv/swagger/security_critical_api_specs/transaction/request_bodies.yaml
+++ b/apps/omg_watcher_rpc/priv/swagger/security_critical_api_specs/transaction/request_bodies.yaml
@@ -4,6 +4,7 @@ TransactionSubmitBodySchema:
   content:
     application/json:
       schema:
+        title: 'submit_transaction_parameter'
         type: object
         properties:
           transaction:

--- a/apps/omg_watcher_rpc/priv/swagger/security_critical_api_specs/transaction/request_bodies.yaml
+++ b/apps/omg_watcher_rpc/priv/swagger/security_critical_api_specs/transaction/request_bodies.yaml
@@ -4,7 +4,7 @@ TransactionSubmitBodySchema:
   content:
     application/json:
       schema:
-        title: 'submit_transaction_parameter'
+        title: 'TransactionSubmitBodySchema'
         type: object
         properties:
           transaction:

--- a/apps/omg_watcher_rpc/priv/swagger/security_critical_api_specs/utxo/request_bodies.yaml
+++ b/apps/omg_watcher_rpc/priv/swagger/security_critical_api_specs/utxo/request_bodies.yaml
@@ -4,6 +4,7 @@ UtxoPositionBodySchema:
   content:
     application/json:
       schema:
+        title: 'uxto_parameter'
         type: object
         properties:
           utxo_pos:

--- a/apps/omg_watcher_rpc/priv/swagger/security_critical_api_specs/utxo/request_bodies.yaml
+++ b/apps/omg_watcher_rpc/priv/swagger/security_critical_api_specs/utxo/request_bodies.yaml
@@ -4,7 +4,7 @@ UtxoPositionBodySchema:
   content:
     application/json:
       schema:
-        title: 'uxto_parameter'
+        title: 'UtxoPositionBodySchema'
         type: object
         properties:
           utxo_pos:


### PR DESCRIPTION
:clipboard: https://github.com/omisego/specs/pull/8

## Overview

This adds names to the swagger schema objects so we don't get generic titles like `InlineObject1`.

## Changes

Adds a `title:` key to all the `request_bodies.yaml`


## Testing

Generate the swagger:

```sh
make operator_api_specs
make informational_api_specs
make security_critical_api_specs
```