### PR TITLE
fix: make EIP712 resistant to appending zero data

### DIFF
--- a/apps/omg/test/omg/dependency_conformance/signature_test.exs
+++ b/apps/omg/test/omg/dependency_conformance/signature_test.exs
@@ -34,6 +34,7 @@ defmodule OMG.DependencyConformance.SignatureTest do
   @bob TestHelper.generate_entity()
   @eth OMG.Eth.RootChain.eth_pseudo_address()
   @token TestHelper.generate_entity().addr
+  @zero_address OMG.Eth.zero_address()
 
   setup_all do
     {:ok, exit_fn} = DevNode.start()
@@ -56,61 +57,117 @@ defmodule OMG.DependencyConformance.SignatureTest do
     [contract: signtest_addr]
   end
 
-  test "signature test empty transaction", context do
-    contract = context[:contract]
-    tx = TestHelper.create_signed([], [])
-    verify(contract, tx)
+  describe "elixir vs solidity conformance test" do
+    # FIXME: simplify all of these tests by not doing signed, just raw should do; remove one `elixir_hash` clause
+    # FIXME: also shorten the test by getting the contract in the test title line
+    test "signature test empty transaction", context do
+      contract = context[:contract]
+      tx = TestHelper.create_signed([], [])
+      verify(contract, tx)
+    end
+
+    test "no inputs test", context do
+      contract = context[:contract]
+      tx = TestHelper.create_signed([], [{@alice, @eth, 100}])
+      verify(contract, tx)
+    end
+
+    test "no outputs test", context do
+      contract = context[:contract]
+      tx = TestHelper.create_signed([{1, 0, 0, @alice}], [])
+      verify(contract, tx)
+    end
+
+    test "signature test - small tx", context do
+      contract = context[:contract]
+      tx = TestHelper.create_signed([{1, 0, 0, @alice}], [{@alice, @eth, 100}])
+      verify(contract, tx)
+    end
+
+    test "signature test - full tx", context do
+      contract = context[:contract]
+
+      tx =
+        TestHelper.create_signed(
+          [{1, 0, 0, @alice}, {1000, 555, 3, @bob}, {2000, 333, 1, @alice}, {15_015, 0, 0, @bob}],
+          [{@alice, @eth, 100}, {@alice, @token, 50}, {@bob, @token, 75}, {@bob, @eth, 25}]
+        )
+
+      verify(contract, tx)
+    end
+
+    test "signature test transaction with metadata", context do
+      contract = context[:contract]
+      {:ok, <<_::256>> = metadata} = DevCrypto.generate_private_key()
+
+      tx =
+        TestHelper.create_signed(
+          [{1, 0, 0, @alice}, {1000, 555, 3, @bob}, {2000, 333, 1, @alice}, {15_015, 0, 0, @bob}],
+          @eth,
+          [{@alice, 100}, {@alice, 50}, {@bob, 75}, {@bob, 25}],
+          metadata
+        )
+
+      verify(contract, tx)
+    end
+
+    test "signature test, transaction with zero output amount", %{contract: contract} do
+      tx = Transaction.Payment.new([{1, 0, 0}], [{@alice.addr, @eth, 100}, {<<1::160>>, @zero_address, 0}])
+      verify(contract, tx)
+    end
+
+    test "signature test, transaction with an explicit zero output", %{contract: contract} do
+      tx = Transaction.Payment.new([{1, 0, 0}], [{@alice.addr, @eth, 100}, {@zero_address, @zero_address, 0}])
+      verify(contract, tx)
+    end
+
+    test "signature test, transaction with an explicit zero input", %{contract: contract} do
+      tx = Transaction.Payment.new([{1, 0, 0}, {0, 0, 0}], [{@alice.addr, @eth, 100}])
+      verify(contract, tx)
+    end
+
+    defp verify(contract, tx) do
+      assert solidity_hash(contract, tx) == elixir_hash(tx)
+    end
   end
 
-  test "no inputs test", context do
-    contract = context[:contract]
-    tx = TestHelper.create_signed([], [{@alice, @eth, 100}])
-    verify(contract, tx)
+  # FIXME: this might not belong here, technically speaking it could cover the same stuff if put in `plasma_contracts`
+  describe "distinct transactions yield distinct sign hashes" do
+    test "sanity check - different txs hash differently", %{contract: contract} do
+      tx1 = Transaction.Payment.new([{1, 0, 0}], [{@alice.addr, @eth, 100}])
+      tx2 = Transaction.Payment.new([{2, 0, 0}], [{@alice.addr, @eth, 100}])
+      verify_distinct(contract, tx1, tx2)
+    end
+
+    test "explicit zero input alters sign hash", %{contract: contract} do
+      tx1 = Transaction.Payment.new([{1, 0, 0}], [{@alice.addr, @eth, 100}])
+      tx2 = Transaction.Payment.new([{1, 0, 0}, {0, 0, 0}], [{@alice.addr, @eth, 100}])
+      verify_distinct(contract, tx1, tx2)
+    end
+
+    test "explicit zero outputs alters sign hash", %{contract: contract} do
+      tx1 = Transaction.Payment.new([{1, 0, 0}], [{@alice.addr, @eth, 100}])
+      tx2 = Transaction.Payment.new([{1, 0, 0}], [{@alice.addr, @eth, 100}, {@zero_address, @zero_address, 0}])
+      verify_distinct(contract, tx1, tx2)
+    end
+
+    defp verify_distinct(contract, tx1, tx2) do
+      # FIXME: commented now, because they're failing anyway (covered in other tests). Decide how exactly we assert here
+      # just sanity checks, the solidity vs elixir testing is in the other section
+      # assert solidity_hash(contract, tx1) == elixir_hash(tx1)
+      # assert solidity_hash(contract, tx2) == elixir_hash(tx2)
+      assert solidity_hash(contract, tx1) != solidity_hash(contract, tx2)
+      assert elixir_hash(tx1) != elixir_hash(tx2)
+    end
   end
 
-  test "no outputs test", context do
-    contract = context[:contract]
-    tx = TestHelper.create_signed([{1, 0, 0, @alice}], [])
-    verify(contract, tx)
-  end
-
-  test "signature test - small tx", context do
-    contract = context[:contract]
-    tx = TestHelper.create_signed([{1, 0, 0, @alice}], [{@alice, @eth, 100}])
-    verify(contract, tx)
-  end
-
-  test "signature test - full tx", context do
-    contract = context[:contract]
-
-    tx =
-      TestHelper.create_signed(
-        [{1, 0, 0, @alice}, {1000, 555, 3, @bob}, {2000, 333, 1, @alice}, {15_015, 0, 0, @bob}],
-        [{@alice, @eth, 100}, {@alice, @token, 50}, {@bob, @token, 75}, {@bob, @eth, 25}]
-      )
-
-    verify(contract, tx)
-  end
-
-  test "signature test transaction with metadata", context do
-    contract = context[:contract]
-    {:ok, <<_::256>> = metadata} = DevCrypto.generate_private_key()
-
-    tx =
-      TestHelper.create_signed(
-        [{1, 0, 0, @alice}, {1000, 555, 3, @bob}, {2000, 333, 1, @alice}, {15_015, 0, 0, @bob}],
-        @eth,
-        [{@alice, 100}, {@alice, 50}, {@bob, 75}, {@bob, 25}],
-        metadata
-      )
-
-    verify(contract, tx)
-  end
-
-  defp verify(contract, %Transaction.Signed{raw_tx: tx}) do
+  defp solidity_hash(contract, tx) do
     {:ok, solidity_hash} =
       Eth.call_contract(contract, "hashTx(address,bytes)", [contract, Transaction.raw_txbytes(tx)], [{:bytes, 32}])
 
-    assert solidity_hash == OMG.TypedDataHash.hash_struct(tx)
+    solidity_hash
   end
+
+  defp elixir_hash(%Transaction.Signed{raw_tx: tx}), do: OMG.TypedDataHash.hash_struct(tx)
+  defp elixir_hash(tx), do: OMG.TypedDataHash.hash_struct(tx)
 end


### PR DESCRIPTION
Discovered by @kevsul, for now this only exposes the issue in a failing test (and other ones as well, like the hashing being different btw. elixir and sol in some cases), no fix yet

## Overview

When fix, this should cover with tests and fix situations where EIP712 hashes are divergent or ambiguous

## Changes

todo

## Testing

```
mix test --include integration test/omg/dependency_conformance/signature_test.exs
```
