### PR TITLE
Avoid code is loaded check for version/service name

### DIFF
--- a/apps/omg_child_chain_rpc/lib/omg_child_chain_rpc/web.ex
+++ b/apps/omg_child_chain_rpc/lib/omg_child_chain_rpc/web.ex
@@ -63,7 +63,7 @@ defmodule OMG.ChildChainRPC.Web do
 
         conn
         |> put_view(view_module)
-        |> render(template, response: data)
+        |> render(template, response: data, app_infos: conn.assigns.app_infos)
       end
     end
   end

--- a/apps/omg_child_chain_rpc/lib/omg_child_chain_rpc/web/controllers/fallback.ex
+++ b/apps/omg_child_chain_rpc/lib/omg_child_chain_rpc/web/controllers/fallback.ex
@@ -30,13 +30,18 @@ defmodule OMG.ChildChainRPC.Web.Controller.Fallback do
   }
 
   def call(conn, Route.NotFound),
-    do: json(conn, Error.serialize("operation:not_found", "Operation cannot be found. Check request URL."))
+    do:
+      json(
+        conn,
+        Error.serialize("operation:not_found", "Operation cannot be found. Check request URL.", conn.assigns.app_infos)
+      )
 
   def call(conn, {:error, {:validation_error, param_name, validator}}) do
     response =
       Error.serialize(
         "operation:bad_request",
         "Parameters required by this operation are missing or incorrect.",
+        conn.assigns.app_infos,
         %{validation_error: %{parameter: param_name, validator: inspect(validator)}}
       )
 
@@ -60,6 +65,6 @@ defmodule OMG.ChildChainRPC.Web.Controller.Fallback do
   def call(conn, _), do: call(conn, {:error, :unknown_error})
 
   defp respond(conn, %{code: code, description: description}) do
-    json(conn, Error.serialize(code, description))
+    json(conn, Error.serialize(code, description, conn.assigns.app_infos))
   end
 end

--- a/apps/omg_child_chain_rpc/lib/omg_child_chain_rpc/web/plugs/health.ex
+++ b/apps/omg_child_chain_rpc/lib/omg_child_chain_rpc/web/plugs/health.ex
@@ -35,7 +35,12 @@ defmodule OMG.ChildChainRPC.Plugs.Health do
     if Status.is_healthy() do
       conn
     else
-      data = Error.serialize("operation:service_unavailable", "The server is not ready to handle the request.")
+      data =
+        Error.serialize(
+          "operation:service_unavailable",
+          "The server is not ready to handle the request.",
+          conn.assigns.app_infos
+        )
 
       conn
       |> Controller.json(data)

--- a/apps/omg_child_chain_rpc/lib/omg_child_chain_rpc/web/router.ex
+++ b/apps/omg_child_chain_rpc/lib/omg_child_chain_rpc/web/router.ex
@@ -17,6 +17,7 @@ defmodule OMG.ChildChainRPC.Web.Router do
 
   pipeline :api do
     plug(:accepts, ["json"])
+    plug(OMG.Utils.HttpRPC.Plugs.ApplicationInfo, application: :omg_child_chain_rpc)
   end
 
   scope "/", OMG.ChildChainRPC.Web do

--- a/apps/omg_child_chain_rpc/lib/omg_child_chain_rpc/web/views/alarm.ex
+++ b/apps/omg_child_chain_rpc/lib/omg_child_chain_rpc/web/views/alarm.ex
@@ -20,7 +20,9 @@ defmodule OMG.ChildChainRPC.Web.View.Alarm do
   use OMG.ChildChainRPC.Web, :view
   alias OMG.Utils.HttpRPC.Response
 
-  def render("alarm.json", %{response: alarms}) do
-    Response.serialize(alarms)
+  def render("alarm.json", %{response: alarms, app_infos: app_infos}) do
+    alarms
+    |> Response.serialize()
+    |> Response.add_app_infos(app_infos)
   end
 end

--- a/apps/omg_child_chain_rpc/lib/omg_child_chain_rpc/web/views/block.ex
+++ b/apps/omg_child_chain_rpc/lib/omg_child_chain_rpc/web/views/block.ex
@@ -18,7 +18,9 @@ defmodule OMG.ChildChainRPC.Web.View.Block do
   """
   alias OMG.Utils.HttpRPC.Response
 
-  def render("block.json", %{response: block}) do
-    Response.serialize(block)
+  def render("block.json", %{response: block, app_infos: app_infos}) do
+    block
+    |> Response.serialize()
+    |> Response.add_app_infos(app_infos)
   end
 end

--- a/apps/omg_child_chain_rpc/lib/omg_child_chain_rpc/web/views/error.ex
+++ b/apps/omg_child_chain_rpc/lib/omg_child_chain_rpc/web/views/error.ex
@@ -23,19 +23,19 @@ defmodule OMG.ChildChainRPC.Web.Views.Error do
   Handles client errors, e.g. malformed json in request body
   """
   def render("400.json", _) do
-    Error.serialize("operation:bad_request", "Server has failed to parse the request.")
+    Error.serialize("operation:bad_request", "Server has failed to parse the request.", %{})
   end
 
   @doc """
   Supports internal server error thrown by Phoenix.
   """
   def render("500.json", %{reason: %{message: message}}) do
-    Error.serialize("server:internal_server_error", message)
+    Error.serialize("server:internal_server_error", message, %{})
   end
 
   # In case no render clause matches or no
   # template is found, let's render it as 500
   def template_not_found(_template, _assigns) do
-    Error.serialize("server:internal_server_error", nil)
+    Error.serialize("server:internal_server_error", nil, %{})
   end
 end

--- a/apps/omg_child_chain_rpc/lib/omg_child_chain_rpc/web/views/fee.ex
+++ b/apps/omg_child_chain_rpc/lib/omg_child_chain_rpc/web/views/fee.ex
@@ -19,10 +19,11 @@ defmodule OMG.ChildChainRPC.Web.View.Fee do
 
   alias OMG.Utils.HttpRPC.Response
 
-  def render("fees_all.json", %{response: fees}) do
+  def render("fees_all.json", %{response: fees, app_infos: app_infos}) do
     fees
     |> to_api_format()
     |> Response.serialize()
+    |> Response.add_app_infos(app_infos)
   end
 
   defp to_api_format(fees) do

--- a/apps/omg_child_chain_rpc/lib/omg_child_chain_rpc/web/views/transaction.ex
+++ b/apps/omg_child_chain_rpc/lib/omg_child_chain_rpc/web/views/transaction.ex
@@ -19,7 +19,9 @@ defmodule OMG.ChildChainRPC.Web.View.Transaction do
 
   alias OMG.Utils.HttpRPC.Response
 
-  def render("submit.json", %{response: result}) do
-    Response.serialize(result)
+  def render("submit.json", %{response: result, app_infos: app_infos}) do
+    result
+    |> Response.serialize()
+    |> Response.add_app_infos(app_infos)
   end
 end

--- a/apps/omg_child_chain_rpc/test/omg_child_chain_rpc/plugs/application_info_test.exs
+++ b/apps/omg_child_chain_rpc/test/omg_child_chain_rpc/plugs/application_info_test.exs
@@ -1,0 +1,33 @@
+# Copyright 2019 OmiseGO Pte Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defmodule OMG.ChildChainRPC.Plugs.ApplicationInfoTest do
+  @moduledoc false
+  use ExUnit.Case, async: false
+  use Phoenix.ConnTest
+
+  alias OMG.Utils.HttpRPC.Plugs.ApplicationInfo
+
+  describe "call/2" do
+    test "service name is appended" do
+      conn = build_conn() |> ApplicationInfo.call(application: :omg_child_chain_rpc)
+      assert "child_chain" == conn.assigns.app_infos.service_name
+    end
+
+    test "version is appended and follows semver" do
+      conn = build_conn() |> ApplicationInfo.call(application: :omg_child_chain_rpc)
+      assert {:ok, _} = Version.parse(conn.assigns.app_infos.version)
+    end
+  end
+end

--- a/apps/omg_utils/lib/omg_utils/http_rpc/error.ex
+++ b/apps/omg_utils/lib/omg_utils/http_rpc/error.ex
@@ -22,7 +22,7 @@ defmodule OMG.Utils.HttpRPC.Error do
   Serializes error's code and description provided in response's data field.
   """
   @spec serialize(atom() | String.t(), String.t() | nil, map() | nil) :: map()
-  def serialize(code, description, messages \\ nil) do
+  def serialize(code, description, app_infos, messages \\ nil) do
     %{
       object: :error,
       code: code,
@@ -30,6 +30,7 @@ defmodule OMG.Utils.HttpRPC.Error do
     }
     |> add_messages(messages)
     |> Response.serialize()
+    |> Response.add_app_infos(app_infos)
   end
 
   defp add_messages(data, nil), do: data

--- a/apps/omg_utils/lib/omg_utils/http_rpc/plugs/application_info_plug.ex
+++ b/apps/omg_utils/lib/omg_utils/http_rpc/plugs/application_info_plug.ex
@@ -1,0 +1,44 @@
+# Copyright 2019 OmiseGO Pte Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defmodule OMG.Utils.HttpRPC.Plugs.ApplicationInfo do
+  @moduledoc """
+  Assigns per-application meta-information like version and service name to the connection, for later use
+  """
+  @behaviour Plug
+
+  @sha String.replace(elem(System.cmd("git", ["rev-parse", "--short=7", "HEAD"]), 0), "\n", "")
+
+  def init(options), do: options
+
+  def call(conn, options) do
+    conn
+    |> Plug.Conn.assign(:app_infos, %{
+      version: version(Keyword.fetch!(options, :application)),
+      service_name: service_name(Keyword.fetch!(options, :application))
+    })
+  end
+
+  defp version(application) do
+    {:ok, vsn} = :application.get_key(application, :vsn)
+    List.to_string(vsn) <> "+" <> @sha
+  end
+
+  defp service_name(application) do
+    case application do
+      :omg_child_chain_rpc -> "child_chain"
+      :omg_watcher_rpc -> "watcher"
+    end
+  end
+end

--- a/apps/omg_utils/lib/omg_utils/http_rpc/response.ex
+++ b/apps/omg_utils/lib/omg_utils/http_rpc/response.ex
@@ -16,7 +16,6 @@ defmodule OMG.Utils.HttpRPC.Response do
   Serializes the response into expected result/data format.
   """
   alias OMG.Utils.HttpRPC.Encoding
-  @sha String.replace(elem(System.cmd("git", ["rev-parse", "--short=7", "HEAD"]), 0), "\n", "")
 
   @type response_t :: %{version: binary(), success: boolean(), data: map()}
 
@@ -32,16 +31,16 @@ defmodule OMG.Utils.HttpRPC.Response do
   @spec serialize(any()) :: response_t()
   def serialize(%{object: :error} = error) do
     to_response(error, :error)
-    |> add_version()
-    |> add_service_name()
   end
 
   def serialize(data) do
     data
     |> sanitize()
     |> to_response(:success)
-    |> add_version()
-    |> add_service_name()
+  end
+
+  def add_app_infos(response, app_infos) do
+    Map.merge(response, app_infos)
   end
 
   @doc """
@@ -105,41 +104,4 @@ defmodule OMG.Utils.HttpRPC.Response do
       success: result == :success,
       data: data
     }
-
-  # not the most beatuful way of doing this but
-  # because our "response serializer" is in utils there's no other way
-  defp add_version(response) do
-    vsn =
-      case :code.is_loaded(OMG.ChildChainRPC) do
-        {:file, _} ->
-          {:ok, vsn} = :application.get_key(:omg_child_chain_rpc, :vsn)
-
-          vsn
-
-        _ ->
-          {:ok, vsn} = :application.get_key(:omg_watcher_rpc, :vsn)
-
-          vsn
-      end
-
-    Map.merge(response, %{version: List.to_string(vsn) <> "+" <> @sha})
-  end
-
-  # Not the most "beautiful way", but I'm just referencing
-  # how they're injecting the version
-  defp add_service_name(response) do
-    service_name = service_name()
-    # Inject it into the response code
-    Map.merge(response, %{service_name: service_name})
-  end
-
-  defp service_name do
-    case :code.is_loaded(OMG.ChildChainRPC) do
-      {:file, _} ->
-        "child_chain"
-
-      _ ->
-        "watcher"
-    end
-  end
 end

--- a/apps/omg_watcher_rpc/lib/web.ex
+++ b/apps/omg_watcher_rpc/lib/web.ex
@@ -62,7 +62,7 @@ defmodule OMG.WatcherRPC.Web do
 
         conn
         |> put_view(view_module)
-        |> render(template, response: data)
+        |> render(template, response: data, app_infos: conn.assigns.app_infos)
       end
     end
   end

--- a/apps/omg_watcher_rpc/lib/web/controllers/fallback.ex
+++ b/apps/omg_watcher_rpc/lib/web/controllers/fallback.ex
@@ -74,13 +74,18 @@ defmodule OMG.WatcherRPC.Web.Controller.Fallback do
   }
 
   def call(conn, Route.NotFound),
-    do: json(conn, Error.serialize("operation:not_found", "Operation cannot be found. Check request URL."))
+    do:
+      json(
+        conn,
+        Error.serialize("operation:not_found", "Operation cannot be found. Check request URL.", conn.assigns.app_infos)
+      )
 
   def call(conn, {:error, {:validation_error, param_name, validator}}) do
     response =
       Error.serialize(
         "operation:bad_request",
         "Parameters required by this operation are missing or incorrect.",
+        conn.assigns.app_infos,
         %{validation_error: %{parameter: param_name, validator: inspect(validator)}}
       )
 
@@ -100,7 +105,7 @@ defmodule OMG.WatcherRPC.Web.Controller.Fallback do
   def call(conn, _), do: call(conn, {:error, :unknown_error})
 
   defp respond(conn, %{code: code, description: description} = err_info) do
-    json(conn, Error.serialize(code, description, Map.get(err_info, :messages)))
+    json(conn, Error.serialize(code, description, conn.assigns.app_infos, Map.get(err_info, :messages)))
   end
 
   defp error_info(conn, reason),

--- a/apps/omg_watcher_rpc/lib/web/plugs/health.ex
+++ b/apps/omg_watcher_rpc/lib/web/plugs/health.ex
@@ -35,7 +35,12 @@ defmodule OMG.WatcherRPC.Plugs.Health do
     if Status.is_healthy() do
       conn
     else
-      data = Error.serialize("operation:service_unavailable", "The server is not ready to handle the request.")
+      data =
+        Error.serialize(
+          "operation:service_unavailable",
+          "The server is not ready to handle the request.",
+          conn.assigns.app_infos
+        )
 
       conn
       |> Controller.json(data)

--- a/apps/omg_watcher_rpc/lib/web/router.ex
+++ b/apps/omg_watcher_rpc/lib/web/router.ex
@@ -17,6 +17,7 @@ defmodule OMG.WatcherRPC.Web.Router do
 
   pipeline :api do
     plug(:accepts, ["json"])
+    plug(OMG.Utils.HttpRPC.Plugs.ApplicationInfo, application: :omg_watcher_rpc)
   end
 
   # Watcher Security-Critical API

--- a/apps/omg_watcher_rpc/lib/web/views/account.ex
+++ b/apps/omg_watcher_rpc/lib/web/views/account.ex
@@ -23,14 +23,16 @@ defmodule OMG.WatcherRPC.Web.View.Account do
 
   require Utxo
 
-  def render("balance.json", %{response: balance}) do
+  def render("balance.json", %{response: balance, app_infos: app_infos}) do
     balance
     |> Response.serialize()
+    |> Response.add_app_infos(app_infos)
   end
 
-  def render("utxos.json", %{response: utxos}) do
+  def render("utxos.json", %{response: utxos, app_infos: app_infos}) do
     utxos
     |> Enum.map(&to_utxo/1)
     |> Response.serialize()
+    |> Response.add_app_infos(app_infos)
   end
 end

--- a/apps/omg_watcher_rpc/lib/web/views/alarm.ex
+++ b/apps/omg_watcher_rpc/lib/web/views/alarm.ex
@@ -20,7 +20,9 @@ defmodule OMG.WatcherRPC.Web.View.Alarm do
   use OMG.WatcherRPC.Web, :view
   alias OMG.Utils.HttpRPC.Response
 
-  def render("alarm.json", %{response: alarms}) do
-    Response.serialize(alarms)
+  def render("alarm.json", %{response: alarms, app_infos: app_infos}) do
+    alarms
+    |> Response.serialize()
+    |> Response.add_app_infos(app_infos)
   end
 end

--- a/apps/omg_watcher_rpc/lib/web/views/challenge.ex
+++ b/apps/omg_watcher_rpc/lib/web/views/challenge.ex
@@ -20,8 +20,9 @@ defmodule OMG.WatcherRPC.Web.View.Challenge do
   use OMG.WatcherRPC.Web, :view
   alias OMG.Utils.HttpRPC.Response
 
-  def render("challenge.json", %{response: challenge}) do
+  def render("challenge.json", %{response: challenge, app_infos: app_infos}) do
     challenge
     |> Response.serialize()
+    |> Response.add_app_infos(app_infos)
   end
 end

--- a/apps/omg_watcher_rpc/lib/web/views/error.ex
+++ b/apps/omg_watcher_rpc/lib/web/views/error.ex
@@ -23,19 +23,19 @@ defmodule OMG.WatcherRPC.Web.Views.Error do
   Handles client errors, e.g. malformed json in request body
   """
   def render("400.json", _) do
-    Error.serialize("operation:bad_request", "Server has failed to parse the request.")
+    Error.serialize("operation:bad_request", "Server has failed to parse the request.", %{})
   end
 
   @doc """
   Supports internal server error thrown by Phoenix.
   """
   def render("500.json", %{reason: %{message: message}} = _conn) do
-    Error.serialize("server:internal_server_error", message)
+    Error.serialize("server:internal_server_error", message, %{})
   end
 
   # In case no render clause matches or no
   # template is found, let's render it as 500
   def template_not_found(_template, _assigns) do
-    Error.serialize("server:internal_server_error", nil)
+    Error.serialize("server:internal_server_error", nil, %{})
   end
 end

--- a/apps/omg_watcher_rpc/lib/web/views/fee.ex
+++ b/apps/omg_watcher_rpc/lib/web/views/fee.ex
@@ -20,7 +20,7 @@ defmodule OMG.WatcherRPC.Web.View.Fee do
   use OMG.WatcherRPC.Web, :view
   alias OMG.Utils.HttpRPC.Response
 
-  def render("fees_all.json", %{response: fees}) do
+  def render("fees_all.json", %{response: fees, app_infos: app_infos}) do
     fees
     |> Enum.map(fn fee ->
       fee
@@ -29,5 +29,6 @@ defmodule OMG.WatcherRPC.Web.View.Fee do
       |> Map.put(:updated_at, {:skip_hex_encode, fee.updated_at})
     end)
     |> Response.serialize()
+    |> Response.add_app_infos(app_infos)
   end
 end

--- a/apps/omg_watcher_rpc/lib/web/views/in_flight_exit.ex
+++ b/apps/omg_watcher_rpc/lib/web/views/in_flight_exit.ex
@@ -22,33 +22,38 @@ defmodule OMG.WatcherRPC.Web.View.InFlightExit do
   alias OMG.Utils.HttpRPC.Response
   alias OMG.Utxo
 
-  def render("in_flight_exit.json", %{response: in_flight_exit}) do
+  def render("in_flight_exit.json", %{response: in_flight_exit, app_infos: app_infos}) do
     in_flight_exit
     |> Response.serialize()
+    |> Response.add_app_infos(app_infos)
   end
 
-  def render("competitor.json", %{response: competitor}) do
+  def render("competitor.json", %{response: competitor, app_infos: app_infos}) do
     competitor
     |> Map.update!(:competing_tx_pos, &Utxo.Position.encode/1)
     |> Map.update!(:input_utxo_pos, &Utxo.Position.encode/1)
     |> Response.serialize()
+    |> Response.add_app_infos(app_infos)
   end
 
-  def render("prove_canonical.json", %{response: prove_canonical}) do
+  def render("prove_canonical.json", %{response: prove_canonical, app_infos: app_infos}) do
     prove_canonical
     |> Map.update!(:in_flight_tx_pos, &Utxo.Position.encode/1)
     |> Response.serialize()
+    |> Response.add_app_infos(app_infos)
   end
 
-  def render("get_input_challenge_data.json", %{response: challenge_data}) do
+  def render("get_input_challenge_data.json", %{response: challenge_data, app_infos: app_infos}) do
     challenge_data
     |> Map.update!(:input_utxo_pos, &Utxo.Position.encode/1)
     |> Response.serialize()
+    |> Response.add_app_infos(app_infos)
   end
 
-  def render("get_output_challenge_data.json", %{response: challenge_data}) do
+  def render("get_output_challenge_data.json", %{response: challenge_data, app_infos: app_infos}) do
     challenge_data
     |> Map.update!(:in_flight_output_pos, &Utxo.Position.encode/1)
     |> Response.serialize()
+    |> Response.add_app_infos(app_infos)
   end
 end

--- a/apps/omg_watcher_rpc/lib/web/views/status.ex
+++ b/apps/omg_watcher_rpc/lib/web/views/status.ex
@@ -20,10 +20,11 @@ defmodule OMG.WatcherRPC.Web.View.Status do
   use OMG.WatcherRPC.Web, :view
   alias OMG.Utils.HttpRPC.Response
 
-  def render("status.json", %{response: status}) do
+  def render("status.json", %{response: status, app_infos: app_infos}) do
     status
     |> format_byzantine_events()
     |> Response.serialize()
+    |> Response.add_app_infos(app_infos)
   end
 
   defp format_byzantine_events(%{byzantine_events: byzantine_events, services_synced_heights: heights} = status) do

--- a/apps/omg_watcher_rpc/lib/web/views/transaction.ex
+++ b/apps/omg_watcher_rpc/lib/web/views/transaction.ex
@@ -22,24 +22,30 @@ defmodule OMG.WatcherRPC.Web.View.Transaction do
 
   use OMG.WatcherRPC.Web, :view
 
-  def render("transaction.json", %{response: transaction}) do
+  def render("transaction.json", %{response: transaction, app_infos: app_infos}) do
     transaction
     |> render_transaction()
     |> Response.serialize()
+    |> Response.add_app_infos(app_infos)
   end
 
-  def render("transactions.json", %{response: %Paginator{data: transactions, data_paging: data_paging}}) do
+  def render("transactions.json", %{
+        response: %Paginator{data: transactions, data_paging: data_paging},
+        app_infos: app_infos
+      }) do
     transactions
     |> Enum.map(&render_transaction/1)
     |> Response.serialize_page(data_paging)
+    |> Response.add_app_infos(app_infos)
   end
 
-  def render("submission.json", %{response: transaction}) do
+  def render("submission.json", %{response: transaction, app_infos: app_infos}) do
     transaction
     |> Response.serialize()
+    |> Response.add_app_infos(app_infos)
   end
 
-  def render("create.json", %{response: advice}) do
+  def render("create.json", %{response: advice, app_infos: app_infos}) do
     transactions =
       advice.transactions
       |> Enum.map(fn tx -> Map.update!(tx, :inputs, &render_txoutputs/1) end)
@@ -48,6 +54,7 @@ defmodule OMG.WatcherRPC.Web.View.Transaction do
     advice
     |> Map.put(:transactions, transactions)
     |> Response.serialize()
+    |> Response.add_app_infos(app_infos)
   end
 
   defp render_transaction(transaction) do

--- a/apps/omg_watcher_rpc/lib/web/views/utxo.ex
+++ b/apps/omg_watcher_rpc/lib/web/views/utxo.ex
@@ -20,8 +20,9 @@ defmodule OMG.WatcherRPC.Web.View.Utxo do
   use OMG.WatcherRPC.Web, :view
   alias OMG.Utils.HttpRPC.Response
 
-  def render("utxo_exit.json", %{response: utxo_exit}) do
+  def render("utxo_exit.json", %{response: utxo_exit, app_infos: app_infos}) do
     utxo_exit
     |> Response.serialize()
+    |> Response.add_app_infos(app_infos)
   end
 end

--- a/apps/omg_watcher_rpc/test/omg_watcher_rpc/plugs/application_info_test.exs
+++ b/apps/omg_watcher_rpc/test/omg_watcher_rpc/plugs/application_info_test.exs
@@ -1,0 +1,33 @@
+# Copyright 2019 OmiseGO Pte Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defmodule OMG.WatcherRPC.Plugs.ApplicationInfoTest do
+  @moduledoc false
+  use ExUnit.Case, async: false
+  use Phoenix.ConnTest
+
+  alias OMG.Utils.HttpRPC.Plugs.ApplicationInfo
+
+  describe "call/2" do
+    test "service name is appended" do
+      conn = build_conn() |> ApplicationInfo.call(application: :omg_watcher_rpc)
+      assert "watcher" == conn.assigns.app_infos.service_name
+    end
+
+    test "version is appended and follows semver" do
+      conn = build_conn() |> ApplicationInfo.call(application: :omg_watcher_rpc)
+      assert {:ok, _} = Version.parse(conn.assigns.app_infos.version)
+    end
+  end
+end

--- a/apps/omg_watcher_rpc/test/omg_watcher_rpc/web/views/transaction_test.exs
+++ b/apps/omg_watcher_rpc/test/omg_watcher_rpc/web/views/transaction_test.exs
@@ -32,7 +32,7 @@ defmodule OMG.WatcherRPC.Web.View.TransactionTest do
         |> DB.Transaction.get_by_position(1)
         |> DB.Repo.preload([:inputs, :outputs])
 
-      rendered = View.Transaction.render("transaction.json", %{response: transaction})
+      rendered = View.Transaction.render("transaction.json", %{response: transaction, app_infos: %{}})
 
       # Asserts all transaction inputs get rendered
       assert Map.has_key?(rendered.data, :inputs)
@@ -58,7 +58,7 @@ defmodule OMG.WatcherRPC.Web.View.TransactionTest do
         }
       }
 
-      rendered = View.Transaction.render("transactions.json", %{response: paginator})
+      rendered = View.Transaction.render("transactions.json", %{response: paginator, app_infos: %{}})
       [rendered_1, rendered_2] = rendered.data
 
       assert utxos_match_all?(rendered_1.inputs, tx_1.inputs)


### PR DESCRIPTION
blocks bumping contracts for #1176 a bit. 

## Overview

Adding version and service name to the API responses was using `Code.is_loaded?` to check what service is being run. This was marked to be changed and was bugging me, also it broke some configurations of `mix test`, for some reasons I wouldn't dare investigate.

Instead, we add a Plug that discovers this and is parametrized by the application being run. This plug assigns some data, which is later picked up by views

## Changes

 - as an additional change, I revamped the `health_test` a bit, so that it doesn't get fooled by alarms that are sometimes thrown as background noise (e.g. `disk_almost_full` alarms)
 - I don't like the way the `app_infos` must be verbosely injected into the response in every single view. Phoenix-gurus out there - is there a way to have sth like a custom JSON view template, so that some fields are always present?

## Testing

`mix test`
