### PR TITLE
fix: prevent from SE challenges from being ignored, when IFE is present

### DIFF
--- a/apps/omg_watcher/lib/omg_watcher/exit_processor/tx_appendix.ex
+++ b/apps/omg_watcher/lib/omg_watcher/exit_processor/tx_appendix.ex
@@ -21,6 +21,12 @@ defmodule OMG.Watcher.ExitProcessor.TxAppendix do
 
   alias OMG.Watcher.ExitProcessor
 
+  @doc """
+  Enumerable of `Transaction.Signed.t()`
+  """
+  @type t() :: Enumerable.t()
+
+  @spec get_all(ExitProcessor.Core.t()) :: t()
   def get_all(%ExitProcessor.Core{in_flight_exits: ifes, competitors: competitors}) do
     ifes
     |> Map.values()

--- a/apps/omg_watcher/test/omg_watcher/exit_processor/standard_exit_test.exs
+++ b/apps/omg_watcher/test/omg_watcher/exit_processor/standard_exit_test.exs
@@ -410,24 +410,47 @@ defmodule OMG.Watcher.ExitProcessor.StandardExitTest do
       assert {:ok, [%Event.InvalidExit{}]} =
                exit_processor_request
                |> struct!(utxo_exists_result: [false, false, false])
-               |> check_validity_filtered(processor, only: [Event.InvalidExit])
+               |> check_validity_filtered(processor, exclude: [Event.PiggybackAvailable])
     end
-  end
 
-  test "ifes and standard exits don't interfere if all valid",
-       %{alice: alice, processor_empty: processor, transactions: [tx | _]} do
-    standard_exit_tx = TestHelper.create_recovered([{@deposit_blknum, 0, 0, alice}], @eth, [{alice, 10}])
-    processor = processor |> start_se_from(standard_exit_tx, @utxo_pos_tx) |> start_ife_from(tx)
+    test "ifes and standard exits don't interfere, when standard exit is challenged",
+         %{alice: alice, processor_empty: processor, transactions: [tx | _]} do
+      standard_exit_tx = TestHelper.create_recovered([], @eth, [{alice, 10}])
 
-    assert %{utxos_to_check: [_, Utxo.position(1, 2, 1), @utxo_pos_tx]} =
-             exit_processor_request =
-             %ExitProcessor.Request{eth_height_now: 5, blknum_now: @late_blknum}
-             |> Core.determine_utxo_existence_to_get(processor)
+      {processor, _} =
+        processor
+        |> start_se_from(standard_exit_tx, @utxo_pos_deposit)
+        |> start_ife_from(tx)
+        |> Core.challenge_exits([%{utxo_pos: Utxo.Position.encode(@utxo_pos_deposit)}])
 
-    assert {:ok, []} =
-             exit_processor_request
-             |> struct!(utxo_exists_result: [true, true, true])
-             |> check_validity_filtered(processor, exclude: [Event.PiggybackAvailable])
+      # doesn't check the challenged SE utxo
+      assert %{utxos_to_check: [_, Utxo.position(1, 2, 1)]} =
+               exit_processor_request =
+               %ExitProcessor.Request{eth_height_now: 5, blknum_now: @late_blknum}
+               |> Core.determine_utxo_existence_to_get(processor)
+
+      # doesn't alert on the challenged SE, despite it being a double-spend wrt the IFE
+      assert {:ok, []} =
+               exit_processor_request
+               |> struct!(utxo_exists_result: [false, false])
+               |> check_validity_filtered(processor, exclude: [Event.PiggybackAvailable])
+    end
+
+    test "ifes and standard exits don't interfere if all valid",
+         %{alice: alice, processor_empty: processor, transactions: [tx | _]} do
+      standard_exit_tx = TestHelper.create_recovered([{@deposit_blknum, 0, 0, alice}], @eth, [{alice, 10}])
+      processor = processor |> start_se_from(standard_exit_tx, @utxo_pos_tx) |> start_ife_from(tx)
+
+      assert %{utxos_to_check: [_, Utxo.position(1, 2, 1), @utxo_pos_tx]} =
+               exit_processor_request =
+               %ExitProcessor.Request{eth_height_now: 5, blknum_now: @late_blknum}
+               |> Core.determine_utxo_existence_to_get(processor)
+
+      assert {:ok, []} =
+               exit_processor_request
+               |> struct!(utxo_exists_result: [true, true, true])
+               |> check_validity_filtered(processor, exclude: [Event.PiggybackAvailable])
+    end
   end
 
   describe "challenge events" do


### PR DESCRIPTION
Found when doing #855 

## Overview

Bug fix + test + some required tidies. When standard exits are confronted with IFE transactions, we forgot to recheck whether the SE is active (e.g. not challenged). This manifested only when there was a coinciding IFE spending that the exiting output.

## Changes

Add the missing filtering for active exits.

## Testing

`mix test` but also you can:

1. submit a tx1 and then submit another tx, spending from the first one's output
2. ife from that tx1
3. se from its tx1 output
4. challenge that se
5. observe that the se still shows up as invalid