### PR TITLE
fix: pin mac brew install to solidity 0.5.11

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -660,6 +660,8 @@ workflows:
           requires: [build]
       - test_barebone_release:
           requires: [build]
+      - barebuild_macos:
+          requires: [build]
       - lint:
           requires: [build]
       - sobelow:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -660,8 +660,6 @@ workflows:
           requires: [build]
       - test_barebone_release:
           requires: [build]
-      - barebuild_macos:
-          requires: [build]
       - lint:
           requires: [build]
       - sobelow:

--- a/bin/setup
+++ b/bin/setup
@@ -90,7 +90,7 @@ brew "gmp"
 brew "libtool"
 brew "cmake"
 brew "rocksdb"
-brew "solidity"
+brew "https://raw.githubusercontent.com/ethereum/homebrew-ethereum/7fa7027f20cca27f76c679d0c5b35ee3c565f284/solidity.rb"
 EOF
 }
 

--- a/bin/setup
+++ b/bin/setup
@@ -90,6 +90,7 @@ brew "gmp"
 brew "libtool"
 brew "cmake"
 brew "rocksdb"
+# Pins solidity to 0.5.11
 brew "https://raw.githubusercontent.com/ethereum/homebrew-ethereum/7fa7027f20cca27f76c679d0c5b35ee3c565f284/solidity.rb"
 EOF
 }


### PR DESCRIPTION
## Overview

Fixes brew installing a newer version of solidity (`0.5.13`) than the contracts' (`0.5.11`) by pinning the solidity version installed by brew.

```
Error: Source file requires different compiler version (current compiler is 0.5.13+commit.5b0b510c.Darwin.appleclang - note that nightly builds are considered to be strictly less than the released version
pragma solidity 0.5.11;
^---------------------^
```
ref: https://circleci.com/gh/omisego/elixir-omg/29602

## Changes

- Pin Mac OS's brew to https://raw.githubusercontent.com/ethereum/homebrew-ethereum/7fa7027f20cca27f76c679d0c5b35ee3c565f284/solidity.rb which is solidity 0.5.11

## Testing

Since this occurs on nightly, https://github.com/omisego/elixir-omg/commit/ba05bec3bfabc2af51304da9f75c6ca9ab90fa0e temporarily adds it to build-deploy workflow for testing and then [removed](https://github.com/omisego/elixir-omg/commit/df65bd9d22a2809951c63f64f505e81e2d9c962b). The passing result is at https://circleci.com/gh/omisego/elixir-omg/29641.
