### PR TITLE
fix: circleci's using wrong values to publish watcher_info

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,7 +60,7 @@ executors:
   metal_watcher_info:
     machine: true
     environment:
-      watcher_info_IMAGE_NAME: "omisego/watcher_info"
+      WATCHER_INFO_IMAGE_NAME: "omisego/watcher_info"
 
 commands:
   setup_elixir-omg_workspace:
@@ -499,10 +499,10 @@ jobs:
       - run: IMAGE_NAME=$WATCHER_IMAGE_NAME sh .circleci/ci_publish.sh
 
   publish_watcher_info:
-    executor: metal_watcher
+    executor: metal_watcher_info
     steps:
       - checkout
-      - run: make docker-watcher_info WATCHER_INFO_IMAGE_NAME=$WATCHER_IMAGE_NAME
+      - run: make docker-watcher_info WATCHER_INFO_IMAGE_NAME=$WATCHER_INFO_IMAGE_NAME
       - run: IMAGE_NAME=$WATCHER_INFO_IMAGE_NAME sh .circleci/ci_publish.sh
 
   deploy_child_chain:


### PR DESCRIPTION
Relates to #1123 

## Overview

Fixes failing CircleCI's docker image publishing due to misconfigured values for watcher_info.

## Changes

Describe your changes and implementation choices. More details make PRs easier to review.

- Fix typo `watcher_info_IMAGE_NAME:` from the app rename
- `publish_watcher_info` build step changed to use the `metal_watcher_info` executor so that it has the value for `$WATCHER_INFO_IMAGE_NAME`

## Testing

`make publish_watcher_info` runs successfully