### PR TITLE
fix: standard exit struct specs

### DIFF
--- a/apps/omg_eth/lib/omg_eth/root_chain.ex
+++ b/apps/omg_eth/lib/omg_eth/root_chain.ex
@@ -76,7 +76,7 @@ defmodule OMG.Eth.RootChain do
   """
   def get_standard_exit(exit_id, contract \\ %{}) do
     contract = Config.maybe_fetch_addr!(contract, :payment_exit_game)
-    return_fields = [:bool, {:uint, 192}, {:bytes, 32}, :address, {:uint, 256}, {:uint, 256}]
+    return_fields = [:bool, {:uint, 256}, {:bytes, 32}, :address, {:uint, 256}, {:uint, 256}]
     Eth.call_contract(contract, "standardExits(uint160)", [exit_id], return_fields)
   end
 


### PR DESCRIPTION
I was working on: https://github.com/omisego/security-issues/issues/7 when I noticed this 🗡 

## Overview

https://github.com/omisego/plasma-contracts/blob/a360d5f68929f1f727104a7b4ab2e63bbc8a4327/plasma_framework/contracts/src/exits/payment/PaymentExitDataModel.sol#L21

## Changes

- uint size incorrect on elixir side

## Testing

/
