### PR TITLE
feat: use .tool-versions to pin elixir/erlang for dev env to the builder's versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -112,10 +112,10 @@ jobs:
           source ~/.bash_profile
           asdf plugin-add elixir https://github.com/asdf-vm/asdf-elixir.git
           asdf plugin-add erlang https://github.com/asdf-vm/asdf-erlang.git
-          asdf install erlang 21.0
+          asdf install erlang 21.2.4
           asdf install elixir 1.8.2
           asdf global elixir 1.8.2
-          asdf global erlang 21.0
+          asdf global erlang 21.2.4
       - run:
           command: ./bin/setup
           no_output_timeout: 2400
@@ -398,7 +398,7 @@ jobs:
             sudo dpkg --configure -a || true &&
             sudo dpkg -i erlang-solutions_2.0_all.deb  &&
             sudo apt-get update &&
-            sudo apt-get install esl-erlang=1:21.3.8.10-1 elixir=1.8.2-1
+            sudo apt-get install esl-erlang=1:21.2.4-1 elixir=1.8.2-1
       - run: sh .circleci/status.sh
       - restore_cache:
           key: v1-mix-specs-cache-{{ .Branch }}-{{ checksum "mix.lock" }}
@@ -453,14 +453,14 @@ jobs:
             source ~/.bash_profile
             asdf plugin-add elixir https://github.com/asdf-vm/asdf-elixir.git
             asdf plugin-add erlang https://github.com/asdf-vm/asdf-erlang.git
-            asdf install erlang 21.0
+            asdf install erlang 21.2.4
           no_output_timeout: 2400
       - run: |
           source ~/.bash_profile
           asdf install elixir 1.8.2
       - run: |
           source ~/.bash_profile
-          asdf global erlang 21.0
+          asdf global erlang 21.2.4
       - run:
           command: |
             echo 'export PATH=~/.cargo/bin:$PATH' >> $BASH_ENV

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,5 +1,5 @@
 # Aligns with CI/CD builder at https://github.com/omisego-images/docker-elixir-omg/blob/master/builder/Dockerfile.elixir
-elixir 1.8.1
+elixir 1.8.2
 
 # Aligns with CI/CD builder at https://github.com/omisego-images/docker-elixir-omg/blob/master/builder/Dockerfile.erlang
 erlang 21.2.4

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,5 @@
+# Aligns with CI/CD builder at https://github.com/omisego-images/docker-elixir-omg/blob/master/builder/Dockerfile.elixir
+elixir 1.8.1
+
+# Aligns with CI/CD builder at https://github.com/omisego-images/docker-elixir-omg/blob/master/builder/Dockerfile.erlang
+erlang 21.2.4


### PR DESCRIPTION
## Overview

RE: @okalouti 

> Hello everyone. You might already be aware of this, but FYI just in case: I tried to run tests (mix test) on elixir-omg yesterday using Elixir v. 1.9.2 and they didn't work because the fixtures were not being loaded (e.g. module OMG.Fixtures is not loaded and could not be found ) . Debugged it with @unnawut for some time before figuring out that setting Elixir version to 1.8.0 fixed this problem.

Had a few occurrences where this happens so I'd like to add a `.tool-versions` so those of us with [asdf](https://github.com/asdf-vm/asdf) can work on the same versions. For non-asdf users, looking up the versions in `.tool-versions` is convenient too.

## Changes

- Add `.tool-versions`

## Testing

- If you use [asdf](https://github.com/asdf-vm/asdf), running `asdf current` on elixir-omg directory should give:

    ```
    elixir         1.8.1    (set by <your_path_to_elixir_omg>/.tool-versions)
    erlang         21.2.4   (set by <your_path_to_elixir_omg>/.tool-versions)
    ```

- If you don't use asdf: no impact.