### PR TITLE
Allow perftesting all kinds of exits, as handled by the Watcher

### DIFF
--- a/apps/omg_eth/test/support/wait_for.ex
+++ b/apps/omg_eth/test/support/wait_for.ex
@@ -20,6 +20,8 @@ defmodule Support.WaitFor do
   alias OMG.Eth.Encoding
   alias __MODULE__
 
+  use OMG.Utils.LoggerExt
+
   def eth_rpc(timeout \\ 10_000) do
     f = fn ->
       case Ethereumex.HttpClient.eth_syncing() do
@@ -67,15 +69,10 @@ defmodule Support.WaitFor do
   defp repeat_until_ok(f) do
     Process.sleep(100)
 
-    try do
-      case f.() do
-        :ok = return -> return
-        {:ok, _} = return -> return
-        _ -> repeat_until_ok(f)
-      end
-    catch
-      _something -> repeat_until_ok(f)
-      :error, {:badmatch, _} = _error -> repeat_until_ok(f)
+    case f.() do
+      :ok = return -> return
+      {:ok, _} = return -> return
+      _ -> repeat_until_ok(f)
     end
   end
 end

--- a/apps/omg_performance/lib/omg_performance/byzantine_events.ex
+++ b/apps/omg_performance/lib/omg_performance/byzantine_events.ex
@@ -38,10 +38,10 @@ defmodule OMG.Performance.ByzantineEvents do
 
   use OMG.Utils.LoggerExt
 
-  alias OMG.Performance.HttpRPC.WatcherClient
   alias OMG.Performance.ByzantineEvents.TransactionCreator
-  alias OMG.Utils.HttpRPC.Encoding
+  alias OMG.Performance.HttpRPC.WatcherClient
   alias OMG.State.Transaction
+  alias OMG.Utils.HttpRPC.Encoding
   alias Support.WaitFor
 
   @doc """
@@ -306,7 +306,7 @@ defmodule OMG.Performance.ByzantineEvents do
   challenge_responses = timeit ByzantineEvents.get_many_non_canonical_proofs(to_challenge)
   ```
   """
-  @spec get_many_non_canonical_proofs(list(Transaction.txbytes())) :: list(map())
+  @spec get_many_non_canonical_proofs(list(Transaction.tx_bytes())) :: list(map())
   def get_many_non_canonical_proofs(txs) do
     txs
     |> Enum.shuffle()
@@ -334,7 +334,10 @@ defmodule OMG.Performance.ByzantineEvents do
   challenge_responses = timeit ByzantineEvents.get_many_non_canonical_proofs(to_challenge)
   ```
   """
-  @spec get_many_invalid_non_canonical_proofs(list(Transaction.Signed.txbytes()), list(Transaction.Signed.txbytes())) ::
+  @spec get_many_invalid_non_canonical_proofs(
+          list(Transaction.Signed.tx_bytes()),
+          list(Transaction.Signed.tx_bytes())
+        ) ::
           list(map())
   def get_many_invalid_non_canonical_proofs(in_flight_txs, competitor_txs) do
     competitor_txs
@@ -397,7 +400,7 @@ defmodule OMG.Performance.ByzantineEvents do
   challenge_responses = timeit ByzantineEvents.get_many_canonicity_responses(to_challenge)
   ```
   """
-  @spec get_many_canonicity_responses(list(Transaction.Signed.txbytes())) :: list(map())
+  @spec get_many_canonicity_responses(list(Transaction.Signed.tx_bytes())) :: list(map())
   def get_many_canonicity_responses(txs) do
     txs
     |> Enum.shuffle()
@@ -438,7 +441,7 @@ defmodule OMG.Performance.ByzantineEvents do
   challenge_responses = timeit ByzantineEvents.get_many_non_canonical_proofs(to_challenge)
   ```
   """
-  @spec get_many_piggyback_challenges(list({Transaction.txbytes(), list(non_neg_integer), list(non_neg_integer)})) ::
+  @spec get_many_piggyback_challenges(list({Transaction.tx_bytes(), list(non_neg_integer), list(non_neg_integer)})) ::
           list(map())
   def get_many_piggyback_challenges(piggybacks) do
     piggybacks

--- a/apps/omg_performance/lib/omg_performance/byzantine_events/mutations.ex
+++ b/apps/omg_performance/lib/omg_performance/byzantine_events/mutations.ex
@@ -1,0 +1,39 @@
+# Copyright 2019 OmiseGO Pte Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defmodule OMG.Performance.ByzantineEvents.Mutations do
+  @moduledoc """
+  Provides helper functions mutate existing entities, preparing them to be used by performance testing routines, for
+  example creating double-spending transactions from healthy transactions
+  """
+
+  alias OMG.Crypto
+  alias OMG.DevCrypto
+  alias OMG.State.Transaction
+
+  @doc """
+  Mutates an Enumerable of signed, encoded transactions, by modifying the metadata field
+  """
+  def mutate_txs(txs, signers_priv_keys) do
+    txs
+    |> Enum.map(&Transaction.Signed.decode!/1)
+    |> Enum.map(&mutate_raw_tx(&1.raw_tx))
+    |> Enum.map(&DevCrypto.sign(&1, signers_priv_keys))
+    |> Enum.map(&Transaction.Signed.encode/1)
+  end
+
+  # just put as metadata something different from the current metadata
+  defp mutate_raw_tx(%{metadata: old_metadata} = raw_tx),
+    do: %{raw_tx | metadata: Crypto.hash(old_metadata)}
+end

--- a/apps/omg_performance/lib/omg_performance/byzantine_events/transaction_creator.ex
+++ b/apps/omg_performance/lib/omg_performance/byzantine_events/transaction_creator.ex
@@ -28,12 +28,12 @@ defmodule OMG.Performance.ByzantineEvents.TransactionCreator do
   @doc """
   Provided a utxo position, produce any spending transaction
   """
+  def spend_utxo_by(encoded_utxo_pos, recipient_address, sender_priv_key, amount) when is_integer(encoded_utxo_pos),
+    do: spend_utxo_by(Utxo.Position.decode!(encoded_utxo_pos), recipient_address, sender_priv_key, amount)
+
   def spend_utxo_by(Utxo.position(blknum, txindex, oindex), recipient_address, sender_priv_key, amount) do
     Transaction.Payment.new([{blknum, txindex, oindex}], [{recipient_address, @eth, amount}])
     |> DevCrypto.sign([sender_priv_key])
     |> Transaction.Signed.encode()
   end
-
-  def spend_utxo_by(encoded_utxo_pos, recipient_address, sender_priv_key, amount),
-    do: spend_utxo_by(Utxo.Position.decode!(encoded_utxo_pos), recipient_address, sender_priv_key, amount)
 end

--- a/apps/omg_performance/lib/omg_performance/byzantine_events/transaction_creator.ex
+++ b/apps/omg_performance/lib/omg_performance/byzantine_events/transaction_creator.ex
@@ -1,0 +1,39 @@
+# Copyright 2019 OmiseGO Pte Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defmodule OMG.Performance.ByzantineEvents.TransactionCreator do
+  @moduledoc """
+  Helper module which wraps all things necessary to easily create and sign transactions to use when perftesting
+  """
+
+  alias OMG.DevCrypto
+  alias OMG.State.Transaction
+  alias OMG.Utxo
+
+  require Utxo
+
+  @eth OMG.Eth.RootChain.eth_pseudo_address()
+
+  @doc """
+  Provided a utxo position, produce any spending transaction
+  """
+  def spend_utxo_by(Utxo.position(blknum, txindex, oindex), recipient_address, sender_priv_key, amount) do
+    Transaction.Payment.new([{blknum, txindex, oindex}], [{recipient_address, @eth, amount}])
+    |> DevCrypto.sign([sender_priv_key])
+    |> Transaction.Signed.encode()
+  end
+
+  def spend_utxo_by(encoded_utxo_pos, recipient_address, sender_priv_key, amount),
+    do: spend_utxo_by(Utxo.Position.decode!(encoded_utxo_pos), recipient_address, sender_priv_key, amount)
+end

--- a/apps/omg_performance/lib/omg_performance/extended_perftest.ex
+++ b/apps/omg_performance/lib/omg_performance/extended_perftest.ex
@@ -43,7 +43,7 @@ defmodule OMG.Performance.ExtendedPerftest do
 
   Performance.init()
   spenders = Generators.generate_users(2)
-  Performance.ExtendedPerftest.start(100, spenders, destdir: destdir)
+  Performance.ExtendedPerftest.start(100, spenders)
   ```
 
   The results are going to be waiting for you in a file within `destdir` and will be logged.

--- a/apps/omg_performance/lib/omg_performance/extended_perftest.ex
+++ b/apps/omg_performance/lib/omg_performance/extended_perftest.ex
@@ -52,6 +52,7 @@ defmodule OMG.Performance.ExtendedPerftest do
     - :destdir - directory where the results will be put, relative to `pwd`, defaults to `"."`
     - :randomized - whether the non-change outputs of the txs sent out will be random or equal to sender (if `false`),
       defaults to `true`
+    - :throttle_ms - if provided, will wait this much before submitting the next tx
   """
   @spec start(pos_integer(), list(TestHelper.entity()), keyword()) :: :ok
   def start(ntx_to_send, spenders, opts \\ []) do

--- a/apps/omg_performance/lib/omg_performance/generators.ex
+++ b/apps/omg_performance/lib/omg_performance/generators.ex
@@ -61,9 +61,9 @@ defmodule OMG.Performance.Generators do
 
   Options:
     - :use_blocks - if not nil, will use this as the stream of blocks, otherwise streams from child chain rpc
-    - :no_deposit_spends - if true, will limit only to transactions that do ont spend deposits (see function with the
+    - :no_deposit_spends - if true, will limit only to transactions that do not spend deposits (see function with the
       same name for explanation)
-    - :sent_by - if not nil, will limit to txs sent
+    - :sent_by - if not nil, will limit to txs sent by this particular address
     - :take - if not nil, will limit to this many results
   """
   @spec stream_transactions([OMG.Block.t()]) :: [binary()]

--- a/apps/omg_performance/lib/omg_performance/generators.ex
+++ b/apps/omg_performance/lib/omg_performance/generators.ex
@@ -88,7 +88,8 @@ defmodule OMG.Performance.Generators do
     if opts[:take], do: Enum.take(transactions, opts[:take]), else: transactions
   end
 
-  # FIXME: whoops, we cannot open IFEs from included txs spending deposits. When fixed, remove this filter
+  # NOTE: whoops, we cannot open IFEs from included txs spending deposits. When fixed, remove this filter
+  #       https://github.com/omisego/elixir-omg/issues/1128
   defp no_deposit_spends?(txbytes) do
     txbytes
     |> Transaction.Signed.decode!()

--- a/apps/omg_performance/lib/omg_performance/http_rpc/watcher_client.ex
+++ b/apps/omg_performance/lib/omg_performance/http_rpc/watcher_client.ex
@@ -14,7 +14,15 @@
 
 defmodule OMG.Performance.HttpRPC.WatcherClient do
   @moduledoc """
-  Provides access to Watcher's RPC API
+  Provides access to Watcher's RPC API, as required by the `OMG.Performance` tool
+
+
+  TODO: This module includes a big fat copy paster from `Support.WatcherHelper` - do sth about this later
+  We need an exact set of functionalities from the `omg_performance`'s Watcher client, but they're executed
+  differently, because in here we're calling the Watcher's API on a slightly different level (full HTTP stack)
+  Differences:
+   - atoms not strings as keys
+   - don't have the many helpers to assert `success?`/`no_success?` etc., success is always expected
   """
 
   alias OMG.Utils.HttpRPC.ClientAdapter
@@ -23,9 +31,9 @@ defmodule OMG.Performance.HttpRPC.WatcherClient do
 
   require Utxo
 
-  #
-  # TODO: here begins a big fat copy paster from `watcher_helper.ex` - do sth about this later
-  #
+  @doc """
+  Copied from `Support.WatcherHelper`, see moduledoc
+  """
   def get_balance(address, token) do
     encoded_token = Encoding.to_hex(token)
 
@@ -35,42 +43,66 @@ defmodule OMG.Performance.HttpRPC.WatcherClient do
     |> Map.get("amount")
   end
 
+  @doc """
+  Copied from `Support.WatcherHelper`, see moduledoc
+  """
   def get_utxos(address) do
-    success?("/account.get_utxos", %{:address => Encoding.to_hex(address)})
+    call("/account.get_utxos", %{:address => Encoding.to_hex(address)})
   end
 
+  @doc """
+  Copied from `Support.WatcherHelper`, see moduledoc
+  """
   def get_exitable_utxos(address) do
-    success?("/account.get_exitable_utxos", %{:address => Encoding.to_hex(address)})
+    call("/account.get_exitable_utxos", %{:address => Encoding.to_hex(address)})
   end
 
+  @doc """
+  Copied from `Support.WatcherHelper`, see moduledoc
+  """
   def get_balance(address) do
-    success?("/account.get_balance", %{:address => Encoding.to_hex(address)})
+    call("/account.get_balance", %{:address => Encoding.to_hex(address)})
   end
 
+  @doc """
+  Copied from `Support.WatcherHelper`, see moduledoc
+  """
   def get_exit_data(blknum, txindex, oindex),
     do: get_exit_data(Utxo.Position.encode(Utxo.position(blknum, txindex, oindex)))
 
+  @doc """
+  Copied from `Support.WatcherHelper`, see moduledoc
+  """
   def get_exit_data(encoded_position) do
-    data = success?("utxo.get_exit_data", %{utxo_pos: encoded_position})
-    decode_response(data, [:txbytes, :proof])
+    data = call("utxo.get_exit_data", %{utxo_pos: encoded_position})
+    ClientAdapter.decode16(data, [:txbytes, :proof])
   end
 
+  @doc """
+  Copied from `Support.WatcherHelper`, see moduledoc
+  """
   def get_exit_challenge(utxo_pos) do
-    data = success?("utxo.get_challenge_data", %{utxo_pos: utxo_pos})
+    data = call("utxo.get_challenge_data", %{utxo_pos: utxo_pos})
 
-    decode_response(data, [:exiting_tx, :txbytes, :sig])
+    ClientAdapter.decode16(data, [:exiting_tx, :txbytes, :sig])
   end
 
+  @doc """
+  Copied from `Support.WatcherHelper`, see moduledoc
+  """
   def get_in_flight_exit(transaction) do
-    exit_data = success?("in_flight_exit.get_data", %{txbytes: Encoding.to_hex(transaction)})
+    exit_data = call("in_flight_exit.get_data", %{txbytes: Encoding.to_hex(transaction)})
 
-    decode_response(exit_data, [:in_flight_tx, :input_txs, :input_txs_inclusion_proofs, :in_flight_tx_sigs])
+    ClientAdapter.decode16(exit_data, [:in_flight_tx, :input_txs, :input_txs_inclusion_proofs, :in_flight_tx_sigs])
   end
 
+  @doc """
+  Copied from `Support.WatcherHelper`, see moduledoc
+  """
   def get_in_flight_exit_competitors(transaction) do
-    competitor_data = success?("in_flight_exit.get_competitor", %{txbytes: Encoding.to_hex(transaction)})
+    competitor_data = call("in_flight_exit.get_competitor", %{txbytes: Encoding.to_hex(transaction)})
 
-    decode_response(competitor_data, [
+    ClientAdapter.decode16(competitor_data, [
       :in_flight_txbytes,
       :competing_txbytes,
       :competing_sig,
@@ -79,26 +111,35 @@ defmodule OMG.Performance.HttpRPC.WatcherClient do
     ])
   end
 
+  @doc """
+  Copied from `Support.WatcherHelper`, see moduledoc
+  """
   def get_prove_canonical(transaction) do
-    competitor_data = success?("in_flight_exit.prove_canonical", %{txbytes: Encoding.to_hex(transaction)})
+    competitor_data = call("in_flight_exit.prove_canonical", %{txbytes: Encoding.to_hex(transaction)})
 
-    decode_response(competitor_data, [:in_flight_txbytes, :in_flight_proof])
+    ClientAdapter.decode16(competitor_data, [:in_flight_txbytes, :in_flight_proof])
   end
 
+  @doc """
+  Copied from `Support.WatcherHelper`, see moduledoc
+  """
   def submit(transaction) do
-    submission_info = success?("transaction.submit", %{transaction: Encoding.to_hex(transaction)})
+    submission_info = call("transaction.submit", %{transaction: Encoding.to_hex(transaction)})
 
-    decode_response(submission_info, ["txhash"])
+    ClientAdapter.decode16(submission_info, ["txhash"])
   end
 
+  @doc """
+  Copied from `Support.WatcherHelper`, see moduledoc
+  """
   def get_input_challenge_data(transaction, input_index) do
     proof_data =
-      success?("in_flight_exit.get_input_challenge_data", %{
+      call("in_flight_exit.get_input_challenge_data", %{
         txbytes: Encoding.to_hex(transaction),
         input_index: input_index
       })
 
-    decode_response(proof_data, [
+    ClientAdapter.decode16(proof_data, [
       :in_flight_txbytes,
       :spending_txbytes,
       :spending_sig,
@@ -106,14 +147,17 @@ defmodule OMG.Performance.HttpRPC.WatcherClient do
     ])
   end
 
+  @doc """
+  Copied from `Support.WatcherHelper`, see moduledoc
+  """
   def get_output_challenge_data(transaction, output_index) do
     proof_data =
-      success?("in_flight_exit.get_output_challenge_data", %{
+      call("in_flight_exit.get_output_challenge_data", %{
         txbytes: Encoding.to_hex(transaction),
         output_index: output_index
       })
 
-    decode_response(proof_data, [
+    ClientAdapter.decode16(proof_data, [
       :in_flight_txbytes,
       :in_flight_proof,
       :spending_txbytes,
@@ -121,27 +165,16 @@ defmodule OMG.Performance.HttpRPC.WatcherClient do
     ])
   end
 
-  # here ends the copy-paste
-  #
-
-  # some functions that I added, following the copy-pasted convention above
-
+  @doc """
+  Copied from `Support.WatcherHelper`, see moduledoc
+  """
   def get_status() do
-    success?("status.get", %{})
+    call("status.get", %{})
   end
 
-  # here are some copy-paste-related functions to get it off the ground
-  # FIXME: we're not asserting success here, rename
-  defp success?(path, body) do
-    watcher_url = Application.fetch_env!(:omg_performance, :watcher_url)
-    {:ok, data} = call(body, path, watcher_url)
+  defp call(path, body) do
+    url = Application.fetch_env!(:omg_performance, :watcher_url)
+    {:ok, response} = ClientAdapter.rpc_post(body, path, url) |> ClientAdapter.get_response_body()
+    response
   end
-
-  # end those functions here
-
-  defp call(params, path, url),
-    do: ClientAdapter.rpc_post(params, path, url) |> ClientAdapter.get_response_body()
-
-  defp decode_response({:ok, response}, keys), do: {:ok, ClientAdapter.decode16(response, keys)}
-  defp decode_response(other, _), do: other
 end

--- a/apps/omg_performance/lib/omg_performance/http_rpc/watcher_client.ex
+++ b/apps/omg_performance/lib/omg_performance/http_rpc/watcher_client.ex
@@ -17,7 +17,9 @@ defmodule OMG.Performance.HttpRPC.WatcherClient do
   Provides access to Watcher's RPC API, as required by the `OMG.Performance` tool
 
 
-  TODO: This module includes a big fat copy paster from `Support.WatcherHelper` - do sth about this later
+  NOTE: This module includes a big fat copy paster from `Support.WatcherHelper`, but since requirements are different,
+        we're allowing a separate implenentation.
+
   We need an exact set of functionalities from the `omg_performance`'s Watcher client, but they're executed
   differently, because in here we're calling the Watcher's API on a slightly different level (full HTTP stack)
   Differences:
@@ -75,7 +77,7 @@ defmodule OMG.Performance.HttpRPC.WatcherClient do
   """
   def get_exit_data(encoded_position) do
     data = call("utxo.get_exit_data", %{utxo_pos: encoded_position})
-    ClientAdapter.decode16(data, [:txbytes, :proof])
+    ClientAdapter.decode16!(data, [:txbytes, :proof])
   end
 
   @doc """
@@ -84,7 +86,7 @@ defmodule OMG.Performance.HttpRPC.WatcherClient do
   def get_exit_challenge(utxo_pos) do
     data = call("utxo.get_challenge_data", %{utxo_pos: utxo_pos})
 
-    ClientAdapter.decode16(data, [:exiting_tx, :txbytes, :sig])
+    ClientAdapter.decode16!(data, [:exiting_tx, :txbytes, :sig])
   end
 
   @doc """
@@ -93,7 +95,7 @@ defmodule OMG.Performance.HttpRPC.WatcherClient do
   def get_in_flight_exit(transaction) do
     exit_data = call("in_flight_exit.get_data", %{txbytes: Encoding.to_hex(transaction)})
 
-    ClientAdapter.decode16(exit_data, [:in_flight_tx, :input_txs, :input_txs_inclusion_proofs, :in_flight_tx_sigs])
+    ClientAdapter.decode16!(exit_data, [:in_flight_tx, :input_txs, :input_txs_inclusion_proofs, :in_flight_tx_sigs])
   end
 
   @doc """
@@ -102,7 +104,7 @@ defmodule OMG.Performance.HttpRPC.WatcherClient do
   def get_in_flight_exit_competitors(transaction) do
     competitor_data = call("in_flight_exit.get_competitor", %{txbytes: Encoding.to_hex(transaction)})
 
-    ClientAdapter.decode16(competitor_data, [
+    ClientAdapter.decode16!(competitor_data, [
       :in_flight_txbytes,
       :competing_txbytes,
       :competing_sig,
@@ -117,7 +119,7 @@ defmodule OMG.Performance.HttpRPC.WatcherClient do
   def get_prove_canonical(transaction) do
     competitor_data = call("in_flight_exit.prove_canonical", %{txbytes: Encoding.to_hex(transaction)})
 
-    ClientAdapter.decode16(competitor_data, [:in_flight_txbytes, :in_flight_proof])
+    ClientAdapter.decode16!(competitor_data, [:in_flight_txbytes, :in_flight_proof])
   end
 
   @doc """
@@ -126,7 +128,7 @@ defmodule OMG.Performance.HttpRPC.WatcherClient do
   def submit(transaction) do
     submission_info = call("transaction.submit", %{transaction: Encoding.to_hex(transaction)})
 
-    ClientAdapter.decode16(submission_info, ["txhash"])
+    ClientAdapter.decode16!(submission_info, ["txhash"])
   end
 
   @doc """
@@ -139,7 +141,7 @@ defmodule OMG.Performance.HttpRPC.WatcherClient do
         input_index: input_index
       })
 
-    ClientAdapter.decode16(proof_data, [
+    ClientAdapter.decode16!(proof_data, [
       :in_flight_txbytes,
       :spending_txbytes,
       :spending_sig,
@@ -157,7 +159,7 @@ defmodule OMG.Performance.HttpRPC.WatcherClient do
         output_index: output_index
       })
 
-    ClientAdapter.decode16(proof_data, [
+    ClientAdapter.decode16!(proof_data, [
       :in_flight_txbytes,
       :in_flight_proof,
       :spending_txbytes,

--- a/apps/omg_performance/lib/omg_performance/simple_perftest.ex
+++ b/apps/omg_performance/lib/omg_performance/simple_perftest.ex
@@ -50,6 +50,7 @@ defmodule OMG.Performance.SimplePerftest do
     - :block_every_ms - how often should the artificial block creation be triggered, defaults to `2000`
     - :randomized - whether the non-change outputs of the txs sent out will be random or equal to sender (if `false`),
       defaults to `true`
+    - :throttle_ms - if provided, will wait this much before submitting the next tx
 
     **NOTE**:
 

--- a/apps/omg_performance/lib/omg_performance/simple_perftest.ex
+++ b/apps/omg_performance/lib/omg_performance/simple_perftest.ex
@@ -39,6 +39,7 @@ defmodule OMG.Performance.SimplePerftest do
   ```
   use OMG.Performance
 
+  Performance.init()
   Performance.SimplePerftest.start(50, 16)
   ```
 

--- a/apps/omg_performance/lib/performance.ex
+++ b/apps/omg_performance/lib/performance.ex
@@ -23,6 +23,7 @@ defmodule OMG.Performance do
       alias OMG.Performance.ByzantineEvents
       alias OMG.Performance.ExtendedPerftest
       alias OMG.Performance.Generators
+      alias OMG.Performance.HttpRPC.WatcherClient
 
       import Performance, only: [timeit: 1]
       require Performance

--- a/apps/omg_performance/test/omg_performance/byzantine_event_test.exs
+++ b/apps/omg_performance/test/omg_performance/byzantine_event_test.exs
@@ -151,7 +151,7 @@ defmodule OMG.Performance.ByzantineEventsTest do
 
     transactions =
       Generators.stream_transactions(sent_by: alice.addr, take: 5, no_deposit_spends: true)
-      |> ByzantineEvents.mutate_txs([alice.priv])
+      |> ByzantineEvents.Mutations.mutate_txs([alice.priv])
 
     {:ok, %{"status" => "0x1", "blockNumber" => last_exit_height}} =
       transactions
@@ -193,7 +193,7 @@ defmodule OMG.Performance.ByzantineEventsTest do
     :ok = ByzantineEvents.watcher_synchronize()
 
     transactions = Generators.stream_transactions(sent_by: alice.addr, take: 5, no_deposit_spends: true)
-    mutated_transactions = ByzantineEvents.mutate_txs(transactions, [alice.priv])
+    mutated_transactions = ByzantineEvents.Mutations.mutate_txs(transactions, [alice.priv])
 
     {:ok, %{"status" => "0x1"}} =
       transactions
@@ -217,8 +217,6 @@ defmodule OMG.Performance.ByzantineEventsTest do
     :ok = ByzantineEvents.watcher_synchronize(root_chain_height: last_response_height)
     assert Enum.count(ByzantineEvents.get_byzantine_events("invalid_ife_challenge")) == 0
   end
-
-  # FIXME: similar: make a test for timing the system under many valid output piggybacks (just piggyback on 1st output)
 
   @tag fixtures: [:perf_test, :mix_based_child_chain, :mix_based_watcher]
   test "can provide timing of operations under many output-invalid IFEs", %{perf_test: {:ok, %{destdir: destdir}}} do

--- a/apps/omg_performance/test/omg_performance/byzantine_event_test.exs
+++ b/apps/omg_performance/test/omg_performance/byzantine_event_test.exs
@@ -138,7 +138,7 @@ defmodule OMG.Performance.ByzantineEventsTest do
       |> ByzantineEvents.start_many_piggybacks(alice.addr)
 
     :ok = ByzantineEvents.watcher_synchronize(root_chain_height: last_piggyback_height)
-    assert Enum.count(ByzantineEvents.get_byzantine_events("piggyback_available")) == 0
+    assert Enum.empty?(ByzantineEvents.get_byzantine_events("piggyback_available"))
   end
 
   @tag fixtures: [:perf_test, :mix_based_child_chain, :mix_based_watcher]
@@ -179,8 +179,8 @@ defmodule OMG.Performance.ByzantineEventsTest do
       |> ByzantineEvents.prove_many_non_canonical(alice.addr)
 
     :ok = ByzantineEvents.watcher_synchronize(root_chain_height: max(last_pb_challenge_height, last_challenge_height))
-    assert Enum.count(ByzantineEvents.get_byzantine_events("invalid_piggyback")) == 0
-    assert Enum.count(ByzantineEvents.get_byzantine_events("non_canonical_ife")) == 0
+    assert Enum.empty?(ByzantineEvents.get_byzantine_events("invalid_piggyback"))
+    assert Enum.empty?(ByzantineEvents.get_byzantine_events("non_canonical_ife"))
   end
 
   @tag fixtures: [:perf_test, :mix_based_child_chain, :mix_based_watcher]
@@ -215,7 +215,7 @@ defmodule OMG.Performance.ByzantineEventsTest do
       |> ByzantineEvents.send_many_canonicity_responses(alice.addr)
 
     :ok = ByzantineEvents.watcher_synchronize(root_chain_height: last_response_height)
-    assert Enum.count(ByzantineEvents.get_byzantine_events("invalid_ife_challenge")) == 0
+    assert Enum.empty?(ByzantineEvents.get_byzantine_events("invalid_ife_challenge"))
   end
 
   @tag fixtures: [:perf_test, :mix_based_child_chain, :mix_based_watcher]
@@ -248,7 +248,7 @@ defmodule OMG.Performance.ByzantineEventsTest do
       |> ByzantineEvents.challenge_many_piggybacks(alice.addr)
 
     :ok = ByzantineEvents.watcher_synchronize(root_chain_height: last_challenge_height)
-    assert Enum.count(ByzantineEvents.get_byzantine_events("invalid_piggyback")) == 0
+    assert Enum.empty?(ByzantineEvents.get_byzantine_events("invalid_piggyback"))
   end
 
   @tag fixtures: [:perf_test, :mix_based_child_chain, :mix_based_watcher]

--- a/apps/omg_performance/test/omg_performance/byzantine_event_test.exs
+++ b/apps/omg_performance/test/omg_performance/byzantine_event_test.exs
@@ -143,6 +143,77 @@ defmodule OMG.Performance.ByzantineEventsTest do
     assert Enum.count(ByzantineEvents.get_byzantine_events("piggyback_available")) == 5
   end
 
+  @tag fixtures: [:perf_test, :mix_based_child_chain, :mix_based_watcher]
+  test "can provide timing of status.get under many challenged non-canonical IFEs - valid challenges",
+       %{perf_test: {:ok, %{destdir: destdir}}} do
+    spenders = Generators.generate_users(2)
+    alice = Enum.at(spenders, 0)
+
+    :ok = Performance.ExtendedPerftest.start(100, spenders, randomized: false, destdir: destdir)
+    :ok = ByzantineEvents.watcher_synchronize()
+
+    transactions = Generators.stream_transactions(sent_by: alice.addr, take: 5, no_deposit_spends: true)
+
+    # valid/canonical/included ifes first
+    {:ok, %{"status" => "0x1", "blockNumber" => last_exit_height1}} =
+      transactions
+      |> ByzantineEvents.get_many_ifes()
+      |> ByzantineEvents.start_many_ifes(alice.addr)
+
+    # non canonical mutations second
+    {:ok, %{"status" => "0x1", "blockNumber" => last_exit_height2}} =
+      transactions
+      |> ByzantineEvents.mutate_txs([alice.priv])
+      |> ByzantineEvents.get_many_ifes()
+      |> ByzantineEvents.start_many_ifes(alice.addr)
+
+    :ok = ByzantineEvents.watcher_synchronize(root_chain_height: max(last_exit_height1, last_exit_height2))
+
+    {:ok, %{"status" => "0x1", "blockNumber" => last_challenge_height}} =
+      ByzantineEvents.get_byzantine_events("non_canonical_ife")
+      |> ByzantineEvents.get_many_non_canonical_proofs()
+      |> ByzantineEvents.prove_many_non_canonical(alice.addr)
+
+    :ok = ByzantineEvents.watcher_synchronize(root_chain_height: last_challenge_height)
+
+    assert Enum.count(ByzantineEvents.get_byzantine_events("non_canonical_ife")) == 0
+  end
+
+  @tag fixtures: [:perf_test, :mix_based_child_chain, :mix_based_watcher]
+  test "can provide timing of operations under many challenged non-canonical IFEs - invalid challenges",
+       %{perf_test: {:ok, %{destdir: destdir}}} do
+    spenders = Generators.generate_users(2)
+    alice = Enum.at(spenders, 0)
+
+    :ok = Performance.ExtendedPerftest.start(100, spenders, randomized: false, destdir: destdir)
+    :ok = ByzantineEvents.watcher_synchronize()
+
+    transactions = Generators.stream_transactions(sent_by: alice.addr, take: 5, no_deposit_spends: true)
+    mutated_transactions = ByzantineEvents.mutate_txs(transactions, [alice.priv])
+
+    {:ok, %{"status" => "0x1"}} =
+      transactions
+      |> ByzantineEvents.get_many_ifes()
+      |> ByzantineEvents.start_many_ifes(alice.addr)
+
+    {:ok, %{"status" => "0x1", "blockNumber" => last_challenge_height}} =
+      transactions
+      |> ByzantineEvents.get_many_invalid_non_canonical_proofs(mutated_transactions)
+      |> ByzantineEvents.prove_many_non_canonical(alice.addr)
+
+    :ok = ByzantineEvents.watcher_synchronize(root_chain_height: last_challenge_height)
+
+    assert Enum.count(ByzantineEvents.get_byzantine_events("invalid_ife_challenge")) == 5
+
+    {:ok, %{"status" => "0x1", "blockNumber" => last_response_height}} =
+      ByzantineEvents.get_byzantine_events("invalid_ife_challenge")
+      |> ByzantineEvents.get_many_canonicity_responses()
+      |> ByzantineEvents.send_many_canonicity_responses(alice.addr)
+
+    :ok = ByzantineEvents.watcher_synchronize(root_chain_height: last_response_height)
+    assert Enum.count(ByzantineEvents.get_byzantine_events("invalid_ife_challenge")) == 0
+  end
+
   # FIXME: similar: make a test for timing the system under many valid output piggybacks (just piggyback on 1st output)
 
   @tag fixtures: [:perf_test, :mix_based_child_chain, :mix_based_watcher]

--- a/apps/omg_performance/test/omg_performance/byzantine_events/mutations_test.exs
+++ b/apps/omg_performance/test/omg_performance/byzantine_events/mutations_test.exs
@@ -1,0 +1,45 @@
+# Copyright 2019 OmiseGO Pte Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defmodule OMG.Performance.ByzantineEvents.MutationsTest do
+  use ExUnit.Case, async: true
+
+  alias OMG.Performance.ByzantineEvents.Mutations
+  alias OMG.State.Transaction
+
+  @eth OMG.Eth.RootChain.eth_pseudo_address()
+
+  setup do
+    alice = OMG.TestHelper.generate_entity()
+    {:ok, %{alice: alice}}
+  end
+
+  describe "mutate_txs/2" do
+    test "should produce a different signed transaction every time", %{alice: alice} do
+      tx = OMG.TestHelper.create_encoded([{1000, 0, 0, alice}], @eth, [{alice, 1}])
+      [mutated] = Mutations.mutate_txs([tx], [alice.priv])
+      assert mutated != tx
+      [mutated2] = Mutations.mutate_txs([mutated], [alice.priv])
+      assert mutated2 != mutated
+      assert mutated2 != tx
+    end
+
+    test "should sign using the private key provided", %{alice: alice} do
+      tx = OMG.TestHelper.create_encoded([{1000, 0, 0, alice}], @eth, [{alice, 1}])
+      [mutated] = Mutations.mutate_txs([tx], [alice.priv])
+      assert %Transaction.Recovered{witnesses: witnesses} = Transaction.Recovered.recover_from!(tx)
+      assert %Transaction.Recovered{witnesses: ^witnesses} = Transaction.Recovered.recover_from!(mutated)
+    end
+  end
+end

--- a/apps/omg_performance/test/omg_performance/byzantine_events/transaction_creator_test.exs
+++ b/apps/omg_performance/test/omg_performance/byzantine_events/transaction_creator_test.exs
@@ -1,0 +1,40 @@
+# Copyright 2019 OmiseGO Pte Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defmodule OMG.Performance.ByzantineEvents.TransactionCreatorTest do
+  use ExUnit.Case, async: true
+
+  alias OMG.Performance.ByzantineEvents.TransactionCreator
+  alias OMG.State.Transaction
+  alias OMG.Utxo
+
+  require Utxo
+
+  setup do
+    alice = OMG.TestHelper.generate_entity()
+    {:ok, %{alice: alice}}
+  end
+
+  describe "spend_utxo_by" do
+    test "should create a well signed transaction from an owner", %{alice: alice} do
+      encoded_tx = TransactionCreator.spend_utxo_by(100_000_000_000_000, alice.addr, alice.priv, 1)
+      assert {:ok, %Transaction.Recovered{}} = Transaction.Recovered.recover_from(encoded_tx)
+    end
+
+    test "should accept a decoded utxo position", %{alice: alice} do
+      encoded_tx = TransactionCreator.spend_utxo_by(Utxo.position(1_000_000, 4, 5), alice.addr, alice.priv, 1)
+      assert {:ok, %Transaction.Recovered{}} = Transaction.Recovered.recover_from(encoded_tx)
+    end
+  end
+end

--- a/apps/omg_utils/lib/omg_utils/http_rpc/client_adapter.ex
+++ b/apps/omg_utils/lib/omg_utils/http_rpc/client_adapter.ex
@@ -93,7 +93,9 @@ defmodule OMG.Utils.HttpRPC.ClientAdapter do
 
   defp convert_keys_to_atoms(data) when is_map(data) do
     data
-    |> Stream.map(fn {k, v} -> {String.to_existing_atom(k), v} end)
+    |> Stream.map(fn {k, v} -> {String.to_existing_atom(k), convert_keys_to_atoms(v)} end)
     |> Map.new()
   end
+
+  defp convert_keys_to_atoms(other_data), do: other_data
 end

--- a/apps/omg_utils/lib/omg_utils/http_rpc/client_adapter.ex
+++ b/apps/omg_utils/lib/omg_utils/http_rpc/client_adapter.ex
@@ -61,17 +61,17 @@ defmodule OMG.Utils.HttpRPC.ClientAdapter do
   @doc """
   Decodes specified keys in map from hex to binary
   """
-  @spec decode16(map(), list()) :: map()
-  def decode16(data, keys) do
+  @spec decode16!(map(), list()) :: map()
+  def decode16!(data, keys) do
     keys
-    |> Enum.into(%{}, &decode16_for_key(data, &1))
+    |> Enum.into(%{}, &decode16_for_key!(data, &1))
     |> (&Map.merge(data, &1)).()
   end
 
-  defp decode16_for_key(data, key) do
+  defp decode16_for_key!(data, key) do
     case data[key] do
       value when is_binary(value) ->
-        {key, decode_binary!(value)}
+        {key, decode16_value!(value)}
 
       value when is_list(value) ->
         bin_list =
@@ -83,7 +83,7 @@ defmodule OMG.Utils.HttpRPC.ClientAdapter do
     end
   end
 
-  defp decode_binary!(value) do
+  defp decode16_value!(value) do
     {:ok, bin} = Encoding.from_hex(value)
     bin
   end

--- a/apps/omg_utils/test/omg_utils/http_rpc/client_adapter_test.exs
+++ b/apps/omg_utils/test/omg_utils/http_rpc/client_adapter_test.exs
@@ -24,7 +24,7 @@ defmodule OMG.Utils.HttpRPC.ClientAdapterTest do
       expected_map = %{"key_1" => "value_1", "key_2" => "value_2", "key_3" => "value_3"}
 
       encoded_map = expected_map |> Response.sanitize()
-      decoded_map = ClientAdapter.decode16(encoded_map, ["key_2"])
+      decoded_map = ClientAdapter.decode16!(encoded_map, ["key_2"])
 
       assert decoded_map["key_1"] == expected_map["key_1"] |> Encoding.to_hex()
       assert decoded_map["key_2"] == expected_map["key_2"]
@@ -32,7 +32,7 @@ defmodule OMG.Utils.HttpRPC.ClientAdapterTest do
     end
 
     test "called with empty map returns empty map" do
-      assert %{} == ClientAdapter.decode16(%{}, [])
+      assert %{} == ClientAdapter.decode16!(%{}, [])
     end
 
     test "decodes all up/down/mixed case values" do
@@ -41,7 +41,7 @@ defmodule OMG.Utils.HttpRPC.ClientAdapterTest do
                "key_2" => <<222, 173, 190, 239>>,
                "key_3" => <<222, 173, 190, 239>>
              } ==
-               ClientAdapter.decode16(
+               ClientAdapter.decode16!(
                  %{
                    "key_1" => "0xdeadbeef",
                    "key_2" => "0xDEADBEEF",
@@ -60,28 +60,28 @@ defmodule OMG.Utils.HttpRPC.ClientAdapterTest do
       }
 
       assert_raise CaseClauseError, fn ->
-        ClientAdapter.decode16(expected, ["not_bin1"])
+        ClientAdapter.decode16!(expected, ["not_bin1"])
       end
 
       assert_raise CaseClauseError, fn ->
-        ClientAdapter.decode16(expected, ["not_bin2"])
+        ClientAdapter.decode16!(expected, ["not_bin2"])
       end
 
       assert_raise MatchError, fn ->
-        ClientAdapter.decode16(expected, ["not_hex"])
+        ClientAdapter.decode16!(expected, ["not_hex"])
       end
 
       assert_raise CaseClauseError, fn ->
-        ClientAdapter.decode16(expected, ["not_value"])
+        ClientAdapter.decode16!(expected, ["not_value"])
       end
 
       assert_raise CaseClauseError, fn ->
-        ClientAdapter.decode16(expected, ["not_exists"])
+        ClientAdapter.decode16!(expected, ["not_exists"])
       end
     end
 
     test "decodes lists" do
-      assert %{"list" => ["\v", <<4>>]} = ClientAdapter.decode16(%{"list" => ["0x0B", "0x04"]}, ["list"])
+      assert %{"list" => ["\v", <<4>>]} = ClientAdapter.decode16!(%{"list" => ["0x0B", "0x04"]}, ["list"])
     end
   end
 end

--- a/apps/omg_utils/test/omg_utils/http_rpc/client_adapter_test.exs
+++ b/apps/omg_utils/test/omg_utils/http_rpc/client_adapter_test.exs
@@ -1,0 +1,87 @@
+# Copyright 2019 OmiseGO Pte Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defmodule OMG.Utils.HttpRPC.ClientAdapterTest do
+  use ExUnit.Case, async: true
+
+  alias OMG.Utils.HttpRPC.ClientAdapter
+  alias OMG.Utils.HttpRPC.Encoding
+  alias OMG.Utils.HttpRPC.Response
+
+  describe "decode16/2" do
+    test "decodes only specified fields" do
+      expected_map = %{"key_1" => "value_1", "key_2" => "value_2", "key_3" => "value_3"}
+
+      encoded_map = expected_map |> Response.sanitize()
+      decoded_map = ClientAdapter.decode16(encoded_map, ["key_2"])
+
+      assert decoded_map["key_1"] == expected_map["key_1"] |> Encoding.to_hex()
+      assert decoded_map["key_2"] == expected_map["key_2"]
+      assert decoded_map["key_3"] == expected_map["key_3"] |> Encoding.to_hex()
+    end
+
+    test "called with empty map returns empty map" do
+      assert %{} == ClientAdapter.decode16(%{}, [])
+    end
+
+    test "decodes all up/down/mixed case values" do
+      assert %{
+               "key_1" => <<222, 173, 190, 239>>,
+               "key_2" => <<222, 173, 190, 239>>,
+               "key_3" => <<222, 173, 190, 239>>
+             } ==
+               ClientAdapter.decode16(
+                 %{
+                   "key_1" => "0xdeadbeef",
+                   "key_2" => "0xDEADBEEF",
+                   "key_3" => "0xDeadBeeF"
+                 },
+                 ["key_1", "key_2", "key_3"]
+               )
+    end
+
+    test "is safe and fails when asked to decode anything else than hex-encoded values" do
+      expected = %{
+        "not_bin1" => 0,
+        "not_bin2" => :atom,
+        "not_hex" => "string",
+        "not_value" => nil
+      }
+
+      assert_raise CaseClauseError, fn ->
+        ClientAdapter.decode16(expected, ["not_bin1"])
+      end
+
+      assert_raise CaseClauseError, fn ->
+        ClientAdapter.decode16(expected, ["not_bin2"])
+      end
+
+      assert_raise MatchError, fn ->
+        ClientAdapter.decode16(expected, ["not_hex"])
+      end
+
+      assert_raise CaseClauseError, fn ->
+        ClientAdapter.decode16(expected, ["not_value"])
+      end
+
+      assert_raise CaseClauseError, fn ->
+        ClientAdapter.decode16(expected, ["not_exists"])
+      end
+    end
+
+    test "decodes lists" do
+      assert %{"list" => ["\v", <<4>>]} = ClientAdapter.decode16(%{"list" => ["0x0B", "0x04"]}, ["list"])
+    end
+  end
+end

--- a/apps/omg_watcher/lib/omg_watcher/http_rpc/client.ex
+++ b/apps/omg_watcher/lib/omg_watcher/http_rpc/client.ex
@@ -17,8 +17,8 @@ defmodule OMG.Watcher.HttpRPC.Client do
   Provides functions to communicate with Child Chain API
   """
 
+  alias OMG.Utils.HttpRPC.ClientAdapter
   alias OMG.Utils.HttpRPC.Encoding
-  alias OMG.Watcher.HttpRPC.Adapter
 
   require Logger
 
@@ -41,7 +41,7 @@ defmodule OMG.Watcher.HttpRPC.Client do
   def submit(tx, url), do: call(%{transaction: Encoding.to_hex(tx)}, "transaction.submit", url)
 
   defp call(params, path, url),
-    do: Adapter.rpc_post(params, path, url) |> Adapter.get_response_body() |> decode_response()
+    do: ClientAdapter.rpc_post(params, path, url) |> ClientAdapter.get_response_body() |> decode_response()
 
   # Translates response's body to known elixir structure, either block or tx submission response or error.
   defp decode_response({:ok, %{transactions: transactions, blknum: number, hash: hash}}) do

--- a/apps/omg_watcher/test/omg_watcher/integration/in_flight_exit_test.exs
+++ b/apps/omg_watcher/test/omg_watcher/integration/in_flight_exit_test.exs
@@ -105,7 +105,7 @@ defmodule OMG.Watcher.Integration.InFlightExitTest do
                # only piggyback_available for tx2 is present, tx1 is included in block and does not spawn that event
                %{"event" => "piggyback_available"}
              ]
-           } = WatcherHelper.success?("/status.get")
+           } = WatcherHelper.get_status()
 
     # ask for proofs
     assert %{"in_flight_txbytes" => ^submitted_txbytes} =
@@ -159,7 +159,7 @@ defmodule OMG.Watcher.Integration.InFlightExitTest do
     DevHelper.wait_for_root_chain_block(last_challenge_eth_height + exit_finality_margin + 1)
 
     assert %{"byzantine_events" => [%{"event" => "non_canonical_ife"}, %{"event" => "piggyback_available"}]} =
-             WatcherHelper.success?("/status.get")
+             WatcherHelper.get_status()
   end
 
   @tag fixtures: [:in_beam_watcher, :alice, :bob, :mix_based_child_chain, :token, :alice_deposits]
@@ -199,10 +199,10 @@ defmodule OMG.Watcher.Integration.InFlightExitTest do
                %{"event" => "non_canonical_ife"},
                %{"event" => "piggyback_available"}
              ]
-           } = WatcherHelper.success?("/status.get")
+           } = WatcherHelper.get_status()
 
     # Check if IFE is recognized as IFE by watcher (kept separate from the above for readability)
-    assert %{"in_flight_exits" => [%{}, %{}]} = WatcherHelper.success?("/status.get")
+    assert %{"in_flight_exits" => [%{}, %{}]} = WatcherHelper.get_status()
 
     ###
     # CANONICITY GAME
@@ -232,7 +232,7 @@ defmodule OMG.Watcher.Integration.InFlightExitTest do
     DevHelper.wait_for_root_chain_block(challenge_eth_height + exit_finality_margin + 1)
 
     # vanishing of `non_canonical_ife` event
-    assert %{"byzantine_events" => [%{"event" => "piggyback_available"}]} = WatcherHelper.success?("/status.get")
+    assert %{"byzantine_events" => [%{"event" => "piggyback_available"}]} = WatcherHelper.get_status()
   end
 
   @tag fixtures: [:in_beam_watcher, :alice, :bob, :mix_based_child_chain, :token, :alice_deposits]
@@ -302,7 +302,7 @@ defmodule OMG.Watcher.Integration.InFlightExitTest do
                %{"event" => "invalid_ife_challenge"},
                %{"event" => "piggyback_available"}
              ]
-           } = WatcherHelper.success?("/status.get")
+           } = WatcherHelper.get_status()
 
     # now included IFE transaction tx1 is challenged and non-canonical, let's respond
     get_prove_canonical_response = WatcherHelper.get_prove_canonical(raw_tx1_bytes)
@@ -320,7 +320,7 @@ defmodule OMG.Watcher.Integration.InFlightExitTest do
 
     # dissapearing of `invalid_ife_challenge` event
     assert %{"byzantine_events" => [%{"event" => "non_canonical_ife"}, %{"event" => "piggyback_available"}]} =
-             WatcherHelper.success?("/status.get")
+             WatcherHelper.get_status()
   end
 
   @tag fixtures: [:in_beam_watcher, :alice, :bob, :mix_based_child_chain, :token, :alice_deposits]
@@ -336,11 +336,11 @@ defmodule OMG.Watcher.Integration.InFlightExitTest do
 
     _ = exit_in_flight_and_wait_for_ife(ife1, alice)
 
-    assert %{"in_flight_exits" => [%{}]} = WatcherHelper.success?("/status.get")
+    assert %{"in_flight_exits" => [%{}]} = WatcherHelper.get_status()
 
     _ = piggyback_and_process_exits(tx, 1, :output, bob)
 
-    assert %{"in_flight_exits" => [], "byzantine_events" => []} = WatcherHelper.success?("/status.get")
+    assert %{"in_flight_exits" => [], "byzantine_events" => []} = WatcherHelper.get_status()
   end
 
   # NOTE: if https://github.com/omisego/elixir-omg/issues/994 is taken care of, this behavior will change, see comments
@@ -354,7 +354,7 @@ defmodule OMG.Watcher.Integration.InFlightExitTest do
     _ = exit_in_flight_and_wait_for_ife(tx, alice)
     piggyback_and_process_exits(tx, 1, :output, bob)
 
-    assert %{"in_flight_exits" => [], "byzantine_events" => []} = WatcherHelper.success?("/status.get")
+    assert %{"in_flight_exits" => [], "byzantine_events" => []} = WatcherHelper.get_status()
   end
 
   @tag fixtures: [:in_beam_watcher, :alice, :bob, :mix_based_child_chain, :token, :alice_deposits]
@@ -377,7 +377,7 @@ defmodule OMG.Watcher.Integration.InFlightExitTest do
              _ = piggyback_and_process_exits(tx, 0, :output, alice)
            end) =~ "Invalid in-flight exit finalization"
 
-    assert %{"in_flight_exits" => [_], "byzantine_events" => byzantine_events} = WatcherHelper.success?("/status.get")
+    assert %{"in_flight_exits" => [_], "byzantine_events" => byzantine_events} = WatcherHelper.get_status()
     assert [%{"event" => "invalid_piggyback"}] = Enum.filter(byzantine_events, &(&1["event"] != "piggyback_available"))
   end
 

--- a/apps/omg_watcher/test/support/integration/bad_child_chain_block.ex
+++ b/apps/omg_watcher/test/support/integration/bad_child_chain_block.ex
@@ -19,9 +19,9 @@ defmodule OMG.Watcher.Integration.BadChildChainServer do
   """
 
   alias OMG.Block
+  alias OMG.Utils.HttpRPC.ClientAdapter
   alias OMG.Utils.HttpRPC.Encoding
   alias OMG.Utils.HttpRPC.Response
-  alias OMG.Watcher.HttpRPC.Adapter
   alias OMG.Watcher.Integration.TestServer
 
   @doc """
@@ -43,8 +43,8 @@ defmodule OMG.Watcher.Integration.BadChildChainServer do
         else
           {:ok, block} =
             %{hash: req_hash}
-            |> Adapter.rpc_post("block.get", context.real_addr)
-            |> Adapter.get_response_body()
+            |> ClientAdapter.rpc_post("block.get", context.real_addr)
+            |> ClientAdapter.get_response_body()
 
           TestServer.make_response(block)
         end

--- a/apps/omg_watcher/test/support/integration/test_helper.ex
+++ b/apps/omg_watcher/test/support/integration/test_helper.ex
@@ -28,7 +28,7 @@ defmodule OMG.Watcher.Integration.TestHelper do
 
   def wait_for_byzantine_events(event_names, timeout) do
     fn ->
-      %{"byzantine_events" => emitted_events} = WatcherHelper.success?("/status.get")
+      %{"byzantine_events" => emitted_events} = WatcherHelper.get_status()
       emitted_event_names = Enum.map(emitted_events, &String.to_atom(&1["event"]))
 
       all_events =

--- a/apps/omg_watcher/test/support/watcher_helper.ex
+++ b/apps/omg_watcher/test/support/watcher_helper.ex
@@ -17,6 +17,7 @@ defmodule Support.WatcherHelper do
   Module provides common testing functions used by App's tests.
   """
   alias ExUnit.CaptureLog
+  alias OMG.Utils.HttpRPC.ClientAdapter
   alias OMG.Utils.HttpRPC.Encoding
   alias OMG.Utxo
 
@@ -83,36 +84,6 @@ defmodule Support.WatcherHelper do
 
   def create_topic(main_topic, subtopic), do: main_topic <> ":" <> subtopic
 
-  @doc """
-  Decodes specified keys in map from hex to binary
-  """
-  @spec decode16(map(), list()) :: map()
-  def decode16(data, keys) do
-    keys
-    |> Enum.into(%{}, &decode16_for_key(data, &1))
-    |> (&Map.merge(data, &1)).()
-  end
-
-  defp decode16_for_key(data, key) do
-    case data[key] do
-      value when is_binary(value) ->
-        {key, decode_binary!(value)}
-
-      value when is_list(value) ->
-        bin_list =
-          value
-          |> Enum.map(&Encoding.from_hex/1)
-          |> Enum.map(fn {:ok, bin} -> bin end)
-
-        {key, bin_list}
-    end
-  end
-
-  defp decode_binary!(value) do
-    {:ok, bin} = Encoding.from_hex(value)
-    bin
-  end
-
   def get_balance(address, token) do
     encoded_token = Encoding.to_hex(token)
 
@@ -139,7 +110,7 @@ defmodule Support.WatcherHelper do
 
   def get_exit_data(encoded_position) do
     data = success?("utxo.get_exit_data", %{utxo_pos: encoded_position})
-    decode16(data, ["txbytes", "proof"])
+    ClientAdapter.decode16(data, ["txbytes", "proof"])
   end
 
   def get_exit_challenge(blknum, txindex, oindex) do
@@ -147,31 +118,37 @@ defmodule Support.WatcherHelper do
 
     data = success?("utxo.get_challenge_data", %{utxo_pos: utxo_pos})
 
-    decode16(data, ["exiting_tx", "txbytes", "sig"])
+    ClientAdapter.decode16(data, ["exiting_tx", "txbytes", "sig"])
   end
 
   def get_in_flight_exit(transaction) do
     exit_data = success?("in_flight_exit.get_data", %{txbytes: Encoding.to_hex(transaction)})
 
-    decode16(exit_data, ["in_flight_tx", "input_txs", "input_txs_inclusion_proofs", "in_flight_tx_sigs"])
+    ClientAdapter.decode16(exit_data, ["in_flight_tx", "input_txs", "input_txs_inclusion_proofs", "in_flight_tx_sigs"])
   end
 
   def get_in_flight_exit_competitors(transaction) do
     competitor_data = success?("in_flight_exit.get_competitor", %{txbytes: Encoding.to_hex(transaction)})
 
-    decode16(competitor_data, ["in_flight_txbytes", "competing_txbytes", "competing_sig", "competing_proof", "input_tx"])
+    ClientAdapter.decode16(competitor_data, [
+      "in_flight_txbytes",
+      "competing_txbytes",
+      "competing_sig",
+      "competing_proof",
+      "input_tx"
+    ])
   end
 
   def get_prove_canonical(transaction) do
     competitor_data = success?("in_flight_exit.prove_canonical", %{txbytes: Encoding.to_hex(transaction)})
 
-    decode16(competitor_data, ["in_flight_txbytes", "in_flight_proof"])
+    ClientAdapter.decode16(competitor_data, ["in_flight_txbytes", "in_flight_proof"])
   end
 
   def submit(transaction) do
     submission_info = success?("transaction.submit", %{transaction: Encoding.to_hex(transaction)})
 
-    decode16(submission_info, ["txhash"])
+    ClientAdapter.decode16(submission_info, ["txhash"])
   end
 
   def get_input_challenge_data(transaction, input_index) do
@@ -181,7 +158,7 @@ defmodule Support.WatcherHelper do
         input_index: input_index
       })
 
-    decode16(proof_data, [
+    ClientAdapter.decode16(proof_data, [
       "in_flight_txbytes",
       "spending_txbytes",
       "spending_sig",
@@ -196,7 +173,7 @@ defmodule Support.WatcherHelper do
         output_index: output_index
       })
 
-    decode16(proof_data, [
+    ClientAdapter.decode16(proof_data, [
       "in_flight_txbytes",
       "in_flight_proof",
       "spending_txbytes",

--- a/apps/omg_watcher/test/support/watcher_helper.ex
+++ b/apps/omg_watcher/test/support/watcher_helper.ex
@@ -110,7 +110,7 @@ defmodule Support.WatcherHelper do
 
   def get_exit_data(encoded_position) do
     data = success?("utxo.get_exit_data", %{utxo_pos: encoded_position})
-    ClientAdapter.decode16(data, ["txbytes", "proof"])
+    ClientAdapter.decode16!(data, ["txbytes", "proof"])
   end
 
   def get_exit_challenge(blknum, txindex, oindex) do
@@ -118,19 +118,19 @@ defmodule Support.WatcherHelper do
 
     data = success?("utxo.get_challenge_data", %{utxo_pos: utxo_pos})
 
-    ClientAdapter.decode16(data, ["exiting_tx", "txbytes", "sig"])
+    ClientAdapter.decode16!(data, ["exiting_tx", "txbytes", "sig"])
   end
 
   def get_in_flight_exit(transaction) do
     exit_data = success?("in_flight_exit.get_data", %{txbytes: Encoding.to_hex(transaction)})
 
-    ClientAdapter.decode16(exit_data, ["in_flight_tx", "input_txs", "input_txs_inclusion_proofs", "in_flight_tx_sigs"])
+    ClientAdapter.decode16!(exit_data, ["in_flight_tx", "input_txs", "input_txs_inclusion_proofs", "in_flight_tx_sigs"])
   end
 
   def get_in_flight_exit_competitors(transaction) do
     competitor_data = success?("in_flight_exit.get_competitor", %{txbytes: Encoding.to_hex(transaction)})
 
-    ClientAdapter.decode16(competitor_data, [
+    ClientAdapter.decode16!(competitor_data, [
       "in_flight_txbytes",
       "competing_txbytes",
       "competing_sig",
@@ -142,13 +142,13 @@ defmodule Support.WatcherHelper do
   def get_prove_canonical(transaction) do
     competitor_data = success?("in_flight_exit.prove_canonical", %{txbytes: Encoding.to_hex(transaction)})
 
-    ClientAdapter.decode16(competitor_data, ["in_flight_txbytes", "in_flight_proof"])
+    ClientAdapter.decode16!(competitor_data, ["in_flight_txbytes", "in_flight_proof"])
   end
 
   def submit(transaction) do
     submission_info = success?("transaction.submit", %{transaction: Encoding.to_hex(transaction)})
 
-    ClientAdapter.decode16(submission_info, ["txhash"])
+    ClientAdapter.decode16!(submission_info, ["txhash"])
   end
 
   def get_input_challenge_data(transaction, input_index) do
@@ -158,7 +158,7 @@ defmodule Support.WatcherHelper do
         input_index: input_index
       })
 
-    ClientAdapter.decode16(proof_data, [
+    ClientAdapter.decode16!(proof_data, [
       "in_flight_txbytes",
       "spending_txbytes",
       "spending_sig",
@@ -173,7 +173,7 @@ defmodule Support.WatcherHelper do
         output_index: output_index
       })
 
-    ClientAdapter.decode16(proof_data, [
+    ClientAdapter.decode16!(proof_data, [
       "in_flight_txbytes",
       "in_flight_proof",
       "spending_txbytes",

--- a/apps/omg_watcher/test/support/watcher_helper.ex
+++ b/apps/omg_watcher/test/support/watcher_helper.ex
@@ -181,6 +181,10 @@ defmodule Support.WatcherHelper do
     ])
   end
 
+  def get_status() do
+    success?("/status.get")
+  end
+
   def capture_log(function, max_waiting_ms \\ 2_000) do
     CaptureLog.capture_log(fn ->
       logs = CaptureLog.capture_log(fn -> function.() end)


### PR DESCRIPTION
closes #855 

## Overview

This PR prepares the perf/load-testing tools to use when testing scenarios in #855.

## Changes

- can use scripts start valid/invalid IFEs, challenge them, challenge them invalidly, piggyback validly/invalidly, detect all this and react 
- tried to be as documented & readable to ease future transition into different test harness (`specs`?), and also not overdo it
- needed to make some cleanups around the `elixir-omg` Watcher API client(s), unfortunately, for separation of concerns' sake, some code got copied over, but I'm prefering decoupling to DRY here. Can discuss this, but OTOH, I don't want to over-talk/over-do this
- improved the use of `Task.async_stream` further so now it doesn't crash `iex` when ethereum txs fail to mine!
- introduced `throttle_ms` option to the transaction-sending perftest, allows to put mild, continuous load on the system

## Testing

```
mix test --include integration test/omg_performance
```

and/or try running the perftests as in `ByzantineEvents` module's docs