### PR TITLE
feat: add `mix xomg.watcher_info.start`

### DIFF
--- a/apps/xomg_tasks/lib/mix/tasks/child_chain.ex
+++ b/apps/xomg_tasks/lib/mix/tasks/child_chain.ex
@@ -14,14 +14,14 @@
 
 defmodule Mix.Tasks.Xomg.ChildChain.Start do
   @moduledoc """
-    Contains mix.task to run the child chain server
+  Contains mix.task to run the child chain server.
   """
 
   use Mix.Task
 
   import XomgTasks.Utils
 
-  @shortdoc "Start the child chain server. See Mix.Tasks.ChildChain"
+  @shortdoc "Start the child chain server. See Mix.Tasks.Xomg.ChildChain.Start."
 
   def run(args) do
     args

--- a/apps/xomg_tasks/lib/mix/tasks/watcher.ex
+++ b/apps/xomg_tasks/lib/mix/tasks/watcher.ex
@@ -24,7 +24,7 @@ defmodule Mix.Tasks.Xomg.Watcher.Start do
 
   @shortdoc "Starts the security-critical watcher. See Mix.Tasks.Watcher."
 
-  defp run(args) do
+  def run(args) do
     args
     |> generic_prepare_args()
     |> generic_run([:omg_watcher, :omg_watcher_rpc])

--- a/apps/xomg_tasks/lib/mix/tasks/watcher_info.ex
+++ b/apps/xomg_tasks/lib/mix/tasks/watcher_info.ex
@@ -24,7 +24,7 @@ defmodule Mix.Tasks.Xomg.WatcherInfo.Start do
 
   @shortdoc "Starts the security-critical + informational watcher. See Mix.Tasks.Xomg.WatcherInfo.Start."
 
-  defp run(args) do
+  def run(args) do
     args
     |> generic_prepare_args()
     |> generic_run([:omg_watcher_info, :omg_watcher_rpc])

--- a/apps/xomg_tasks/lib/mix/tasks/watcher_info.ex
+++ b/apps/xomg_tasks/lib/mix/tasks/watcher_info.ex
@@ -12,9 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-defmodule Mix.Tasks.Xomg.Watcher.Start do
+defmodule Mix.Tasks.Xomg.WatcherInfo.Start do
   @moduledoc """
-  Contains mix.task to run the watcher in security-critical only modes.
+  Contains mix.task to run the watcher in security-critical + informational mode.
 
   See the README.md file.
   """
@@ -22,11 +22,11 @@ defmodule Mix.Tasks.Xomg.Watcher.Start do
 
   import XomgTasks.Utils
 
-  @shortdoc "Starts the security-critical watcher. See Mix.Tasks.Watcher."
+  @shortdoc "Starts the security-critical + informational watcher. See Mix.Tasks.Xomg.WatcherInfo.Start."
 
   defp run(args) do
     args
     |> generic_prepare_args()
-    |> generic_run([:omg_watcher, :omg_watcher_rpc])
+    |> generic_run([:omg_watcher_info, :omg_watcher_rpc])
   end
 end

--- a/apps/xomg_tasks/lib/utils.ex
+++ b/apps/xomg_tasks/lib/utils.ex
@@ -60,7 +60,7 @@ defmodule XomgTasks.Utils do
 
   # mix loads entire codebase which fools `Response.add_version`
   defp ensure_one_rpc_loaded(apps) do
-    if Enum.member?(apps, :omg_watcher) do
+    if Enum.member?(apps, :omg_watcher) || Enum.member?(apps, :omg_watcher_info) do
       true = :code.delete(OMG.ChildChainRPC)
       :code.purge(OMG.ChildChainRPC)
     end


### PR DESCRIPTION
## Overview

Adds `mix xomg.watcher_info.start` in addition to the existing `mix xomg.watcher.start` and `mix xomg.child_chain.start`. I forgot about this in the main code split PR.

## Changes

- Removed convenience api option from watcher.start and replace with a new task for watcher_info so it has closer UX to API and releases.

## Testing

Run `mix xomg.watcher_info.start`. Couldn't think of a way to automate test without significant overhead. And this is a dev tool so 🤷‍♂ 