### PR TITLE
feature: decrese polling

### DIFF
--- a/apps/omg/config/config.exs
+++ b/apps/omg/config/config.exs
@@ -4,7 +4,7 @@ use Mix.Config
 
 config :omg,
   deposit_finality_margin: 10,
-  ethereum_events_check_interval_ms: 500,
+  ethereum_events_check_interval_ms: 8_000,
   coordinator_eth_height_check_interval_ms: 6_000,
   metrics_collection_interval: 60_000,
   input_pointer_types_modules: %{<<1>> => OMG.InputPointer.UtxoPosition},

--- a/apps/omg_child_chain/config/dev.exs
+++ b/apps/omg_child_chain/config/dev.exs
@@ -2,5 +2,4 @@
 use Mix.Config
 
 config :omg_child_chain,
-  ethereum_events_check_interval_ms: 500,
   block_queue_eth_height_check_interval_ms: 1_000


### PR DESCRIPTION


## Overview
We've been pulling events every 500 ms, which is obviously too much. The pull value should be less than frequency of pushed ethereum blocks (mainnet and rinkeby) + processing time 

## Changes



- Increase
- remove stale configuration

## Testing
/