### PR TITLE
Fix sla margin config

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,6 +339,7 @@ Affects how quick the services reading Ethereum events realize there's a new blo
 After this margin passes, every invalid exit is deemed a critical failure of the child chain (`unchallenged_exit`).
 Such event will prompt a mass exit and stop processing new blocks.
 See [exit validation documentation](docs/exit_validation.md) for details.
+Override using the `EXIT_PROCESSOR_SLA_MARGIN` system environment variable.
 
 * **`maximum_block_withholding_time_ms`** - for how long the Watcher will tolerate failures to get a submitted child chain block, before reporting a block withholding attack and stopping
 

--- a/apps/omg_child_chain_rpc/lib/omg_child_chain_rpc/release_tasks/set_endpoint.ex
+++ b/apps/omg_child_chain_rpc/lib/omg_child_chain_rpc/release_tasks/set_endpoint.ex
@@ -53,7 +53,7 @@ defmodule OMG.ChildChainRPC.ReleaseTasks.SetEndpoint do
         Keyword.get(Application.get_env(@app, OMG.ChildChainRPC.Web.Endpoint)[:http], :port)
       )
 
-    _ = Logger.warn("CONFIGURATION: App: #{@app} Key: PORT Value: #{inspect(port)}.")
+    _ = Logger.info("CONFIGURATION: App: #{@app} Key: PORT Value: #{inspect(port)}.")
     {:port, port}
   end
 
@@ -64,7 +64,7 @@ defmodule OMG.ChildChainRPC.ReleaseTasks.SetEndpoint do
         Keyword.get(Application.get_env(@app, OMG.ChildChainRPC.Web.Endpoint)[:url], :host)
       )
 
-    _ = Logger.warn("CONFIGURATION: App: #{@app} Key: HOSTNAME Value: #{inspect(hostname)}.")
+    _ = Logger.info("CONFIGURATION: App: #{@app} Key: HOSTNAME Value: #{inspect(hostname)}.")
     {:host, hostname}
   end
 

--- a/apps/omg_child_chain_rpc/lib/omg_child_chain_rpc/release_tasks/set_tracer.ex
+++ b/apps/omg_child_chain_rpc/lib/omg_child_chain_rpc/release_tasks/set_tracer.ex
@@ -35,13 +35,13 @@ defmodule OMG.ChildChainRPC.ReleaseTasks.SetTracer do
         Application.get_env(@app, OMG.ChildChainRPC.Tracer)[:disabled?]
       )
 
-    _ = Logger.warn("CONFIGURATION: App: #{@app} Key: DD_DISABLED Value: #{inspect(dd_disabled?)}.")
+    _ = Logger.info("CONFIGURATION: App: #{@app} Key: DD_DISABLED Value: #{inspect(dd_disabled?)}.")
     dd_disabled?
   end
 
   defp get_app_env do
     env = validate_string(get_env("APP_ENV"), Application.get_env(@app, OMG.ChildChainRPC.Tracer)[:env])
-    _ = Logger.warn("CONFIGURATION: App: #{@app} Key: APP_ENV Value: #{inspect(env)}.")
+    _ = Logger.info("CONFIGURATION: App: #{@app} Key: APP_ENV Value: #{inspect(env)}.")
     env
   end
 

--- a/apps/omg_child_chain_rpc/test/omg_child_chain_rpc/release_tasks/set_tracer_test.exs
+++ b/apps/omg_child_chain_rpc/test/omg_child_chain_rpc/release_tasks/set_tracer_test.exs
@@ -19,6 +19,15 @@ defmodule OMG.ChildChainRPC.ReleaseTasks.SetTracerTest do
 
   @app :omg_child_chain_rpc
   @configuration_old Application.get_env(@app, Tracer)
+  setup do
+    on_exit(fn ->
+      # configuration is global state so we reset it to known values in case
+      # it got fiddled before
+      :ok = Application.put_env(@app, Tracer, @configuration_old, persistent: true)
+    end)
+
+    :ok
+  end
 
   test "if environment variables get applied in the configuration" do
     :ok = System.put_env("DD_DISABLED", "TRUE")
@@ -48,12 +57,7 @@ defmodule OMG.ChildChainRPC.ReleaseTasks.SetTracerTest do
 
   test "if exit is thrown when faulty configuration is used" do
     :ok = System.put_env("DD_DISABLED", "TRUEeee")
-
-    try do
-      :ok = SetTracer.init([])
-    catch
-      :exit, _ ->
-        :ok = System.delete_env("DD_DISABLED")
-    end
+    catch_exit(SetTracer.init([]))
+    :ok = System.delete_env("DD_DISABLED")
   end
 end

--- a/apps/omg_db/lib/omg_db/release_tasks/set_key_value_db.ex
+++ b/apps/omg_db/lib/omg_db/release_tasks/set_key_value_db.ex
@@ -34,7 +34,7 @@ defmodule OMG.DB.ReleaseTasks.SetKeyValueDB do
           path
       end
 
-    _ = Logger.warn("CONFIGURATION: App: #{@app} Key: DB_PATH Value: #{inspect(path)}.")
+    _ = Logger.info("CONFIGURATION: App: #{@app} Key: DB_PATH Value: #{inspect(path)}.")
     :ok
   end
 

--- a/apps/omg_eth/lib/omg_eth/release_tasks/set_ethereum_client.ex
+++ b/apps/omg_eth/lib/omg_eth/release_tasks/set_ethereum_client.ex
@@ -36,7 +36,7 @@ defmodule OMG.Eth.ReleaseTasks.SetEthereumClient do
 
   defp get_ethereum_rpc_url do
     url = validate_string(get_env("ETHEREUM_RPC_URL"), Application.get_env(:ethereumex, :url))
-    _ = Logger.warn("CONFIGURATION: App: #{@app} Key: ETHEREUM_RPC_URL Value: #{inspect(url)}.")
+    _ = Logger.info("CONFIGURATION: App: #{@app} Key: ETHEREUM_RPC_URL Value: #{inspect(url)}.")
 
     url
   end
@@ -44,14 +44,14 @@ defmodule OMG.Eth.ReleaseTasks.SetEthereumClient do
   defp get_ethereum_ws_rpc_url do
     url = validate_string(get_env("ETHEREUM_WS_RPC_URL"), Application.get_env(@app, :ws_url))
 
-    _ = Logger.warn("CONFIGURATION: App: #{@app} Key: ETHEREUM_WS_RPC_URL Value: #{inspect(url)}.")
+    _ = Logger.info("CONFIGURATION: App: #{@app} Key: ETHEREUM_WS_RPC_URL Value: #{inspect(url)}.")
 
     url
   end
 
   defp get_rpc_client_type do
     rpc_client_type = validate_rpc_client_type(get_env("ETH_NODE"), Application.get_env(@app, :eth_node))
-    _ = Logger.warn("CONFIGURATION: App: #{@app} Key: ETH_NODE Value: #{inspect(rpc_client_type)}.")
+    _ = Logger.info("CONFIGURATION: App: #{@app} Key: ETH_NODE Value: #{inspect(rpc_client_type)}.")
 
     rpc_client_type
   end

--- a/apps/omg_status/lib/omg_status/release_tasks/set_sentry.ex
+++ b/apps/omg_status/lib/omg_status/release_tasks/set_sentry.ex
@@ -62,7 +62,7 @@ defmodule OMG.Status.ReleaseTasks.SetSentry do
 
   defp get_app_env do
     env = validate_string(get_env("APP_ENV"), Application.get_env(@app, :environment_name))
-    _ = Logger.warn("CONFIGURATION: App: #{@app} Key: APP_ENV Value: #{inspect(env)}.")
+    _ = Logger.info("CONFIGURATION: App: #{@app} Key: APP_ENV Value: #{inspect(env)}.")
     env
   end
 
@@ -73,7 +73,7 @@ defmodule OMG.Status.ReleaseTasks.SetSentry do
         Application.get_env(@app, :server_name)
       )
 
-    _ = Logger.warn("CONFIGURATION: App: #{@app} Key: HOSTNAME, server_name Value: #{inspect(hostname)}.")
+    _ = Logger.info("CONFIGURATION: App: #{@app} Key: HOSTNAME, server_name Value: #{inspect(hostname)}.")
     hostname
   end
 
@@ -84,14 +84,14 @@ defmodule OMG.Status.ReleaseTasks.SetSentry do
         _ -> :child_chain
       end
 
-    _ = Logger.warn("CONFIGURATION: App: #{@app} Key: application Value: #{inspect(app)}.")
+    _ = Logger.info("CONFIGURATION: App: #{@app} Key: application Value: #{inspect(app)}.")
 
     app
   end
 
   defp get_rpc_client_type do
     rpc_client_type = validate_rpc_client_type(get_env("ETH_NODE"), Application.get_env(@app, :tags)[:eth_node])
-    _ = Logger.warn("CONFIGURATION: App: #{@app} Key: ETH_NODE Value: #{inspect(rpc_client_type)}.")
+    _ = Logger.info("CONFIGURATION: App: #{@app} Key: ETH_NODE Value: #{inspect(rpc_client_type)}.")
 
     rpc_client_type
   end

--- a/apps/omg_status/lib/omg_status/release_tasks/set_tracer.ex
+++ b/apps/omg_status/lib/omg_status/release_tasks/set_tracer.ex
@@ -54,38 +54,38 @@ defmodule OMG.Status.ReleaseTasks.SetTracer do
         Application.get_env(:omg_status, Tracer)[:disabled?]
       )
 
-    _ = Logger.warn("CONFIGURATION: App: #{@app} Key: DD_DISABLED Value: #{inspect(dd_disabled?)}.")
+    _ = Logger.info("CONFIGURATION: App: #{@app} Key: DD_DISABLED Value: #{inspect(dd_disabled?)}.")
     dd_disabled?
   end
 
   defp get_app_env do
     env = validate_string(get_env("APP_ENV"), Application.get_env(@app, Tracer)[:env])
-    _ = Logger.warn("CONFIGURATION: App: #{@app} Key: APP_ENV Value: #{inspect(env)}.")
+    _ = Logger.info("CONFIGURATION: App: #{@app} Key: APP_ENV Value: #{inspect(env)}.")
     env
   end
 
   defp get_dd_hostname(default) do
     dd_hostname = validate_string(get_env("DD_HOSTNAME"), default)
-    _ = Logger.warn("CONFIGURATION: App: #{@app} Key: DD_HOSTNAME Value: #{inspect(dd_hostname)}.")
+    _ = Logger.info("CONFIGURATION: App: #{@app} Key: DD_HOSTNAME Value: #{inspect(dd_hostname)}.")
     dd_hostname
   end
 
   defp get_dd_port(default) do
     dd_port = validate_integer(get_env("DD_PORT"), default)
-    _ = Logger.warn("CONFIGURATION: App: #{@app} Key: DD_PORT Value: #{inspect(dd_port)}.")
+    _ = Logger.info("CONFIGURATION: App: #{@app} Key: DD_PORT Value: #{inspect(dd_port)}.")
     dd_port
   end
 
   defp get_dd_spandex_port(default) do
     dd_spandex_port = validate_integer(get_env("DD_APM_PORT"), default)
-    _ = Logger.warn("CONFIGURATION: App: #{@app} Key: DD_APM_PORT Value: #{inspect(dd_spandex_port)}.")
+    _ = Logger.info("CONFIGURATION: App: #{@app} Key: DD_APM_PORT Value: #{inspect(dd_spandex_port)}.")
     dd_spandex_port
   end
 
   def get_batch_size do
     batch_size = validate_integer(get_env("BATCH_SIZE"), Application.get_env(:spandex_datadog, :batch_size))
 
-    _ = Logger.warn("CONFIGURATION: App: #{@app} Key: BATCH_SIZE Value: #{inspect(batch_size)}.")
+    _ = Logger.info("CONFIGURATION: App: #{@app} Key: BATCH_SIZE Value: #{inspect(batch_size)}.")
     batch_size
   end
 
@@ -96,7 +96,7 @@ defmodule OMG.Status.ReleaseTasks.SetTracer do
         Application.get_env(:spandex_datadog, :sync_threshold)
       )
 
-    _ = Logger.warn("CONFIGURATION: App: #{@app} Key: SYNC_THRESHOLD Value: #{inspect(sync_threshold)}.")
+    _ = Logger.info("CONFIGURATION: App: #{@app} Key: SYNC_THRESHOLD Value: #{inspect(sync_threshold)}.")
     sync_threshold
   end
 

--- a/apps/omg_watcher/config/config.exs
+++ b/apps/omg_watcher/config/config.exs
@@ -14,7 +14,7 @@ config :omg_watcher,
   namespace: OMG.Watcher,
   ecto_repos: [OMG.Watcher.DB.Repo],
   # 23 hours worth of blocks - this is how long the child chain server has to block spends from exiting utxos
-  exit_processor_sla_margin: {:system, "EXIT_PROCESSOR_SLA_MARGIN", 23 * 60 * 4, {String, :to_integer}},
+  exit_processor_sla_margin: 23 * 60 * 4,
   maximum_block_withholding_time_ms: 1_200_000,
   block_getter_loops_interval_ms: 500,
   maximum_number_of_unapplied_blocks: 50,

--- a/apps/omg_watcher/config/dev.exs
+++ b/apps/omg_watcher/config/dev.exs
@@ -2,6 +2,10 @@ use Mix.Config
 
 config :omg_watcher, environment: :dev
 
+config :omg_watcher,
+  # 1 hour of Ethereum blocks
+  exit_processor_sla_margin: 60 * 4
+
 config :omg_watcher, OMG.Watcher.Tracer,
   disabled?: true,
   env: "development"

--- a/apps/omg_watcher/lib/omg_watcher/release_tasks/set_child_chain.ex
+++ b/apps/omg_watcher/lib/omg_watcher/release_tasks/set_child_chain.ex
@@ -27,7 +27,7 @@ defmodule OMG.Watcher.ReleaseTasks.SetChildChain do
   defp get_app_env do
     child_chain_url = validate_string(get_env("CHILD_CHAIN_URL"), Application.get_env(@app, :child_chain_url))
 
-    _ = Logger.warn("CONFIGURATION: App: #{@app} Key: CHILD_CHAIN_URL Value: #{inspect(child_chain_url)}.")
+    _ = Logger.info("CONFIGURATION: App: #{@app} Key: CHILD_CHAIN_URL Value: #{inspect(child_chain_url)}.")
     child_chain_url
   end
 

--- a/apps/omg_watcher/lib/omg_watcher/release_tasks/set_db.ex
+++ b/apps/omg_watcher/lib/omg_watcher/release_tasks/set_db.ex
@@ -29,7 +29,7 @@ defmodule OMG.Watcher.ReleaseTasks.SetDB do
   defp get_db_url do
     db_url = validate_string(get_env("DATABASE_URL"), Application.get_env(@app, OMG.Watcher.DB.Repo)[:url])
 
-    _ = Logger.warn("CONFIGURATION: App: #{@app} Key: DATABASE_URL Value: #{inspect(db_url)}.")
+    _ = Logger.info("CONFIGURATION: App: #{@app} Key: DATABASE_URL Value: #{inspect(db_url)}.")
     db_url
   end
 

--- a/apps/omg_watcher/lib/omg_watcher/release_tasks/set_exit_processor_sla_margin.ex
+++ b/apps/omg_watcher/lib/omg_watcher/release_tasks/set_exit_processor_sla_margin.ex
@@ -1,0 +1,48 @@
+# Copyright 2019-2019 OmiseGO Pte Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defmodule OMG.Watcher.ReleaseTasks.SetExitProcessorSLAMargin do
+  @moduledoc false
+  use Distillery.Releases.Config.Provider
+  require Logger
+  @app :omg_watcher
+
+  @impl Provider
+
+  @system_env_name "EXIT_PROCESSOR_SLA_MARGIN"
+  @app_env_name :exit_processor_sla_margin
+
+  def init(_args) do
+    _ = Application.ensure_all_started(:logger)
+    :ok = Application.put_env(@app, @app_env_name, get_exit_processor_sla_margin(), persistent: true)
+  end
+
+  defp get_exit_processor_sla_margin do
+    config_value = validate_int(get_env(@system_env_name), Application.get_env(@app, @app_env_name))
+    _ = Logger.info("CONFIGURATION: App: #{@app} Key: #{@system_env_name} Value: #{inspect(config_value)}.")
+    config_value
+  end
+
+  defp get_env(key), do: System.get_env(key)
+
+  defp validate_int(value, _default) when is_binary(value), do: to_int(value)
+  defp validate_int(_, default), do: default
+
+  defp to_int(value) do
+    case Integer.parse(value) do
+      {result, ""} -> result
+      _ -> exit("#{@system_env_name} must be an integer.")
+    end
+  end
+end

--- a/apps/omg_watcher/lib/omg_watcher/release_tasks/set_tracer.ex
+++ b/apps/omg_watcher/lib/omg_watcher/release_tasks/set_tracer.ex
@@ -30,13 +30,13 @@ defmodule OMG.Watcher.ReleaseTasks.SetTracer do
   defp get_dd_disabled do
     dd_disabled? = validate_bool(get_env("DD_DISABLED"), Application.get_env(@app, OMG.Watcher.Tracer)[:disabled?])
 
-    _ = Logger.warn("CONFIGURATION: App: #{@app} Key: DD_DISABLED Value: #{inspect(dd_disabled?)}.")
+    _ = Logger.info("CONFIGURATION: App: #{@app} Key: DD_DISABLED Value: #{inspect(dd_disabled?)}.")
     dd_disabled?
   end
 
   defp get_app_env do
     env = validate_string(get_env("APP_ENV"), Application.get_env(@app, OMG.Watcher.Tracer)[:env])
-    _ = Logger.warn("CONFIGURATION: App: #{@app} Key: APP_ENV Value: #{inspect(env)}.")
+    _ = Logger.info("CONFIGURATION: App: #{@app} Key: APP_ENV Value: #{inspect(env)}.")
     env
   end
 

--- a/apps/omg_watcher/test/omg_watcher/release_tasks/set_exit_processor_sla_margin_test.exs
+++ b/apps/omg_watcher/test/omg_watcher/release_tasks/set_exit_processor_sla_margin_test.exs
@@ -1,0 +1,52 @@
+# Copyright 2019 OmiseGO Pte Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defmodule OMG.Watcher.ReleaseTasks.SetExitProcessorSLAMarginTest do
+  use ExUnit.Case, async: false
+
+  alias OMG.Watcher.ReleaseTasks.SetExitProcessorSLAMargin
+  @app :omg_watcher
+  @configuration_old Application.get_env(@app, :exit_processor_sla_margin)
+
+  setup do
+    on_exit(fn ->
+      # configuration is global state so we reset it to known values in case
+      # it got fiddled before
+      :ok = Application.put_env(@app, :exit_processor_sla_margin, @configuration_old, persistent: true)
+    end)
+
+    :ok
+  end
+
+  test "if environment variables get applied in the configuration" do
+    :ok = System.put_env("EXIT_PROCESSOR_SLA_MARGIN", "15")
+    :ok = SetExitProcessorSLAMargin.init([])
+    exit_processor_sla_margin_updated = Application.get_env(@app, :exit_processor_sla_margin)
+
+    assert 15 = exit_processor_sla_margin_updated
+  end
+
+  test "if default configuration is used when there's no environment variables" do
+    :ok = System.delete_env("EXIT_PROCESSOR_SLA_MARGIN")
+    :ok = SetExitProcessorSLAMargin.init([])
+
+    assert @configuration_old = Application.get_env(@app, :exit_processor_sla_margin)
+  end
+
+  test "if exit is thrown when faulty configuration is used" do
+    :ok = System.put_env("EXIT_PROCESSOR_SLA_MARGIN", "15a")
+    catch_exit(SetExitProcessorSLAMargin.init([]))
+    :ok = System.delete_env("EXIT_PROCESSOR_SLA_MARGIN")
+  end
+end

--- a/apps/omg_watcher/test/omg_watcher/release_tasks/set_tracer_test.exs
+++ b/apps/omg_watcher/test/omg_watcher/release_tasks/set_tracer_test.exs
@@ -55,12 +55,7 @@ defmodule OMG.Watcher.ReleaseTasks.SetTracerTest do
 
   test "if exit is thrown when faulty configuration is used" do
     :ok = System.put_env("DD_DISABLED", "TRUEeee")
-
-    try do
-      :ok = SetTracer.init([])
-    catch
-      :exit, _ ->
-        :ok = System.delete_env("DD_DISABLED")
-    end
+    catch_exit(SetTracer.init([]))
+    :ok = System.delete_env("DD_DISABLED")
   end
 end

--- a/apps/omg_watcher_rpc/lib/release_tasks/set_endpoint.ex
+++ b/apps/omg_watcher_rpc/lib/release_tasks/set_endpoint.ex
@@ -53,7 +53,7 @@ defmodule OMG.WatcherRPC.ReleaseTasks.SetEndpoint do
         Keyword.get(Application.get_env(@app, OMG.WatcherRPC.Web.Endpoint)[:http], :port)
       )
 
-    _ = Logger.warn("CONFIGURATION: App: #{@app} Key: PORT Value: #{inspect(port)}.")
+    _ = Logger.info("CONFIGURATION: App: #{@app} Key: PORT Value: #{inspect(port)}.")
     {:port, port}
   end
 
@@ -64,7 +64,7 @@ defmodule OMG.WatcherRPC.ReleaseTasks.SetEndpoint do
         Keyword.get(Application.get_env(@app, OMG.WatcherRPC.Web.Endpoint)[:url], :host)
       )
 
-    _ = Logger.warn("CONFIGURATION: App: #{@app} Key: HOSTNAME Value: #{inspect(hostname)}.")
+    _ = Logger.info("CONFIGURATION: App: #{@app} Key: HOSTNAME Value: #{inspect(hostname)}.")
     {:host, hostname}
   end
 

--- a/apps/omg_watcher_rpc/lib/release_tasks/set_tracer.ex
+++ b/apps/omg_watcher_rpc/lib/release_tasks/set_tracer.ex
@@ -35,13 +35,13 @@ defmodule OMG.WatcherRPC.ReleaseTasks.SetTracer do
         Application.get_env(@app, OMG.WatcherRPC.Tracer)[:disabled?]
       )
 
-    _ = Logger.warn("CONFIGURATION: App: #{@app} Key: DD_DISABLED Value: #{inspect(dd_disabled?)}.")
+    _ = Logger.info("CONFIGURATION: App: #{@app} Key: DD_DISABLED Value: #{inspect(dd_disabled?)}.")
     dd_disabled?
   end
 
   defp get_app_env do
     env = validate_string(get_env("APP_ENV"), Application.get_env(@app, OMG.WatcherRPC.Tracer)[:env])
-    _ = Logger.warn("CONFIGURATION: App: #{@app} Key: APP_ENV Value: #{inspect(env)}.")
+    _ = Logger.info("CONFIGURATION: App: #{@app} Key: APP_ENV Value: #{inspect(env)}.")
     env
   end
 

--- a/apps/omg_watcher_rpc/test/omg_watcher_rpc/release_tasks/set_tracer_test.exs
+++ b/apps/omg_watcher_rpc/test/omg_watcher_rpc/release_tasks/set_tracer_test.exs
@@ -19,6 +19,15 @@ defmodule OMG.WatcherRPC.ReleaseTasks.SetTracerTest do
 
   @app :omg_watcher_rpc
   @configuration_old Application.get_env(@app, Tracer)
+  setup do
+    on_exit(fn ->
+      # configuration is global state so we reset it to known values in case
+      # it got fiddled before
+      :ok = Application.put_env(@app, Tracer, @configuration_old, persistent: true)
+    end)
+
+    :ok
+  end
 
   test "if environment variables get applied in the configuration" do
     :ok = System.put_env("DD_DISABLED", "TRUE")
@@ -48,12 +57,7 @@ defmodule OMG.WatcherRPC.ReleaseTasks.SetTracerTest do
 
   test "if exit is thrown when faulty configuration is used" do
     :ok = System.put_env("DD_DISABLED", "TRUEeee")
-
-    try do
-      :ok = SetTracer.init([])
-    catch
-      :exit, _ ->
-        :ok = System.delete_env("DD_DISABLED")
-    end
+    catch_exit(SetTracer.init([]))
+    :ok = System.delete_env("DD_DISABLED")
   end
 end

--- a/rel/config.exs
+++ b/rel/config.exs
@@ -54,7 +54,8 @@ release :watcher do
       {OMG.Status.ReleaseTasks.SetTracer, ["${RELEASE_ROOT_DIR}/config/config.exs"]},
       {OMG.Watcher.ReleaseTasks.SetChildChain, ["${RELEASE_ROOT_DIR}/config/config.exs"]},
       {OMG.Watcher.ReleaseTasks.SetDB, ["${RELEASE_ROOT_DIR}/config/config.exs"]},
-      {OMG.Watcher.ReleaseTasks.SetTracer, ["${RELEASE_ROOT_DIR}/config/config.exs"]}
+      {OMG.Watcher.ReleaseTasks.SetTracer, ["${RELEASE_ROOT_DIR}/config/config.exs"]},
+      {OMG.Watcher.ReleaseTasks.SetExitProcessorSLAMargin, ["${RELEASE_ROOT_DIR}/config/config.exs"]}
     ]
   )
 


### PR DESCRIPTION
fixes #1079 

## Overview

A cherrypick from `v0.2` led to an invalid entry in the configuration for `:exit_processor_sla_margin`. This fixes that, introducing a new config provider, see commit `
fix: introduce a config provider for exit_processor_sla_margin setting`

## Changes

On top of the actual fix, I ran into a couple of things to tidy around the release_tasks (separate commit `style: cleanup release_tasks`):
- change log level from warn to info
- add more teardown procedures in tests (in cases where it was missing)
- use catch_exit in all tests

## Testing

`mix test`