### PR TITLE
test docker-compose and release generation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -343,6 +343,17 @@ jobs:
 
       - run: mix dialyzer --format short --halt-exit-status
 
+  test_docker_compose:
+    machine:
+      image: circleci/classic:201808-01
+    steps:
+      - checkout
+      - run: make docker-child_chain CHILD_CHAIN_IMAGE_NAME="omisego/child_chain"
+      - run: make docker-watcher WATCHER_IMAGE_NAME="omisego/watcher"
+      - run: docker-compose up -d
+      - run: sleep 60;
+      - run: make get-alarms
+
   publish_child_chain:
     executor: metal_child_chain
     steps:
@@ -497,6 +508,8 @@ workflows:
       - watcher_coveralls_and_integration_tests:
           requires: [build]
       - common_coveralls_and_integration_tests:
+          requires: [build]
+      - test_docker_compose:
           requires: [build]
       - lint:
           requires: [build]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -134,6 +134,7 @@ services:
       interval: 30s
       timeout: 1s
       retries: 5
+      start_period: 30s
     depends_on:
       plasma-deployer:
         condition: service_healthy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,8 +49,8 @@ services:
       test: curl plasma-deployer:8000/contracts
       interval: 80s
       timeout: 15s
-      retries: 60
-      start_period: 2m
+      retries: 120
+      start_period: 4m
 
   geth:
     image: ethereum/client-go:v1.8.27


### PR DESCRIPTION
## Overview

This PR builds Watcher and Child Chain and invokes `docker-compose up -d` and proceeds with `make get-alarms` proving that all services booted correctly, which means, you're able to run `docker-compose up` locally and develop towards it.

## Changes


- Add circle CI step that supports docker-compose 2.1

## Testing

The test is the test itself.
