### PR TITLE
fix: load both deployer and authority priv keys into docker-compose's geth

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,9 +33,9 @@ services:
       - "8000"
     environment:
       # DEPLOYER_PRIVATEKEY is the geth dev account initially funded address
-      - DEPLOYER_PRIVATEKEY=d885a307e35738f773d8c9c63c7a3f3977819274638d04aaf934a1e1158513ce
-      - MAINTAINER_PRIVATEKEY=6f30f140fd4724519e5017c0895f158d68bbbe4a81c0c10dbb25a0006e348807
-      - AUTHORITY_PRIVATEKEY=7f30f140fd4724519e5017c0895f158d68bbbe4a81c0c10dbb25a0006e348807
+      - DEPLOYER_PRIVATEKEY=d885a307e35738f773d8c9c63c7a3f3977819274638d04aaf934a1e1158513ce # 0x6de4b3b9c28e9c3e84c2b2d3a875c947a84de68d
+      - MAINTAINER_PRIVATEKEY=6f30f140fd4724519e5017c0895f158d68bbbe4a81c0c10dbb25a0006e348807 # 0x59695413678e19d7d490893810a8ac9fe6cb0f5c
+      - AUTHORITY_PRIVATEKEY=7f30f140fd4724519e5017c0895f158d68bbbe4a81c0c10dbb25a0006e348807 # 0xc0f780dfc35075979b0def588d999225b7ecc56f
       - REMOTE_URL=http://geth:8545
       - MIN_EXIT_PERIOD=20
     depends_on:
@@ -56,11 +56,23 @@ services:
       - -c
       - |
           apk add --update curl
-          # Add account to geth dev
+          # Configures geth with the deployer and authority accounts. This includes:
+          #   1. Configuring the deployer's keystore
+          #   2. Configuring the authority's keystore
+          #   3. Configuring the keystores' password
+          #   4. Unlocking with accounts by their indexes
           mkdir -p /tmp/geth-dev
           echo '{"address":"6de4b3b9c28e9c3e84c2b2d3a875c947a84de68d","crypto":{"cipher":"aes-128-ctr","ciphertext":"1adf32e70f22f7e775255b4e6aa0bb0b9338402f8ee2470b6c2ffce9d7d54918","cipherparams":{"iv":"38103d2e38263399e79884f8448172b0"},"kdf":"scrypt","kdfparams":{"dklen":32,"n":262144,"p":1,"r":8,"salt":"eac5b9eee7c6cdf6557f9d84d02294801fd5d6ad67df6ec25a8fcb4dc0011e72"},"mac":"42bc14b9b00ef8387b46feb3f8599ffee82e50442b9d305ef7bfc0e9480566da"},"id":"8ba88812-cef4-44e7-888e-de40b8881120","version":3}' > /tmp/geth-dev/UTC--2019-10-29T05-54-49.573595611Z--6de4b3b9c28e9c3e84c2b2d3a875c947a84de68d
+          echo '{"address":"c0f780dfc35075979b0def588d999225b7ecc56f","crypto":{"cipher":"aes-128-ctr","ciphertext":"70af4aa4485c8bb750d6cc52800bf61eaef29e16460fb9b1dd3d225affc494d8","cipherparams":{"iv":"cdff3498ff1464bf4945642e80ed5187"},"kdf":"scrypt","kdfparams":{"dklen":32,"n":262144,"p":1,"r":8,"salt":"80405b854cf1c1fa56557d060fc9075176463b47b75b535fce19840612d02b06"},"mac":"54bfa823a4bacb9c6a4cb95088fb72755cd0220e26adee4c356b22285d6a167f"},"id":"40c21866-79a2-46ce-990e-d2d77cf86bc3","version":3}' > /tmp/geth-dev/UTC--2019-11-06T08-20-13.587131000Z--c0f780dfc35075979b0def588d999225b7ecc56f
+          echo "" > /tmp/geth-blank-password
           # Starts geth
-          geth --miner.gastarget 7500000 --miner.gasprice "10" --dev --dev.period 1 --keystore=/tmp/geth-dev --rpc --rpcapi personal,web3,eth,net --rpcaddr 0.0.0.0 --rpcvhosts=* --rpcport=8545 --ws --wsaddr 0.0.0.0 --wsorigins='*'
+          geth --miner.gastarget 7500000 --miner.gasprice "10" \
+            --dev --dev.period 1 --keystore=/tmp/geth-dev \
+            --password /tmp/geth-blank-password \
+            --unlock "0,1" \
+            --miner.etherbase "0x6de4b3b9c28e9c3e84c2b2d3a875c947a84de68d" \
+            --rpc --rpcapi personal,web3,eth,net --rpcaddr 0.0.0.0 --rpcvhosts=* --rpcport=8545 \
+            --ws --wsaddr 0.0.0.0 --wsorigins='*'
     ports:
       - "8545:8545"
       - "8546:8546"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,7 +60,7 @@ services:
           #   1. Configuring the deployer's keystore
           #   2. Configuring the authority's keystore
           #   3. Configuring the keystores' password
-          #   4. Unlocking with accounts by their indexes
+          #   4. Unlocking the accounts by their indexes
           mkdir -p /tmp/geth-dev
           echo '{"address":"6de4b3b9c28e9c3e84c2b2d3a875c947a84de68d","crypto":{"cipher":"aes-128-ctr","ciphertext":"1adf32e70f22f7e775255b4e6aa0bb0b9338402f8ee2470b6c2ffce9d7d54918","cipherparams":{"iv":"38103d2e38263399e79884f8448172b0"},"kdf":"scrypt","kdfparams":{"dklen":32,"n":262144,"p":1,"r":8,"salt":"eac5b9eee7c6cdf6557f9d84d02294801fd5d6ad67df6ec25a8fcb4dc0011e72"},"mac":"42bc14b9b00ef8387b46feb3f8599ffee82e50442b9d305ef7bfc0e9480566da"},"id":"8ba88812-cef4-44e7-888e-de40b8881120","version":3}' > /tmp/geth-dev/UTC--2019-10-29T05-54-49.573595611Z--6de4b3b9c28e9c3e84c2b2d3a875c947a84de68d
           echo '{"address":"c0f780dfc35075979b0def588d999225b7ecc56f","crypto":{"cipher":"aes-128-ctr","ciphertext":"70af4aa4485c8bb750d6cc52800bf61eaef29e16460fb9b1dd3d225affc494d8","cipherparams":{"iv":"cdff3498ff1464bf4945642e80ed5187"},"kdf":"scrypt","kdfparams":{"dklen":32,"n":262144,"p":1,"r":8,"salt":"80405b854cf1c1fa56557d060fc9075176463b47b75b535fce19840612d02b06"},"mac":"54bfa823a4bacb9c6a4cb95088fb72755cd0220e26adee4c356b22285d6a167f"},"id":"40c21866-79a2-46ce-990e-d2d77cf86bc3","version":3}' > /tmp/geth-dev/UTC--2019-11-06T08-20-13.587131000Z--c0f780dfc35075979b0def588d999225b7ecc56f


### PR DESCRIPTION
Closes #1098

## Overview

`{:error, %{"code" => -32000, "message" => "unknown account"}` is returned from geth when the childchain submits a block. This is due to how the docker-compose setup relies on the authority account to be unlocked but it was not configured in geth.

## Changes

- Configure the authority keystore into geth
- Add `--unlock "0,1"` to unlock the two accounts
- Provide a blank password file into geth since it is needed for the `--unlock` argument
- Set `--miner.etherbase` to the deployer address so we do not depend on the accounts ordering which is prone to change

## Testing

Tested with:

```
# In elixir-omg:
$ docker-compose up

# In omg-js:
$ npm run childchain-deposit
...
Alice's new rootchain balance: 115792089237316195423570985008687907853269984665640564039456737018433129639927
Alice's new childchain balance: 500000000000000000

$ npm run childchain-transaction
...
Created a childchain transaction of 0.05 ETH from Alice to Bob.
Submitted transaction. Transaction receipt: {
  "blknum": 1000,
  "txhash": "0xb3387025978fa8dbb88e36b121fe09b3d7f40aacb0f1aaed8612fc662a12d6b3",
  "txindex": 0
}
...
```