### PR TITLE
fix: fix, simplify and tidy exiting from piggyback events in OMG.State

### DIFF
--- a/apps/omg/test/omg/state/core_test.exs
+++ b/apps/omg/test/omg/state/core_test.exs
@@ -695,11 +695,16 @@ defmodule OMG.State.CoreTest do
     assert {:ok, {[], {[], [^utxo_pos_exit_1]}}, ^state} = Core.exit_utxos([utxo_pos_exit_1], state)
   end
 
-  @tag fixtures: [:state_empty]
-  test "notifies about invalid in-flight exit", %{state_empty: state} do
-    piggyback = %{tx_hash: 1, output_index: 1, omg_data: %{piggyback_type: :output}}
+  @tag fixtures: [:state_alice_deposit]
+  test "ignores a piggyback of a non-included tx's outout", %{state_alice_deposit: state} do
+    piggyback_event = %{tx_hash: 1, output_index: 0, omg_data: %{piggyback_type: :output}}
+    assert {:ok, {[], {[], []}}, ^state} = Core.exit_utxos([piggyback_event], state)
+  end
 
-    assert {:ok, {[], {[], [^piggyback]}}, ^state} = Core.exit_utxos([piggyback], state)
+  @tag fixtures: [:state_alice_deposit]
+  test "ignores on exiting, when input piggybacks are detected", %{state_alice_deposit: state} do
+    piggyback_event = %{tx_hash: 1, output_index: 0, omg_data: %{piggyback_type: :input}}
+    assert {:ok, {[], {[], []}}, ^state} = Core.exit_utxos([piggyback_event], state)
   end
 
   @tag fixtures: [:alice, :state_empty]


### PR DESCRIPTION
Found when #855 

## Overview

When doing ALD compatibility, I managed to introduce a bug, where `input` piggybacks would crash the child chain (a bit silently, b/c #1141, hence our integration tests didn't pick this up)

## Changes

- fix bug - now child chain will completetly ignore input piggybacking events (like it did before). The bug manifests with this being thrown from the child chain server, when one piggybacks on input:
```
(omg) lib/omg/state/core.ex:387: OMG.State.Core.find_utxo_matching_piggyback(%{eth_height: 576, event_signature: "InFlightExitInputPiggybacked(address,bytes32,uint16)".........
...
** (EXIT) an exception was raised:
        ** (FunctionClauseError) no function clause matching in OMG.State.Core.find_utxo_matching_piggyback/2
...
```
- added an explicit `OMG.State.Core` test for this
- added a more explicit `ChildChain` integration test for this to be extra sure

## Testing

`mix test`