### PR TITLE
Add ganache support for convenience/new integration tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -373,7 +373,9 @@ All binary entries are expected in hex-encoded, `0x`-prefixed.
 
 * **`txhash_contract`** - the Ethereum-transaction hash holding the deployment of the root chain contract
 
-* **`eth_node`** - the Ethereum client which is used: `"geth" | "parity" or "infura"`.
+* **`eth_node`** - the Ethereum client which is used: `"geth" | "parity" | "infura" | "ganache"`.
+Use `"ganache"` for tests only, also note that you must run `ganache-cli` yourself (e.g. using the provided `docker-compose-fixtures.yml` file).
+When setting to `"ganache"`, set also `run_test_eth_dev_node` to `false`, to prevent tests from setting up the dev Ethereum node themselves.
 
 * **`node_logging_in_debug`** - whether the output of the Ethereum node being run in integration test should be printed to `:debug` level logs.
 If you set this to false, remember to set the logging level to `:debug` to see the logs

--- a/apps/omg/config/test.exs
+++ b/apps/omg/config/test.exs
@@ -2,8 +2,8 @@ use Mix.Config
 
 config :omg,
   deposit_finality_margin: 1,
-  ethereum_events_check_interval_ms: 50,
-  coordinator_eth_height_check_interval_ms: 100,
+  ethereum_events_check_interval_ms: 10,
+  coordinator_eth_height_check_interval_ms: 10,
   environment: :test,
   # an entry to fix a common reference path to the root directory of the umbrella project
   # this is useful because `mix test` and `mix coveralls --umbrella` have different views on the root dir when testing

--- a/apps/omg/test/test_helper.exs
+++ b/apps/omg/test/test_helper.exs
@@ -17,3 +17,6 @@ ExUnit.configure(exclude: [integration: true, property: true, wrappers: true])
 umbrella_root_dir = Application.fetch_env!(:omg, :umbrella_root_dir)
 ExUnitFixtures.load_fixture_files(Path.join(umbrella_root_dir, "apps/*/test/**/fixtures.exs"))
 ExUnit.start()
+
+{:ok, _} = Application.ensure_all_started(:briefly)
+{:ok, _} = Application.ensure_all_started(:erlexec)

--- a/apps/omg_child_chain/lib/omg_child_chain/block_queue/core.ex
+++ b/apps/omg_child_chain/lib/omg_child_chain/block_queue/core.ex
@@ -472,60 +472,116 @@ defmodule OMG.ChildChain.BlockQueue.Core do
   # TODO: consider moving this logic to separate module
   @spec process_submit_result(BlockSubmission.t(), submit_result_t(), BlockSubmission.plasma_block_num()) ::
           :ok | {:error, atom}
-  def process_submit_result(submission, submit_result, newest_mined_blknum) do
-    case submit_result do
-      {:ok, txhash} ->
-        _ = Logger.info("Submitted #{inspect(submission)} at: #{inspect(txhash)}")
-        :ok
+  def process_submit_result(submission, submit_result, newest_mined_blknum)
 
-      {:error, %{"code" => -32_000, "message" => "known transaction" <> _}} ->
-        _ = log_known_tx(submission)
-        :ok
+  def process_submit_result(submission, {:ok, txhash}, _newest_mined_blknum) do
+    log_success(submission, txhash)
+    :ok
+  end
 
-      # parity error code for duplicated tx
-      {:error, %{"code" => -32_010, "message" => "Transaction with the same hash was already imported."}} ->
-        _ = log_known_tx(submission)
-        :ok
+  def process_submit_result(
+        submission,
+        {:error, %{"code" => -32_000, "message" => "known transaction" <> _}},
+        _newest_mined_blknum
+      ) do
+    log_known_tx(submission)
+    :ok
+  end
 
-      {:error, %{"code" => -32_000, "message" => "replacement transaction underpriced"}} ->
-        _ = log_low_replacement_price(submission)
-        :ok
+  # parity error code for duplicated tx
+  def process_submit_result(
+        submission,
+        {:error, %{"code" => -32_010, "message" => "Transaction with the same hash was already imported."}},
+        _newest_mined_blknum
+      ) do
+    log_known_tx(submission)
+    :ok
+  end
 
-      # parity version
-      {:error, %{"code" => -32_010, "message" => "Transaction gas price is too low. There is another" <> _}} ->
-        _ = log_low_replacement_price(submission)
-        :ok
+  def process_submit_result(
+        submission,
+        {:error, %{"code" => -32_000, "message" => "replacement transaction underpriced"}},
+        _newest_mined_blknum
+      ) do
+    log_low_replacement_price(submission)
+    :ok
+  end
 
-      {:error, %{"code" => -32_000, "message" => "authentication needed: password or unlock"}} ->
-        diagnostic = prepare_diagnostic(submission, newest_mined_blknum)
-        _ = Logger.error("It seems that authority account is locked: #{inspect(diagnostic)}. Check README.md")
-        {:error, :account_locked}
+  # parity version
+  def process_submit_result(
+        submission,
+        {:error, %{"code" => -32_010, "message" => "Transaction gas price is too low. There is another" <> _}},
+        _newest_mined_blknum
+      ) do
+    log_low_replacement_price(submission)
+    :ok
+  end
 
-      {:error, %{"code" => -32_000, "message" => "nonce too low"}} ->
-        process_nonce_too_low(submission, newest_mined_blknum)
+  def process_submit_result(
+        submission,
+        {:error, %{"code" => -32_000, "message" => "authentication needed: password or unlock"}},
+        newest_mined_blknum
+      ) do
+    diagnostic = prepare_diagnostic(submission, newest_mined_blknum)
+    log_locked(diagnostic)
+    {:error, :account_locked}
+  end
 
-      # parity specific error for nonce-too-low
-      {:error, %{"code" => -32_010, "message" => "Transaction nonce is too low." <> _}} ->
-        process_nonce_too_low(submission, newest_mined_blknum)
+  def process_submit_result(
+        submission,
+        {:error, %{"code" => -32_000, "message" => "nonce too low"}},
+        newest_mined_blknum
+      ) do
+    process_nonce_too_low(submission, newest_mined_blknum)
+  end
 
-      # ganache has this error, but these are valid nonce_too_low errors, that just don't make any sense
-      # `process_nonce_too_low/2` would mark it as a genuine failure and crash the BlockQueue :(
-      # however, everything seems to just work regardless, things get retried and mined eventually
-      # NOTE: we decide to degrade the severity to warn and continue, considering it's just `ganache`
-      {:error, %{"code" => -32000, "data" => %{"stack" => "n: the tx doesn't have the correct nonce" <> _}}} = error ->
-        # runtime sanity check if we're actually running `ganache`, if we aren't and we're here, we must crash
-        :ganache = Application.fetch_env!(:omg_eth, :eth_node)
-        _ = Logger.warn(inspect(error))
-        :ok
-    end
+  # parity specific error for nonce-too-low
+  def process_submit_result(
+        submission,
+        {:error, %{"code" => -32_010, "message" => "Transaction nonce is too low." <> _}},
+        newest_mined_blknum
+      ) do
+    process_nonce_too_low(submission, newest_mined_blknum)
+  end
+
+  # ganache has this error, but these are valid nonce_too_low errors, that just don't make any sense
+  # `process_nonce_too_low/2` would mark it as a genuine failure and crash the BlockQueue :(
+  # however, everything seems to just work regardless, things get retried and mined eventually
+  # NOTE: we decide to degrade the severity to warn and continue, considering it's just `ganache`
+  def process_submit_result(
+        _submission,
+        {:error, %{"code" => -32_000, "data" => %{"stack" => "n: the tx doesn't have the correct nonce" <> _}}} = error,
+        _newest_mined_blknum
+      ) do
+    log_ganache_nonce_too_low(error)
+    :ok
+  end
+
+  defp log_ganache_nonce_too_low(error) do
+    # runtime sanity check if we're actually running `ganache`, if we aren't and we're here, we must crash
+    :ganache = Application.fetch_env!(:omg_eth, :eth_node)
+    _ = Logger.warn(inspect(error))
+    :ok
+  end
+
+  defp log_success(submission, txhash) do
+    _ = Logger.info("Submitted #{inspect(submission)} at: #{inspect(txhash)}")
+    :ok
   end
 
   defp log_known_tx(submission) do
-    Logger.debug("Submission #{inspect(submission)} is known transaction - ignored")
+    _ = Logger.debug("Submission #{inspect(submission)} is known transaction - ignored")
+    :ok
   end
 
   defp log_low_replacement_price(submission) do
-    Logger.debug("Submission #{inspect(submission)} is known, but with higher price - ignored")
+    _ = Logger.debug("Submission #{inspect(submission)} is known, but with higher price - ignored")
+    :ok
+  end
+
+  defp log_locked(diagnostic) do
+    _ = Logger.error("It seems that authority account is locked: #{inspect(diagnostic)}. Check README.md")
+    :ok
   end
 
   defp process_nonce_too_low(%BlockSubmission{num: blknum} = submission, newest_mined_blknum) do

--- a/apps/omg_child_chain/test/test_helper.exs
+++ b/apps/omg_child_chain/test/test_helper.exs
@@ -17,3 +17,6 @@ ExUnitFixtures.start()
 # loading all fixture files from the whole umbrella project
 ExUnitFixtures.load_fixture_files()
 ExUnit.start()
+
+{:ok, _} = Application.ensure_all_started(:briefly)
+{:ok, _} = Application.ensure_all_started(:erlexec)

--- a/apps/omg_eth/config/test.exs
+++ b/apps/omg_eth/config/test.exs
@@ -19,4 +19,5 @@ config :omg_eth,
   # this is useful because `mix test` and `mix coveralls --umbrella` have different views on the root dir when testing
   umbrella_root_dir: Path.join(__DIR__, "../../.."),
   ws_url: "ws://localhost:8546/ws",
-  eth_node: :geth
+  eth_node: :geth,
+  run_test_eth_dev_node: true

--- a/apps/omg_eth/lib/omg_eth/transaction.ex
+++ b/apps/omg_eth/lib/omg_eth/transaction.ex
@@ -30,6 +30,9 @@ defmodule OMG.Eth.Transaction do
     transact(backend, txmap, opts)
   end
 
+  # ganache works the same as geth in this aspect
+  defp transact(:ganache, txmap, opts), do: transact(:geth, txmap, opts)
+
   defp transact(:geth, txmap, _opts) do
     case Ethereumex.HttpClient.eth_send_transaction(txmap) do
       {:ok, receipt_enc} -> {:ok, Encoding.from_hex(receipt_enc)}

--- a/apps/omg_eth/test/fixtures.exs
+++ b/apps/omg_eth/test/fixtures.exs
@@ -28,8 +28,11 @@ defmodule OMG.Eth.Fixtures do
   @test_erc20_vault_id 2
 
   deffixture eth_node do
-    {:ok, exit_fn} = DevNode.start()
-    on_exit(exit_fn)
+    if Application.get_env(:omg_eth, :run_test_eth_dev_node, true) do
+      {:ok, exit_fn} = DevNode.start()
+      on_exit(exit_fn)
+    end
+
     :ok
   end
 

--- a/apps/omg_eth/test/support/dev_geth.ex
+++ b/apps/omg_eth/test/support/dev_geth.ex
@@ -62,11 +62,7 @@ defmodule OMG.Eth.DevGeth do
 
     _ =
       if Application.get_env(:omg_eth, :node_logging_in_debug) do
-        %Task{} =
-          fn ->
-            Enum.each(geth_out, &Support.DevNode.default_logger/1)
-          end
-          |> Task.async()
+        %Task{} = Task.async(fn -> Enum.each(geth_out, &Support.DevNode.default_logger/1) end)
       end
 
     geth_proc

--- a/apps/omg_eth/test/support/dev_node.ex
+++ b/apps/omg_eth/test/support/dev_node.ex
@@ -30,6 +30,13 @@ defmodule Support.DevNode do
     Support.DevParity.start()
   end
 
+  defp start(:ganache) do
+    {:ok, _} = Application.ensure_all_started(:ethereumex)
+    # we won't start ganache for the testing user, so we want to warn in case this was expected
+    false = Application.get_env(:omg_eth, :run_test_eth_dev_node) && {:error, :ganache_must_be_already_started}
+    {:ok, fn -> :ok end}
+  end
+
   def wait_for_start(outstream, look_for, timeout, logger_fn \\ &default_logger/1) do
     # Monitors the stdout coming out of a process for signal of successful startup
     waiting_task_function = fn ->

--- a/apps/omg_performance/test/fixtures.exs
+++ b/apps/omg_performance/test/fixtures.exs
@@ -23,6 +23,7 @@ defmodule OMG.Performance.Fixtures do
   use OMG.Utils.LoggerExt
 
   deffixture omg_watcher(contract) do
+    {:ok, _} = Application.ensure_all_started(:briefly)
     config_file_path = Briefly.create!(extname: ".exs")
     db_path = Briefly.create!(directory: true)
 
@@ -32,7 +33,7 @@ defmodule OMG.Performance.Fixtures do
     #{Support.DevHelper.create_conf_file(contract)}
 
     config :omg_db, path: "#{db_path}"
-    # this causes the inner test watcher server process to log debug. To see these logs adjust test's log level
+    # this causes the inner test watcher server process to log info. To see these logs adjust test's log level
     config :logger, level: :info
     """)
     |> File.close()
@@ -65,6 +66,8 @@ defmodule OMG.Performance.Fixtures do
     {:ok, watcher_proc, _ref, [{:stream, watcher_out, _stream_server}]} =
       Exexec.run_link(watcher_mix_cmd, exexec_opts_for_mix)
 
+    wait_for_start(watcher_out, "Running OMG.WatcherRPC.Web.Endpoint", 20_000, &log_output("watcher", &1))
+
     Task.async(fn -> Enum.each(watcher_out, &log_output("watcher", &1)) end)
 
     on_exit(fn ->
@@ -86,6 +89,23 @@ defmodule OMG.Performance.Fixtures do
       File.rm(config_file_path)
       File.rm_rf(db_path)
     end)
+
+    :ok
+  end
+
+  # NOTE: we could dry or do sth about this (copied from Support.DevNode), but this might be removed soon altogether
+  defp wait_for_start(outstream, look_for, timeout, logger_fn) do
+    # Monitors the stdout coming out of a process for signal of successful startup
+    waiting_task_function = fn ->
+      outstream
+      |> Stream.map(logger_fn)
+      |> Stream.take_while(fn line -> not String.contains?(line, look_for) end)
+      |> Enum.to_list()
+    end
+
+    waiting_task_function
+    |> Task.async()
+    |> Task.await(timeout)
 
     :ok
   end

--- a/apps/omg_performance/test/test_helper.exs
+++ b/apps/omg_performance/test/test_helper.exs
@@ -15,3 +15,5 @@
 ExUnit.configure(exclude: [integration: true, property: true, wrappers: true])
 ExUnitFixtures.start()
 ExUnit.start()
+{:ok, _} = Application.ensure_all_started(:briefly)
+{:ok, _} = Application.ensure_all_started(:erlexec)

--- a/apps/omg_watcher/test/test_helper.exs
+++ b/apps/omg_watcher/test/test_helper.exs
@@ -21,3 +21,6 @@ ExUnit.start()
 
 Mix.Task.run("ecto.create", ~w(--quiet))
 Mix.Task.run("ecto.migrate", ~w(--quiet))
+
+{:ok, _} = Application.ensure_all_started(:briefly)
+{:ok, _} = Application.ensure_all_started(:erlexec)

--- a/docker-compose-fixtures.yml
+++ b/docker-compose-fixtures.yml
@@ -2,7 +2,7 @@ version: "3.4"
 services:
   ganache:
     image: trufflesuite/ganache-cli:latest
-    command: ganache-cli -d -e 100000 -m "myth like bonus scare over problem client lizard pioneer submit female collect"
+    command: ganache-cli -b 0.1 -d -e 100000 -m "myth like bonus scare over problem client lizard pioneer submit female collect"
     ports:
       - "8545:8545"
       - "8546:8545"


### PR DESCRIPTION
Cherry picked from #1106 

## Overview

Adds support to run integration tests (and the chch/watcher as a whole) against `ganache-cli`. Should be useful immediately (was when I was doing #1106) and as a baby step towards the new integration testing.

Contrary to `geth`/`parity` it doesn't auto-start `ganache` when doing integration tests, bring your own RPC. There's little point in providing this auto-start, facing impending revamp of integration tests.

### Caveats of `ganache`:

- BlockQueue doesn't like the way `ganache` handles submitted transactions. This looks like a discrepancy wrt. other nodes. Submitted transactions here contribute to the addresses nonce, while for other nodes, only mined transactions do. This is punted now just by turning what would be an error into a warnings, logging and moving on (only if `eth_node: :ganache`!).
- it's slow (`eth_call`s we do turns out ~50 times slower), so things that work fine with `geth`/`parity` might be unstable with `ganache`. I'll file a separate issue with the details.

## Changes

- introduce a `ganache` setting to `eth_node`, document
- introduce some handling functions to make it run and test
- make the docker-compose invocation of `ganache-cli` mine blocks on a cadence (10blocks/s)
- patch up `BlockQueue` to cater for one peculiarity of `ganache`
- this in turn resulted in woes from `credo` so the function there got a slight refactor

## Testing

Put:
```
  eth_node: :ganache,
  run_test_eth_dev_node: false
```
into your `omg_eth/config/test.exs`, `docker-compose -f docker-compose-fixtures.yml up ganache` and 
`mix test --only integration`.

One of the tests is flaky with this, but let's punt it maybe? CI continues on `geth` for now.
