### PR TITLE
 test baremetal release  #1087 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -352,8 +352,7 @@ jobs:
       - run: make docker-child_chain CHILD_CHAIN_IMAGE_NAME="omisego/child_chain"
       - run: make docker-watcher WATCHER_IMAGE_NAME="omisego/watcher"
       - run: docker-compose up -d
-      - run: sleep 60;
-      - run: make get-alarms
+      - run: sh .circleci/status.sh
 
   test_barebone_release:
     machine:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -158,6 +158,7 @@ jobs:
             - rel/
             - VERSION
             - .git
+            - Makefile
 
   lint:
     executor: builder_pg
@@ -354,6 +355,56 @@ jobs:
       - run: sleep 60;
       - run: make get-alarms
 
+  test_barebone_release:
+    machine:
+      image: circleci/classic:201808-01
+    steps:
+      - checkout
+      - run: echo 'export PATH=~/.cargo/bin:$PATH' >> $BASH_ENV
+      - run: sudo kill $(lsof /var/lib/dpkg/lock | awk '{print $2}' | tail -n+2) || true
+      - run:
+          name: Start geth, postgres and plasma-deployer
+          command: make start-services
+          background: true
+      - run: echo 'export PATH=~/.cargo/bin:$PATH' >> $BASH_ENV
+      - run:
+          command: |
+            git clone https://github.com/asdf-vm/asdf.git ~/.asdf --branch v0.7.4
+            echo -e '\n. $HOME/.asdf/asdf.sh' >> ~/.bash_profile
+            echo -e '\n. $HOME/.asdf/completions/asdf.bash' >> ~/.bash_profile
+            source ~/.bash_profile
+            asdf plugin-add elixir https://github.com/asdf-vm/asdf-elixir.git
+            asdf plugin-add erlang https://github.com/asdf-vm/asdf-erlang.git
+            asdf install erlang 21.0
+          no_output_timeout: 2400
+      - run: |
+          source ~/.bash_profile
+          asdf install elixir 1.8.2
+      - run: |
+          source ~/.bash_profile
+          asdf global erlang 21.0
+      - run:
+          command: |
+            echo 'export PATH=~/.cargo/bin:$PATH' >> $BASH_ENV
+            source ~/.bash_profile
+            asdf global elixir 1.8.2
+            mix local.rebar --force &&
+            mix local.hex --force &&
+            sudo lsof /var/lib/dpkg/lock || true &&
+            sudo kill $(lsof /var/lib/dpkg/lock | awk '{print $2}' | tail -n+2) || true
+            sudo rm /var/lib/dpkg/lock || true &&
+            sudo rm /var/cache/apt/archives/lock || true &&
+            sudo dpkg --configure -a || true &&
+            ./bin/setup
+            make deps-elixir-omg &&
+            TERM=xterm-256color make start-child_chain OVERRIDING_START=start &&
+            TERM=xterm-256color make start-watcher OVERRIDING_START=start
+          no_output_timeout: 2400
+      - run: docker ps
+      - run: ps axww | grep watcher
+      - run: ps axww | grep child_chain
+      - run: sh .circleci/status.sh
+
   publish_child_chain:
     executor: metal_child_chain
     steps:
@@ -510,6 +561,8 @@ workflows:
       - common_coveralls_and_integration_tests:
           requires: [build]
       - test_docker_compose_release:
+          requires: [build]
+      - test_barebone_release:
           requires: [build]
       - lint:
           requires: [build]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -361,6 +361,7 @@ jobs:
     steps:
       - checkout
       - run: echo 'export PATH=~/.cargo/bin:$PATH' >> $BASH_ENV
+      - run: lsof /var/lib/dpkg/lock | awk '{print $2}' | tail -n+2 || true
       - run: sudo kill $(lsof /var/lib/dpkg/lock | awk '{print $2}' | tail -n+2) || true
       - run:
           name: Start geth, postgres and plasma-deployer

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -361,8 +361,6 @@ jobs:
     steps:
       - checkout
       - run: echo 'export PATH=~/.cargo/bin:$PATH' >> $BASH_ENV
-      - run: lsof /var/lib/dpkg/lock | awk '{print $2}' | tail -n+2 || true
-      - run: sudo kill $(lsof /var/lib/dpkg/lock | awk '{print $2}' | tail -n+2) || true
       - run:
           name: Start geth, postgres and plasma-deployer
           command: make start-services
@@ -391,12 +389,11 @@ jobs:
             asdf global elixir 1.8.2
             mix local.rebar --force &&
             mix local.hex --force &&
-            sudo lsof /var/lib/dpkg/lock || true &&
-            sudo kill $(lsof /var/lib/dpkg/lock | awk '{print $2}' | tail -n+2) || true
+            sudo killall dpkg || true &&
             sudo rm /var/lib/dpkg/lock || true &&
             sudo rm /var/cache/apt/archives/lock || true &&
             sudo dpkg --configure -a || true &&
-            ./bin/setup
+            ./bin/setup &&
             make deps-elixir-omg &&
             TERM=xterm-256color make start-child_chain OVERRIDING_START=start &&
             TERM=xterm-256color make start-watcher OVERRIDING_START=start

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -351,12 +351,15 @@ jobs:
       - checkout
       - run: make docker-child_chain CHILD_CHAIN_IMAGE_NAME="omisego/child_chain"
       - run: make docker-watcher WATCHER_IMAGE_NAME="omisego/watcher"
+      - run: docker-compose pull
       - run: docker-compose up -d
       - run: sh .circleci/status.sh
 
   test_barebone_release:
     machine:
       image: circleci/classic:201808-01
+    environment:
+      TERM: xterm-256color
     steps:
       - checkout
       - run: echo 'export PATH=~/.cargo/bin:$PATH' >> $BASH_ENV
@@ -394,8 +397,8 @@ jobs:
             sudo dpkg --configure -a || true &&
             ./bin/setup &&
             make deps-elixir-omg &&
-            TERM=xterm-256color make start-child_chain OVERRIDING_START=start &&
-            TERM=xterm-256color make start-watcher OVERRIDING_START=start
+            make start-child_chain OVERRIDING_START=start &&
+            make start-watcher OVERRIDING_START=start
           no_output_timeout: 2400
       - run: docker ps
       - run: ps axww | grep watcher

--- a/.circleci/status.sh
+++ b/.circleci/status.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+while true;  do
+  alarms=$(make get-alarms)
+  status=$?
+  echo ${alarms}
+  if [ "$status" -eq "0" ]; then
+    break;
+  else
+    sleep 5
+  fi
+done

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 MAKEFLAGS += --silent
-OVERRIDING_START=foreground
+OVERRIDING_START ?= foreground
 help:
 	@echo "Dont Fear the Makefile"
 	@echo "*DOCKER DEVELOPMENT*:"

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 MAKEFLAGS += --silent
+OVERRIDING_START=foreground
 help:
 	@echo "Dont Fear the Makefile"
 	@echo "*DOCKER DEVELOPMENT*:"
@@ -176,7 +177,10 @@ docker-push: docker
 
 ###OTHER
 docker-start-cluster:
-	docker-compose up
+	docker-compose build --no-cache && docker-compose up
+
+docker-stop-cluster:
+	docker-compose down
 
 docker-update-watcher:
 	docker stop elixir-omg_watcher_1
@@ -200,6 +204,9 @@ docker-stop-cluster-with-datadog:
 start-services:
 	docker-compose up geth postgres plasma-deployer
 
+prune-plasma-deployer:
+	docker rmi -f $(docker images --format '{{.Repository}}:{{.Tag}}' | grep elixir-omg_plasma-deployer:latest)
+
 start-child_chain:
 	set -e; . ./bin/variables; \
 	echo "Building Child Chain" && \
@@ -208,7 +215,7 @@ start-child_chain:
 	echo "Init Child Chain DB" && \
 	_build/dev/rel/child_chain/bin/child_chain init_key_value_db && \
 	echo "Init Child Chain DB DONE" && \
-	_build/dev/rel/child_chain/bin/child_chain foreground
+	_build/dev/rel/child_chain/bin/child_chain $(OVERRIDING_START)
 
 start-watcher:
 	set -e; . ./bin/variables; \
@@ -221,7 +228,7 @@ start-watcher:
 	_build/dev/rel/watcher/bin/watcher init_postgresql_db && \
 	echo "Init Watcher DBs DONE" && \
 	echo "Run Watcher" && \
-	_build/dev/rel/watcher/bin/watcher foreground
+	_build/dev/rel/watcher/bin/watcher $(OVERRIDING_START)
 
 update-child_chain:
 	_build/dev/rel/child_chain/bin/child_chain stop ; \

--- a/apps/omg_watcher/test/fixtures.exs
+++ b/apps/omg_watcher/test/fixtures.exs
@@ -145,14 +145,9 @@ defmodule OMG.Watcher.Fixtures do
       nil
     )
 
-    {:ok, pid} =
-      Supervisor.start_link(
-        [
-          %{id: OMG.WatcherRPC.Web.Endpoint, start: {OMG.WatcherRPC.Web.Endpoint, :start_link, []}, type: :supervisor}
-        ],
-        strategy: :one_for_one,
-        name: Watcher.Endpoint
-      )
+    Process.flag(:trap_exit, true)
+
+    {:ok, pid} = ensure_web_started(OMG.WatcherRPC.Web.Endpoint, :start_link, [], 100)
 
     _ = Application.load(:omg_watcher_rpc)
 
@@ -273,5 +268,27 @@ defmodule OMG.Watcher.Fixtures do
     recovered_txs
     |> Enum.with_index()
     |> Enum.map(fn {recovered_tx, txindex} -> {blknum, txindex, recovered_tx.tx_hash, recovered_tx} end)
+  end
+
+  defp ensure_web_started(module, function, args, 0), do: apply(module, function, args)
+
+  defp ensure_web_started(module, function, args, counter) do
+    try do
+      {:ok, pid} = apply(module, function, args)
+      {:ok, pid}
+    rescue
+      e in MatchError ->
+        %MatchError{
+          term:
+            {:error,
+             {:shutdown,
+              {:failed_to_start_child, {:ranch_listener_sup, OMG.WatcherRPC.Web.Endpoint.HTTP},
+               {:shutdown,
+                {:failed_to_start_child, :ranch_acceptors_sup,
+                 {:listen_error, OMG.WatcherRPC.Web.Endpoint.HTTP, :eaddrinuse}}}}}}
+        } = e
+
+        ensure_web_started(module, function, args, counter - 1)
+    end
   end
 end

--- a/apps/omg_watcher/test/fixtures.exs
+++ b/apps/omg_watcher/test/fixtures.exs
@@ -273,22 +273,20 @@ defmodule OMG.Watcher.Fixtures do
   defp ensure_web_started(module, function, args, 0), do: apply(module, function, args)
 
   defp ensure_web_started(module, function, args, counter) do
-    try do
-      {:ok, pid} = apply(module, function, args)
-      {:ok, pid}
-    rescue
-      e in MatchError ->
-        %MatchError{
-          term:
-            {:error,
+    {:ok, pid} = apply(module, function, args)
+    {:ok, pid}
+  rescue
+    e in MatchError ->
+      %MatchError{
+        term:
+          {:error,
+           {:shutdown,
+            {:failed_to_start_child, {:ranch_listener_sup, OMG.WatcherRPC.Web.Endpoint.HTTP},
              {:shutdown,
-              {:failed_to_start_child, {:ranch_listener_sup, OMG.WatcherRPC.Web.Endpoint.HTTP},
-               {:shutdown,
-                {:failed_to_start_child, :ranch_acceptors_sup,
-                 {:listen_error, OMG.WatcherRPC.Web.Endpoint.HTTP, :eaddrinuse}}}}}}
-        } = e
+              {:failed_to_start_child, :ranch_acceptors_sup,
+               {:listen_error, OMG.WatcherRPC.Web.Endpoint.HTTP, :eaddrinuse}}}}}}
+      } = e
 
-        ensure_web_started(module, function, args, counter - 1)
-    end
+      ensure_web_started(module, function, args, counter - 1)
   end
 end

--- a/apps/omg_watcher_rpc/test/omg_watcher_rpc/web/controllers/transaction_test.exs
+++ b/apps/omg_watcher_rpc/test/omg_watcher_rpc/web/controllers/transaction_test.exs
@@ -35,8 +35,7 @@ defmodule OMG.WatcherRPC.Web.Controller.TransactionTest do
   describe "getting transaction by id" do
     @tag fixtures: [:initial_blocks]
     test "verifies all inserted transactions available to get", %{initial_blocks: initial_blocks} do
-      initial_blocks
-      |> Enum.each(fn {blknum, txindex, txhash, _recovered_tx} ->
+      Enum.each(initial_blocks, fn {blknum, txindex, txhash, _recovered_tx} ->
         txhash_enc = Encoding.to_hex(txhash)
 
         assert %{"block" => %{"blknum" => ^blknum}, "txhash" => ^txhash_enc, "txindex" => ^txindex} =

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,7 +49,7 @@ services:
       interval: 80s
       timeout: 15s
       retries: 120
-      start_period: 4m
+      start_period: 5m
 
   geth:
     image: ethereum/client-go:v1.8.27

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -101,6 +101,7 @@ services:
       interval: 30s
       timeout: 1s
       retries: 5
+      start_period: 30s
     depends_on:
       plasma-deployer:
         condition: service_healthy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,9 +16,7 @@ services:
       retries: 5
 
   plasma-deployer:
-    build:
-      context: .
-      dockerfile: plasma-contract.Dockerfile
+    image: omisegoimages/elixir-omg-tester-plasma-deployer:dev-f104c41
     command:
       - /bin/sh
       - -c

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       retries: 5
 
   plasma-deployer:
-    image: omisegoimages/elixir-omg-tester-plasma-deployer:dev-f104c41
+    image: omisegoimages/elixir-omg-tester-plasma-deployer:dev-247d0e3
     command:
       - /bin/sh
       - -c


### PR DESCRIPTION
## Overview

This PR builds Watcher and Child Chain on baremetal and invokes `make start-services` (geth, plasma-deployer, postgres) and proceeds with `make get-alarms` proving that all services booted correctly, which means, you're able to run elixir-omg baremetal locally and develop towards it.

## Changes

- run bin/setup to install dependencies
- Add circle CI step with machine executor

## Testing

The test is the test itself.
