### PR TITLE
Datadog service tag app env

### DIFF
--- a/apps/omg_child_chain_rpc/lib/omg_child_chain_rpc/release_tasks/set_tracer.ex
+++ b/apps/omg_child_chain_rpc/lib/omg_child_chain_rpc/release_tasks/set_tracer.ex
@@ -25,10 +25,7 @@ defmodule OMG.ChildChainRPC.ReleaseTasks.SetTracer do
     config = Keyword.put(config, :disabled?, get_dd_disabled())
     config = Keyword.put(config, :env, get_app_env())
 
-    :ok =
-      Application.put_env(:statix, :tags, ["application:child_chain", "deployment_environment:#{get_deployed_to()}"],
-        persistent: true
-      )
+    :ok = Application.put_env(:statix, :tags, ["application:child_chain", "app_env:#{get_app_env()}"], persistent: true)
 
     :ok = Application.put_env(@app, OMG.ChildChainRPC.Tracer, config, persistent: true)
     :ok = Application.put_env(:spandex_phoenix, :tracer, OMG.ChildChainRPC.Tracer, persistent: true)
@@ -46,15 +43,9 @@ defmodule OMG.ChildChainRPC.ReleaseTasks.SetTracer do
   end
 
   defp get_app_env() do
-    env = validate_string(get_env("APP_ENV"), Application.get_env(@app, OMG.ChildChainRPC.Tracer)[:env])
+    env = validate_app_env(get_env("APP_ENV"))
     _ = Logger.info("CONFIGURATION: App: #{@app} Key: APP_ENV Value: #{inspect(env)}.")
     env
-  end
-
-  defp get_deployed_to() do
-    deployed_to = validate_deployed_to(get_env("DEPLOYED_TO"))
-    _ = Logger.info("CONFIGURATION: App: #{@app} Key: DEPLOYED_TO Value: #{inspect(deployed_to)}.")
-    deployed_to
   end
 
   defp get_env(key), do: System.get_env(key)
@@ -66,9 +57,6 @@ defmodule OMG.ChildChainRPC.ReleaseTasks.SetTracer do
   defp to_bool("FALSE"), do: false
   defp to_bool(_), do: exit("DD_DISABLED either true or false.")
 
-  defp validate_string(value, _default) when is_binary(value), do: value
-  defp validate_string(_, default), do: default
-
-  defp validate_deployed_to(value) when is_binary(value), do: value
-  defp validate_deployed_to(nil), do: exit("DEPLOYED_TO must be set.")
+  defp validate_app_env(value) when is_binary(value), do: value
+  defp validate_app_env(nil), do: exit("APP_ENV must be set.")
 end

--- a/apps/omg_child_chain_rpc/lib/omg_child_chain_rpc/web/router.ex
+++ b/apps/omg_child_chain_rpc/lib/omg_child_chain_rpc/web/router.ex
@@ -24,7 +24,7 @@ defmodule OMG.ChildChainRPC.Web.Router do
 
     post("/block.get", Controller.Block, :get_block)
     post("/transaction.submit", Controller.Transaction, :submit)
-    post("/alarm.get", Controller.Alarm, :get_alarms)
+    get("/alarm.get", Controller.Alarm, :get_alarms)
     post("/fees.all", Controller.Fee, :fees_all)
 
     # NOTE: This *has to* be the last route, catching all unhandled paths

--- a/apps/omg_child_chain_rpc/priv/swagger/operator_api_specs.yaml
+++ b/apps/omg_child_chain_rpc/priv/swagger/operator_api_specs.yaml
@@ -21,6 +21,142 @@ tags:
 servers:
   - url: 'http://localhost:9656/'
 paths:
+  /alarm.get:
+    get:
+      tags:
+        - Alarm
+      summary: Gets all utxos belonging to the given address.
+      description: |
+        **Note:** Service operator alarms.
+      operationId: alarm_get
+      responses:
+        '200':
+          description: System alarms
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - description: The response schema for a successful operation
+                    type: object
+                    properties:
+                      version:
+                        type: string
+                      success:
+                        type: boolean
+                      data:
+                        type: object
+                    required:
+                      - version
+                      - success
+                      - data
+                    example:
+                      version: '1.0'
+                      success: true
+                      data: {}
+                  - type: object
+                    properties:
+                      data:
+                        type: array
+                        items:
+                          type: array
+                          items:
+                            anyOf:
+                              - type: object
+                                properties:
+                                  ethereum_client_connection:
+                                    type: object
+                                    properties:
+                                      node:
+                                        type: string
+                                      reporter:
+                                        type: string
+                              - type: object
+                                properties:
+                                  ethereum_client_connection:
+                                    type: object
+                                    properties:
+                                      node:
+                                        type: string
+                                      reporter:
+                                        type: string
+                              - type: object
+                                properties:
+                                  statsd_client_connection:
+                                    type: object
+                                    properties:
+                                      node:
+                                        type: string
+                                      reporter:
+                                        type: string
+                              - type: object
+                                properties:
+                                  statsd_client_connection:
+                                    type: array
+                                    items:
+                                      type: string
+                                    default: []
+                              - type: object
+                                properties:
+                                  disk_almost_full:
+                                    type: string
+                    example:
+                      data:
+                        - disk_almost_full: /dev/null
+                          ethereum_client_connection: {}
+                          system_memory_high_watermark: []
+        '500':
+          description: Returns an internal server error
+          content:
+            application/json:
+              schema:
+                description: The response schema for an error
+                allOf:
+                  - description: The response schema for a successful operation
+                    type: object
+                    properties:
+                      version:
+                        type: string
+                      success:
+                        type: boolean
+                      data:
+                        type: object
+                    required:
+                      - version
+                      - success
+                      - data
+                    example:
+                      version: '1.0'
+                      success: true
+                      data: {}
+                  - type: object
+                    properties:
+                      data:
+                        description: The object schema for an error
+                        type: object
+                        properties:
+                          object:
+                            type: string
+                          code:
+                            type: string
+                          description:
+                            type: string
+                          messages:
+                            type: object
+                        required:
+                          - object
+                          - code
+                          - description
+                          - messages
+                    required:
+                      - data
+                    example:
+                      success: false
+                      data:
+                        object: error
+                        code: 'server:internal_server_error'
+                        description: Something went wrong on the server
+                        messages:
+                          error_key: error_reason
   /transaction.submit:
     post:
       tags:

--- a/apps/omg_child_chain_rpc/priv/swagger/operator_api_specs/alarm/alarms_schema.yml
+++ b/apps/omg_child_chain_rpc/priv/swagger/operator_api_specs/alarm/alarms_schema.yml
@@ -1,0 +1,45 @@
+components:
+  schemas:
+    ethereum_client_connection:
+      type: object
+      properties:
+        ethereum_client_connection:
+          type: object
+          properties:
+            node:
+              type: string
+            reporter:
+              type: string
+    invalid_fee_file:
+      type: object
+      properties:
+        ethereum_client_connection:
+          type: object
+          properties:
+            node:
+              type: string
+            reporter:
+              type: string
+    statsd_client_connection:
+      type: object
+      properties:
+        statsd_client_connection:
+          type: object
+          properties:
+            node:
+              type: string
+            reporter:
+              type: string
+    system_memory_high_watermark:
+      type: object
+      properties:
+        statsd_client_connection:
+          type: array
+          items:
+            type: string
+          default: []
+    disk_almost_full:
+      type: object
+      properties: 
+        disk_almost_full:
+          type: string

--- a/apps/omg_child_chain_rpc/priv/swagger/operator_api_specs/alarm/paths.yaml
+++ b/apps/omg_child_chain_rpc/priv/swagger/operator_api_specs/alarm/paths.yaml
@@ -1,0 +1,13 @@
+alarm.get:
+  get:
+    tags:
+      - Alarm
+    summary: Gets all utxos belonging to the given address.
+    description: >
+      **Note:** Service operator alarms.
+    operationId: alarm_get
+    responses:
+      200:
+        $ref: 'responses.yaml#/AlarmResponse'
+      500:
+        $ref: '../../shared/responses.yaml#/InternalServerError'

--- a/apps/omg_child_chain_rpc/priv/swagger/operator_api_specs/alarm/response_schemas.yaml
+++ b/apps/omg_child_chain_rpc/priv/swagger/operator_api_specs/alarm/response_schemas.yaml
@@ -1,0 +1,15 @@
+AlarmResponseSchema:
+  allOf:
+  - $ref: '../../shared/schemas.yaml#/BaseResponseSchema'
+  - type: object
+    properties:
+      data:
+        type: array
+        items:
+          $ref: 'schemas.yaml#/AlarmSchema'
+    example:
+      data:
+      -
+        disk_almost_full: "/dev/null"
+        ethereum_client_connection: {}
+        system_memory_high_watermark: []

--- a/apps/omg_child_chain_rpc/priv/swagger/operator_api_specs/alarm/responses.yaml
+++ b/apps/omg_child_chain_rpc/priv/swagger/operator_api_specs/alarm/responses.yaml
@@ -1,0 +1,6 @@
+AlarmResponse:
+  description: System alarms
+  content:
+    application/json:
+      schema:
+        $ref: 'response_schemas.yaml#/AlarmResponseSchema'

--- a/apps/omg_child_chain_rpc/priv/swagger/operator_api_specs/alarm/schemas.yaml
+++ b/apps/omg_child_chain_rpc/priv/swagger/operator_api_specs/alarm/schemas.yaml
@@ -1,0 +1,9 @@
+AlarmSchema:
+  type: array
+  items:
+    anyOf:
+      - $ref: 'alarms_schema.yml#/components/schemas/ethereum_client_connection'
+      - $ref: 'alarms_schema.yml#/components/schemas/invalid_fee_file'
+      - $ref: 'alarms_schema.yml#/components/schemas/statsd_client_connection'
+      - $ref: 'alarms_schema.yml#/components/schemas/system_memory_high_watermark'
+      - $ref: 'alarms_schema.yml#/components/schemas/disk_almost_full'

--- a/apps/omg_child_chain_rpc/priv/swagger/operator_api_specs/swagger.yaml
+++ b/apps/omg_child_chain_rpc/priv/swagger/operator_api_specs/swagger.yaml
@@ -25,6 +25,8 @@ servers:
   - url: 'http://localhost:9656/'
 
 paths:
+  /alarm.get:
+    $ref: 'alarm/paths.yaml#/alarm.get'
   /transaction.submit:
     $ref: 'transaction/paths.yaml#/transaction.submit'
   /block.get:

--- a/apps/omg_child_chain_rpc/test/omg_child_chain_rpc/release_tasks/set_tracer_test.exs
+++ b/apps/omg_child_chain_rpc/test/omg_child_chain_rpc/release_tasks/set_tracer_test.exs
@@ -48,8 +48,18 @@ defmodule OMG.ChildChainRPC.ReleaseTasks.SetTracerTest do
   test "if default configuration is used when there's no environment variables" do
     :ok = Application.put_env(@app, Tracer, @configuration_old, persistent: true)
     :ok = System.delete_env("DD_DISABLED")
-    :ok = System.delete_env("APP_ENV")
+    :ok = System.put_env("APP_ENV", "YOLO")
     :ok = SetTracer.init([])
+    configuration = Application.get_env(@app, Tracer)
+    sorted_configuration = Enum.sort(configuration)
+    assert sorted_configuration == @configuration_old |> Keyword.put(:env, "YOLO") |> Enum.sort()
+  end
+
+  test "that if APP_ENV env var is not present we crash" do
+    :ok = Application.put_env(@app, Tracer, @configuration_old, persistent: true)
+    :ok = System.delete_env("DD_DISABLED")
+    :ok = System.delete_env("APP_ENV")
+    catch_exit(SetTracer.init([]))
     configuration = Application.get_env(@app, Tracer)
     sorted_configuration = Enum.sort(configuration)
     ^sorted_configuration = Enum.sort(@configuration_old)

--- a/apps/omg_child_chain_rpc/test/omg_child_chain_rpc/release_tasks/set_tracer_test.exs
+++ b/apps/omg_child_chain_rpc/test/omg_child_chain_rpc/release_tasks/set_tracer_test.exs
@@ -19,17 +19,12 @@ defmodule OMG.ChildChainRPC.ReleaseTasks.SetTracerTest do
 
   @app :omg_child_chain_rpc
   @configuration_old Application.get_env(@app, Tracer)
-  @configuration_statix_old Application.get_all_env(:statix)
+
   setup do
     on_exit(fn ->
       # configuration is global state so we reset it to known values in case
       # it got fiddled before
       :ok = Application.put_env(@app, Tracer, @configuration_old, persistent: true)
-
-      :ok =
-        Enum.each(@configuration_statix_old, fn {key, value} ->
-          Application.put_env(:statix, key, value, persistent: true)
-        end)
     end)
 
     :ok

--- a/apps/omg_child_chain_rpc/test/omg_child_chain_rpc/web/controllers/alarm_test.exs
+++ b/apps/omg_child_chain_rpc/test/omg_child_chain_rpc/web/controllers/alarm_test.exs
@@ -35,7 +35,7 @@ defmodule OMG.ChildChainRPC.Web.Controller.AlarmTest do
   ### covered in OMG.Utils.HttpRPC.ResponseTest
   @tag fixtures: [:phoenix_sandbox]
   test "if the controller returns the correct result when there's no alarms raised", _ do
-    response = TestHelper.rpc_call(:post, "alarm.get")
+    response = TestHelper.rpc_call(:get, "alarm.get")
     version = Map.get(response, "version")
     %{"data" => [], "success" => true, "version" => ^version} = response
   end

--- a/apps/omg_child_chain_rpc/test/omg_child_chain_rpc/web/plugs/health_test.exs
+++ b/apps/omg_child_chain_rpc/test/omg_child_chain_rpc/web/plugs/health_test.exs
@@ -40,7 +40,7 @@ defmodule OMG.ChildChainRPC.Plugs.HealthTest do
             ],
             "success" => true
           },
-          fn -> TestHelper.rpc_call(:post, "/alarm.get", %{}) end
+          fn -> TestHelper.rpc_call(:get, "/alarm.get") end
         )
 
       :ok = :alarm_handler.clear_alarm(@alarm_1)
@@ -62,7 +62,7 @@ defmodule OMG.ChildChainRPC.Plugs.HealthTest do
             },
             "success" => false
           },
-          fn -> TestHelper.rpc_call(:post, "/block.get", %{}) end
+          fn -> TestHelper.rpc_call(:post, "/block.get") end
         )
 
       :ok = :alarm_handler.clear_alarm(@alarm_1)
@@ -104,7 +104,7 @@ defmodule OMG.ChildChainRPC.Plugs.HealthTest do
             ],
             "success" => true
           },
-          fn -> TestHelper.rpc_call(:post, "/alarm.get", %{}) end
+          fn -> TestHelper.rpc_call(:get, "/alarm.get") end
         )
 
       :ok = :alarm_handler.clear_alarm(@alarm_2)

--- a/apps/omg_status/lib/omg_status/release_tasks/set_tracer.ex
+++ b/apps/omg_status/lib/omg_status/release_tasks/set_tracer.ex
@@ -30,7 +30,6 @@ defmodule OMG.Status.ReleaseTasks.SetTracer do
     # statix setup
     :ok = Application.put_env(:statix, :host, get_dd_hostname(Application.get_env(:statix, :host)), persistent: true)
     :ok = Application.put_env(:statix, :port, get_dd_port(Application.get_env(:statix, :port)), persistent: true)
-    :ok = Application.put_env(:statix, :tags, ["application:#{application()}"], persistent: true)
     # spandex_datadog setup
 
     :ok =
@@ -114,12 +113,4 @@ defmodule OMG.Status.ReleaseTasks.SetTracer do
 
   defp validate_integer(value, _default) when is_binary(value), do: String.to_integer(value)
   defp validate_integer(_, default), do: default
-
-  defp application do
-    if Code.ensure_loaded?(OMG.ChildChain) do
-      :child_chain
-    else
-      :watcher
-    end
-  end
 end

--- a/apps/omg_status/test/omg_status/release_tasks/set_tracer_test.exs
+++ b/apps/omg_status/test/omg_status/release_tasks/set_tracer_test.exs
@@ -69,12 +69,11 @@ defmodule OMG.Status.ReleaseTasks.SetTracerTest do
     "cluster" = host
     1919 = port
 
-    ^configuration =
-      @configuration_old_statix
-      |> Keyword.put(:host, "cluster")
-      |> Keyword.put(:port, 1919)
-      |> Keyword.put(:tags, ["application:#{application()}"])
-      |> Enum.sort()
+    assert configuration ==
+             @configuration_old_statix
+             |> Keyword.put(:host, "cluster")
+             |> Keyword.put(:port, 1919)
+             |> Enum.sort()
   end
 
   test "if default statix configuration is used when there's no environment variables" do
@@ -89,10 +88,7 @@ defmodule OMG.Status.ReleaseTasks.SetTracerTest do
     configuration = Application.get_all_env(:statix)
     sorted_configuration = Enum.sort(configuration)
 
-    ^sorted_configuration =
-      @configuration_old_statix
-      |> Keyword.put(:tags, ["application:#{application()}"])
-      |> Enum.sort()
+    assert sorted_configuration == Enum.sort(@configuration_old_statix)
   end
 
   test "if environment variables get applied in the spandex_datadog configuration" do
@@ -141,13 +137,5 @@ defmodule OMG.Status.ReleaseTasks.SetTracerTest do
     :ok = System.put_env("DD_DISABLED", "TRUEeee")
     catch_exit(SetTracer.init([]))
     :ok = System.delete_env("DD_DISABLED")
-  end
-
-  defp application do
-    if Code.ensure_loaded?(OMG.ChildChain) do
-      :child_chain
-    else
-      :watcher
-    end
   end
 end

--- a/apps/omg_status/test/omg_status/release_tasks/set_tracer_test.exs
+++ b/apps/omg_status/test/omg_status/release_tasks/set_tracer_test.exs
@@ -26,8 +26,10 @@ defmodule OMG.Status.ReleaseTasks.SetTracerTest do
       # configuration is global state so we reset it to known values in case
       # it got fiddled before
       :ok = Application.put_env(@app, Tracer, @configuration_old, persistent: true)
-      :ok = Application.put_env(@app, :statix, @configuration_old_statix, persistent: true)
       :ok = Application.put_env(@app, :spandex_datadog, @configuration_old_spandex_datadog, persistent: true)
+      :ok = Application.put_env(:statix, :host, Keyword.get(@configuration_old_statix, :host), persistent: true)
+      :ok = Application.put_env(:statix, :port, Keyword.get(@configuration_old_statix, :port), persistent: true)
+      :ok = Application.put_env(:statix, :tags, nil, persistent: true)
     end)
 
     :ok
@@ -73,6 +75,7 @@ defmodule OMG.Status.ReleaseTasks.SetTracerTest do
              @configuration_old_statix
              |> Keyword.put(:host, "cluster")
              |> Keyword.put(:port, 1919)
+             |> Keyword.put(:tags, nil)
              |> Enum.sort()
   end
 
@@ -88,7 +91,7 @@ defmodule OMG.Status.ReleaseTasks.SetTracerTest do
     configuration = Application.get_all_env(:statix)
     sorted_configuration = Enum.sort(configuration)
 
-    assert sorted_configuration == Enum.sort(@configuration_old_statix)
+    assert sorted_configuration == @configuration_old_statix |> Keyword.put(:tags, nil) |> Enum.sort()
   end
 
   test "if environment variables get applied in the spandex_datadog configuration" do

--- a/apps/omg_watcher/lib/omg_watcher/release_tasks/set_tracer.ex
+++ b/apps/omg_watcher/lib/omg_watcher/release_tasks/set_tracer.ex
@@ -24,20 +24,32 @@ defmodule OMG.Watcher.ReleaseTasks.SetTracer do
     config = Application.get_env(@app, OMG.Watcher.Tracer)
     config = Keyword.put(config, :disabled?, get_dd_disabled())
     config = Keyword.put(config, :env, get_app_env())
+
+    :ok =
+      Application.put_env(:statix, :tags, ["application:watcher", "deployment_environment:#{get_deployed_to()}"],
+        persistent: true
+      )
+
     :ok = Application.put_env(@app, OMG.Watcher.Tracer, config, persistent: true)
   end
 
-  defp get_dd_disabled do
+  defp get_dd_disabled() do
     dd_disabled? = validate_bool(get_env("DD_DISABLED"), Application.get_env(@app, OMG.Watcher.Tracer)[:disabled?])
 
     _ = Logger.info("CONFIGURATION: App: #{@app} Key: DD_DISABLED Value: #{inspect(dd_disabled?)}.")
     dd_disabled?
   end
 
-  defp get_app_env do
+  defp get_app_env() do
     env = validate_string(get_env("APP_ENV"), Application.get_env(@app, OMG.Watcher.Tracer)[:env])
     _ = Logger.info("CONFIGURATION: App: #{@app} Key: APP_ENV Value: #{inspect(env)}.")
     env
+  end
+
+  defp get_deployed_to() do
+    deployed_to = validate_deployed_to(get_env("DEPLOYED_TO"))
+    _ = Logger.info("CONFIGURATION: App: #{@app} Key: DEPLOYED_TO Value: #{inspect(deployed_to)}.")
+    deployed_to
   end
 
   defp get_env(key), do: System.get_env(key)
@@ -51,4 +63,7 @@ defmodule OMG.Watcher.ReleaseTasks.SetTracer do
 
   defp validate_string(value, _default) when is_binary(value), do: value
   defp validate_string(_, default), do: default
+
+  defp validate_deployed_to(value) when is_binary(value), do: value
+  defp validate_deployed_to(nil), do: exit("DEPLOYED_TO must be set.")
 end

--- a/apps/omg_watcher/lib/omg_watcher/release_tasks/set_tracer.ex
+++ b/apps/omg_watcher/lib/omg_watcher/release_tasks/set_tracer.ex
@@ -25,10 +25,7 @@ defmodule OMG.Watcher.ReleaseTasks.SetTracer do
     config = Keyword.put(config, :disabled?, get_dd_disabled())
     config = Keyword.put(config, :env, get_app_env())
 
-    :ok =
-      Application.put_env(:statix, :tags, ["application:watcher", "deployment_environment:#{get_deployed_to()}"],
-        persistent: true
-      )
+    :ok = Application.put_env(:statix, :tags, ["application:watcher", "app_env:#{get_app_env()}"], persistent: true)
 
     :ok = Application.put_env(@app, OMG.Watcher.Tracer, config, persistent: true)
   end
@@ -41,15 +38,9 @@ defmodule OMG.Watcher.ReleaseTasks.SetTracer do
   end
 
   defp get_app_env() do
-    env = validate_string(get_env("APP_ENV"), Application.get_env(@app, OMG.Watcher.Tracer)[:env])
+    env = validate_app_env(get_env("APP_ENV"))
     _ = Logger.info("CONFIGURATION: App: #{@app} Key: APP_ENV Value: #{inspect(env)}.")
     env
-  end
-
-  defp get_deployed_to() do
-    deployed_to = validate_deployed_to(get_env("DEPLOYED_TO"))
-    _ = Logger.info("CONFIGURATION: App: #{@app} Key: DEPLOYED_TO Value: #{inspect(deployed_to)}.")
-    deployed_to
   end
 
   defp get_env(key), do: System.get_env(key)
@@ -61,9 +52,6 @@ defmodule OMG.Watcher.ReleaseTasks.SetTracer do
   defp to_bool("FALSE"), do: false
   defp to_bool(_), do: exit("DD_DISABLED either true or false.")
 
-  defp validate_string(value, _default) when is_binary(value), do: value
-  defp validate_string(_, default), do: default
-
-  defp validate_deployed_to(value) when is_binary(value), do: value
-  defp validate_deployed_to(nil), do: exit("DEPLOYED_TO must be set.")
+  defp validate_app_env(value) when is_binary(value), do: value
+  defp validate_app_env(nil), do: exit("APP_ENV must be set.")
 end

--- a/apps/omg_watcher/test/omg_watcher/release_tasks/set_tracer_test.exs
+++ b/apps/omg_watcher/test/omg_watcher/release_tasks/set_tracer_test.exs
@@ -18,17 +18,11 @@ defmodule OMG.Watcher.ReleaseTasks.SetTracerTest do
   alias OMG.Watcher.Tracer
   @app :omg_watcher
   @configuration_old Application.get_env(@app, Tracer)
-  @configuration_statix_old Application.get_all_env(:statix)
   setup do
     on_exit(fn ->
       # configuration is global state so we reset it to known values in case
       # it got fiddled before
       :ok = Application.put_env(@app, Tracer, @configuration_old, persistent: true)
-
-      :ok =
-        Enum.each(@configuration_statix_old, fn {key, value} ->
-          Application.put_env(:statix, key, value, persistent: true)
-        end)
     end)
 
     :ok

--- a/apps/omg_watcher/test/omg_watcher/release_tasks/set_tracer_test.exs
+++ b/apps/omg_watcher/test/omg_watcher/release_tasks/set_tracer_test.exs
@@ -12,12 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-defmodule OMG.ChildChainRPC.ReleaseTasks.SetTracerTest do
+defmodule OMG.Watcher.ReleaseTasks.SetTracerTest do
   use ExUnit.Case, async: false
-  alias OMG.ChildChainRPC.ReleaseTasks.SetTracer
-  alias OMG.ChildChainRPC.Tracer
-
-  @app :omg_child_chain_rpc
+  alias OMG.Watcher.ReleaseTasks.SetTracer
+  alias OMG.Watcher.Tracer
+  @app :omg_watcher
   @configuration_old Application.get_env(@app, Tracer)
   @configuration_statix_old Application.get_all_env(:statix)
   setup do
@@ -52,23 +51,12 @@ defmodule OMG.ChildChainRPC.ReleaseTasks.SetTracerTest do
   end
 
   test "if default configuration is used when there's no environment variables" do
-    :ok = Application.put_env(@app, Tracer, @configuration_old, persistent: true)
     :ok = System.delete_env("DD_DISABLED")
     :ok = System.put_env("APP_ENV", "YOLO")
     :ok = SetTracer.init([])
     configuration = Application.get_env(@app, Tracer)
     sorted_configuration = Enum.sort(configuration)
     assert sorted_configuration == @configuration_old |> Keyword.put(:env, "YOLO") |> Enum.sort()
-  end
-
-  test "that if APP_ENV env var is not present we crash" do
-    :ok = Application.put_env(@app, Tracer, @configuration_old, persistent: true)
-    :ok = System.delete_env("DD_DISABLED")
-    :ok = System.delete_env("APP_ENV")
-    catch_exit(SetTracer.init([]))
-    configuration = Application.get_env(@app, Tracer)
-    sorted_configuration = Enum.sort(configuration)
-    ^sorted_configuration = Enum.sort(@configuration_old)
   end
 
   test "if exit is thrown when faulty configuration is used" do

--- a/apps/omg_watcher_info/lib/omg_watcher_info/release_tasks/set_tracer.ex
+++ b/apps/omg_watcher_info/lib/omg_watcher_info/release_tasks/set_tracer.ex
@@ -26,9 +26,7 @@ defmodule OMG.WatcherInfo.ReleaseTasks.SetTracer do
     config = Keyword.put(config, :env, get_app_env())
 
     :ok =
-      Application.put_env(:statix, :tags, ["application:watcher_info", "deployment_environment:#{get_deployed_to()}"],
-        persistent: true
-      )
+      Application.put_env(:statix, :tags, ["application:watcher_info", "app_env:#{get_app_env()}"], persistent: true)
 
     :ok = Application.put_env(@app, OMG.WatcherInfo.Tracer, config, persistent: true)
   end
@@ -41,15 +39,9 @@ defmodule OMG.WatcherInfo.ReleaseTasks.SetTracer do
   end
 
   defp get_app_env() do
-    env = validate_string(get_env("APP_ENV"), Application.get_env(@app, OMG.WatcherInfo.Tracer)[:env])
+    env = validate_app_env(get_env("APP_ENV"))
     _ = Logger.info("CONFIGURATION: App: #{@app} Key: APP_ENV Value: #{inspect(env)}.")
     env
-  end
-
-  defp get_deployed_to() do
-    deployed_to = validate_deployed_to(get_env("DEPLOYED_TO"))
-    _ = Logger.info("CONFIGURATION: App: #{@app} Key: DEPLOYED_TO Value: #{inspect(deployed_to)}.")
-    deployed_to
   end
 
   defp get_env(key), do: System.get_env(key)
@@ -61,9 +53,6 @@ defmodule OMG.WatcherInfo.ReleaseTasks.SetTracer do
   defp to_bool("FALSE"), do: false
   defp to_bool(_), do: exit("DD_DISABLED either true or false.")
 
-  defp validate_string(value, _default) when is_binary(value), do: value
-  defp validate_string(_, default), do: default
-
-  defp validate_deployed_to(value) when is_binary(value), do: value
-  defp validate_deployed_to(nil), do: exit("DEPLOYED_TO must be set.")
+  defp validate_app_env(value) when is_binary(value), do: value
+  defp validate_app_env(nil), do: exit("APP_ENV must be set.")
 end

--- a/apps/omg_watcher_info/lib/omg_watcher_info/release_tasks/set_tracer.ex
+++ b/apps/omg_watcher_info/lib/omg_watcher_info/release_tasks/set_tracer.ex
@@ -24,20 +24,32 @@ defmodule OMG.WatcherInfo.ReleaseTasks.SetTracer do
     config = Application.get_env(@app, OMG.WatcherInfo.Tracer)
     config = Keyword.put(config, :disabled?, get_dd_disabled())
     config = Keyword.put(config, :env, get_app_env())
+
+    :ok =
+      Application.put_env(:statix, :tags, ["application:watcher_info", "deployment_environment:#{get_deployed_to()}"],
+        persistent: true
+      )
+
     :ok = Application.put_env(@app, OMG.WatcherInfo.Tracer, config, persistent: true)
   end
 
-  defp get_dd_disabled do
+  defp get_dd_disabled() do
     dd_disabled? = validate_bool(get_env("DD_DISABLED"), Application.get_env(@app, OMG.WatcherInfo.Tracer)[:disabled?])
 
     _ = Logger.info("CONFIGURATION: App: #{@app} Key: DD_DISABLED Value: #{inspect(dd_disabled?)}.")
     dd_disabled?
   end
 
-  defp get_app_env do
+  defp get_app_env() do
     env = validate_string(get_env("APP_ENV"), Application.get_env(@app, OMG.WatcherInfo.Tracer)[:env])
     _ = Logger.info("CONFIGURATION: App: #{@app} Key: APP_ENV Value: #{inspect(env)}.")
     env
+  end
+
+  defp get_deployed_to() do
+    deployed_to = validate_deployed_to(get_env("DEPLOYED_TO"))
+    _ = Logger.info("CONFIGURATION: App: #{@app} Key: DEPLOYED_TO Value: #{inspect(deployed_to)}.")
+    deployed_to
   end
 
   defp get_env(key), do: System.get_env(key)
@@ -51,4 +63,7 @@ defmodule OMG.WatcherInfo.ReleaseTasks.SetTracer do
 
   defp validate_string(value, _default) when is_binary(value), do: value
   defp validate_string(_, default), do: default
+
+  defp validate_deployed_to(value) when is_binary(value), do: value
+  defp validate_deployed_to(nil), do: exit("DEPLOYED_TO must be set.")
 end

--- a/apps/omg_watcher_info/test/omg_watcher_info/release_tasks/set_tracer_test.exs
+++ b/apps/omg_watcher_info/test/omg_watcher_info/release_tasks/set_tracer_test.exs
@@ -46,11 +46,11 @@ defmodule OMG.WatcherInfo.ReleaseTasks.SetTracerTest do
 
   test "if default configuration is used when there's no environment variables" do
     :ok = System.delete_env("DD_DISABLED")
-    :ok = System.delete_env("APP_ENV")
+    :ok = System.put_env("APP_ENV", "YOLO")
     :ok = SetTracer.init([])
     configuration = Application.get_env(@app, Tracer)
     sorted_configuration = Enum.sort(configuration)
-    ^sorted_configuration = Enum.sort(@configuration_old)
+    assert sorted_configuration == @configuration_old |> Keyword.put(:env, "YOLO") |> Enum.sort()
   end
 
   test "if exit is thrown when faulty configuration is used" do

--- a/apps/omg_watcher_info/test/omg_watcher_info/release_tasks/set_tracer_test.exs
+++ b/apps/omg_watcher_info/test/omg_watcher_info/release_tasks/set_tracer_test.exs
@@ -18,17 +18,12 @@ defmodule OMG.WatcherInfo.ReleaseTasks.SetTracerTest do
   alias OMG.WatcherInfo.Tracer
   @app :omg_watcher_info
   @configuration_old Application.get_env(@app, Tracer)
-  @configuration_statix_old Application.get_all_env(:statix)
+
   setup do
     on_exit(fn ->
       # configuration is global state so we reset it to known values in case
       # it got fiddled before
       :ok = Application.put_env(@app, Tracer, @configuration_old, persistent: true)
-
-      :ok =
-        Enum.each(@configuration_statix_old, fn {key, value} ->
-          Application.put_env(:statix, key, value, persistent: true)
-        end)
     end)
 
     :ok

--- a/apps/omg_watcher_info/test/omg_watcher_info/release_tasks/set_tracer_test.exs
+++ b/apps/omg_watcher_info/test/omg_watcher_info/release_tasks/set_tracer_test.exs
@@ -18,11 +18,17 @@ defmodule OMG.WatcherInfo.ReleaseTasks.SetTracerTest do
   alias OMG.WatcherInfo.Tracer
   @app :omg_watcher_info
   @configuration_old Application.get_env(@app, Tracer)
+  @configuration_statix_old Application.get_all_env(:statix)
   setup do
     on_exit(fn ->
       # configuration is global state so we reset it to known values in case
       # it got fiddled before
       :ok = Application.put_env(@app, Tracer, @configuration_old, persistent: true)
+
+      :ok =
+        Enum.each(@configuration_statix_old, fn {key, value} ->
+          Application.put_env(:statix, key, value, persistent: true)
+        end)
     end)
 
     :ok

--- a/apps/omg_watcher_rpc/lib/web/router.ex
+++ b/apps/omg_watcher_rpc/lib/web/router.ex
@@ -24,7 +24,7 @@ defmodule OMG.WatcherRPC.Web.Router do
     pipe_through([:api])
 
     post("/status.get", Controller.Status, :get_status)
-    post("/alarm.get", Controller.Alarm, :get_alarms)
+    get("/alarm.get", Controller.Alarm, :get_alarms)
 
     post("/account.get_exitable_utxos", Controller.Account, :get_exitable_utxos)
 

--- a/apps/omg_watcher_rpc/priv/swagger/info_api_specs.yaml
+++ b/apps/omg_watcher_rpc/priv/swagger/info_api_specs.yaml
@@ -21,6 +21,142 @@ tags:
   - name: Fees
     description: Fees related API.
 paths:
+  /alarm.get:
+    get:
+      tags:
+        - Alarm
+      summary: Gets all utxos belonging to the given address.
+      description: |
+        **Note:** Service operator alarms.
+      operationId: alarm_get
+      responses:
+        '200':
+          description: System alarms
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - description: The response schema for a successful operation
+                    type: object
+                    properties:
+                      version:
+                        type: string
+                      success:
+                        type: boolean
+                      data:
+                        type: object
+                    required:
+                      - version
+                      - success
+                      - data
+                    example:
+                      version: '1.0'
+                      success: true
+                      data: {}
+                  - type: object
+                    properties:
+                      data:
+                        type: array
+                        items:
+                          type: array
+                          items:
+                            anyOf:
+                              - type: object
+                                properties:
+                                  ethereum_client_connection:
+                                    type: object
+                                    properties:
+                                      node:
+                                        type: string
+                                      reporter:
+                                        type: string
+                              - type: object
+                                properties:
+                                  ethereum_client_connection:
+                                    type: object
+                                    properties:
+                                      node:
+                                        type: string
+                                      reporter:
+                                        type: string
+                              - type: object
+                                properties:
+                                  statsd_client_connection:
+                                    type: object
+                                    properties:
+                                      node:
+                                        type: string
+                                      reporter:
+                                        type: string
+                              - type: object
+                                properties:
+                                  statsd_client_connection:
+                                    type: array
+                                    items:
+                                      type: string
+                                    default: []
+                              - type: object
+                                properties:
+                                  disk_almost_full:
+                                    type: string
+                    example:
+                      data:
+                        - disk_almost_full: /dev/null
+                          ethereum_client_connection: {}
+                          system_memory_high_watermark: []
+        '500':
+          description: Returns an internal server error
+          content:
+            application/json:
+              schema:
+                description: The response schema for an error
+                allOf:
+                  - description: The response schema for a successful operation
+                    type: object
+                    properties:
+                      version:
+                        type: string
+                      success:
+                        type: boolean
+                      data:
+                        type: object
+                    required:
+                      - version
+                      - success
+                      - data
+                    example:
+                      version: '1.0'
+                      success: true
+                      data: {}
+                  - type: object
+                    properties:
+                      data:
+                        description: The object schema for an error
+                        type: object
+                        properties:
+                          object:
+                            type: string
+                          code:
+                            type: string
+                          description:
+                            type: string
+                          messages:
+                            type: object
+                        required:
+                          - object
+                          - code
+                          - description
+                          - messages
+                    required:
+                      - data
+                    example:
+                      success: false
+                      data:
+                        object: error
+                        code: 'server:internal_server_error'
+                        description: Something went wrong on the server
+                        messages:
+                          error_key: error_reason
   /account.get_balance:
     post:
       tags:

--- a/apps/omg_watcher_rpc/priv/swagger/info_api_specs/alarm/alarms_schema.yml
+++ b/apps/omg_watcher_rpc/priv/swagger/info_api_specs/alarm/alarms_schema.yml
@@ -1,0 +1,45 @@
+components:
+  schemas:
+    ethereum_client_connection:
+      type: object
+      properties:
+        ethereum_client_connection:
+          type: object
+          properties:
+            node:
+              type: string
+            reporter:
+              type: string
+    invalid_fee_file:
+      type: object
+      properties:
+        ethereum_client_connection:
+          type: object
+          properties:
+            node:
+              type: string
+            reporter:
+              type: string
+    statsd_client_connection:
+      type: object
+      properties:
+        statsd_client_connection:
+          type: object
+          properties:
+            node:
+              type: string
+            reporter:
+              type: string
+    system_memory_high_watermark:
+      type: object
+      properties:
+        statsd_client_connection:
+          type: array
+          items:
+            type: string
+          default: []
+    disk_almost_full:
+      type: object
+      properties: 
+        disk_almost_full:
+          type: string

--- a/apps/omg_watcher_rpc/priv/swagger/info_api_specs/alarm/paths.yaml
+++ b/apps/omg_watcher_rpc/priv/swagger/info_api_specs/alarm/paths.yaml
@@ -1,0 +1,13 @@
+alarm.get:
+  get:
+    tags:
+      - Alarm
+    summary: Gets all utxos belonging to the given address.
+    description: >
+      **Note:** Service operator alarms.
+    operationId: alarm_get
+    responses:
+      200:
+        $ref: 'responses.yaml#/AlarmResponse'
+      500:
+        $ref: '../../shared/responses.yaml#/InternalServerError'

--- a/apps/omg_watcher_rpc/priv/swagger/info_api_specs/alarm/response_schemas.yaml
+++ b/apps/omg_watcher_rpc/priv/swagger/info_api_specs/alarm/response_schemas.yaml
@@ -1,0 +1,15 @@
+AlarmResponseSchema:
+  allOf:
+  - $ref: '../../shared/schemas.yaml#/BaseResponseSchema'
+  - type: object
+    properties:
+      data:
+        type: array
+        items:
+          $ref: 'schemas.yaml#/AlarmSchema'
+    example:
+      data:
+      -
+        disk_almost_full: "/dev/null"
+        ethereum_client_connection: {}
+        system_memory_high_watermark: []

--- a/apps/omg_watcher_rpc/priv/swagger/info_api_specs/alarm/responses.yaml
+++ b/apps/omg_watcher_rpc/priv/swagger/info_api_specs/alarm/responses.yaml
@@ -1,0 +1,6 @@
+AlarmResponse:
+  description: System alarms
+  content:
+    application/json:
+      schema:
+        $ref: 'response_schemas.yaml#/AlarmResponseSchema'

--- a/apps/omg_watcher_rpc/priv/swagger/info_api_specs/alarm/schemas.yaml
+++ b/apps/omg_watcher_rpc/priv/swagger/info_api_specs/alarm/schemas.yaml
@@ -1,0 +1,9 @@
+AlarmSchema:
+  type: array
+  items:
+    anyOf:
+      - $ref: 'alarms_schema.yml#/components/schemas/ethereum_client_connection'
+      - $ref: 'alarms_schema.yml#/components/schemas/invalid_fee_file'
+      - $ref: 'alarms_schema.yml#/components/schemas/statsd_client_connection'
+      - $ref: 'alarms_schema.yml#/components/schemas/system_memory_high_watermark'
+      - $ref: 'alarms_schema.yml#/components/schemas/disk_almost_full'

--- a/apps/omg_watcher_rpc/priv/swagger/info_api_specs/swagger.yaml
+++ b/apps/omg_watcher_rpc/priv/swagger/info_api_specs/swagger.yaml
@@ -27,6 +27,8 @@ tags:
   #   description: Block related API.
 
 paths:
+  /alarm.get:
+    $ref: 'alarm/paths.yaml#/alarm.get'
   /account.get_balance:
     $ref: 'account/paths.yaml#/account.get_balance'
   /account.get_utxos:

--- a/apps/omg_watcher_rpc/priv/swagger/security_critical_api_specs.yaml
+++ b/apps/omg_watcher_rpc/priv/swagger/security_critical_api_specs.yaml
@@ -26,9 +26,144 @@ tags:
   - name: InFlightExit
     description: InFlightExit related API.
 servers:
-  - url: 'https://watcher.ari.omg.network/'
   - url: 'http://localhost:7434/'
 paths:
+  /alarm.get:
+    get:
+      tags:
+        - Alarm
+      summary: Gets all utxos belonging to the given address.
+      description: |
+        **Note:** Service operator alarms.
+      operationId: alarm_get
+      responses:
+        '200':
+          description: System alarms
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - description: The response schema for a successful operation
+                    type: object
+                    properties:
+                      version:
+                        type: string
+                      success:
+                        type: boolean
+                      data:
+                        type: object
+                    required:
+                      - version
+                      - success
+                      - data
+                    example:
+                      version: '1.0'
+                      success: true
+                      data: {}
+                  - type: object
+                    properties:
+                      data:
+                        type: array
+                        items:
+                          type: array
+                          items:
+                            anyOf:
+                              - type: object
+                                properties:
+                                  ethereum_client_connection:
+                                    type: object
+                                    properties:
+                                      node:
+                                        type: string
+                                      reporter:
+                                        type: string
+                              - type: object
+                                properties:
+                                  ethereum_client_connection:
+                                    type: object
+                                    properties:
+                                      node:
+                                        type: string
+                                      reporter:
+                                        type: string
+                              - type: object
+                                properties:
+                                  statsd_client_connection:
+                                    type: object
+                                    properties:
+                                      node:
+                                        type: string
+                                      reporter:
+                                        type: string
+                              - type: object
+                                properties:
+                                  statsd_client_connection:
+                                    type: array
+                                    items:
+                                      type: string
+                                    default: []
+                              - type: object
+                                properties:
+                                  disk_almost_full:
+                                    type: string
+                    example:
+                      data:
+                        - disk_almost_full: /dev/null
+                          ethereum_client_connection: {}
+                          system_memory_high_watermark: []
+        '500':
+          description: Returns an internal server error
+          content:
+            application/json:
+              schema:
+                description: The response schema for an error
+                allOf:
+                  - description: The response schema for a successful operation
+                    type: object
+                    properties:
+                      version:
+                        type: string
+                      success:
+                        type: boolean
+                      data:
+                        type: object
+                    required:
+                      - version
+                      - success
+                      - data
+                    example:
+                      version: '1.0'
+                      success: true
+                      data: {}
+                  - type: object
+                    properties:
+                      data:
+                        description: The object schema for an error
+                        type: object
+                        properties:
+                          object:
+                            type: string
+                          code:
+                            type: string
+                          description:
+                            type: string
+                          messages:
+                            type: object
+                        required:
+                          - object
+                          - code
+                          - description
+                          - messages
+                    required:
+                      - data
+                    example:
+                      success: false
+                      data:
+                        object: error
+                        code: 'server:internal_server_error'
+                        description: Something went wrong on the server
+                        messages:
+                          error_key: error_reason
   /status.get:
     post:
       tags:

--- a/apps/omg_watcher_rpc/priv/swagger/security_critical_api_specs/alarm/alarms_schema.yml
+++ b/apps/omg_watcher_rpc/priv/swagger/security_critical_api_specs/alarm/alarms_schema.yml
@@ -1,0 +1,45 @@
+components:
+  schemas:
+    ethereum_client_connection:
+      type: object
+      properties:
+        ethereum_client_connection:
+          type: object
+          properties:
+            node:
+              type: string
+            reporter:
+              type: string
+    invalid_fee_file:
+      type: object
+      properties:
+        ethereum_client_connection:
+          type: object
+          properties:
+            node:
+              type: string
+            reporter:
+              type: string
+    statsd_client_connection:
+      type: object
+      properties:
+        statsd_client_connection:
+          type: object
+          properties:
+            node:
+              type: string
+            reporter:
+              type: string
+    system_memory_high_watermark:
+      type: object
+      properties:
+        statsd_client_connection:
+          type: array
+          items:
+            type: string
+          default: []
+    disk_almost_full:
+      type: object
+      properties: 
+        disk_almost_full:
+          type: string

--- a/apps/omg_watcher_rpc/priv/swagger/security_critical_api_specs/alarm/paths.yaml
+++ b/apps/omg_watcher_rpc/priv/swagger/security_critical_api_specs/alarm/paths.yaml
@@ -1,0 +1,13 @@
+alarm.get:
+  get:
+    tags:
+      - Alarm
+    summary: Gets all utxos belonging to the given address.
+    description: >
+      **Note:** Service operator alarms.
+    operationId: alarm_get
+    responses:
+      200:
+        $ref: 'responses.yaml#/AlarmResponse'
+      500:
+        $ref: '../../shared/responses.yaml#/InternalServerError'

--- a/apps/omg_watcher_rpc/priv/swagger/security_critical_api_specs/alarm/response_schemas.yaml
+++ b/apps/omg_watcher_rpc/priv/swagger/security_critical_api_specs/alarm/response_schemas.yaml
@@ -1,0 +1,15 @@
+AlarmResponseSchema:
+  allOf:
+  - $ref: '../../shared/schemas.yaml#/BaseResponseSchema'
+  - type: object
+    properties:
+      data:
+        type: array
+        items:
+          $ref: 'schemas.yaml#/AlarmSchema'
+    example:
+      data:
+      -
+        disk_almost_full: "/dev/null"
+        ethereum_client_connection: {}
+        system_memory_high_watermark: []

--- a/apps/omg_watcher_rpc/priv/swagger/security_critical_api_specs/alarm/responses.yaml
+++ b/apps/omg_watcher_rpc/priv/swagger/security_critical_api_specs/alarm/responses.yaml
@@ -1,0 +1,6 @@
+AlarmResponse:
+  description: System alarms
+  content:
+    application/json:
+      schema:
+        $ref: 'response_schemas.yaml#/AlarmResponseSchema'

--- a/apps/omg_watcher_rpc/priv/swagger/security_critical_api_specs/alarm/schemas.yaml
+++ b/apps/omg_watcher_rpc/priv/swagger/security_critical_api_specs/alarm/schemas.yaml
@@ -1,0 +1,9 @@
+AlarmSchema:
+  type: array
+  items:
+    anyOf:
+      - $ref: 'alarms_schema.yml#/components/schemas/ethereum_client_connection'
+      - $ref: 'alarms_schema.yml#/components/schemas/invalid_fee_file'
+      - $ref: 'alarms_schema.yml#/components/schemas/statsd_client_connection'
+      - $ref: 'alarms_schema.yml#/components/schemas/system_memory_high_watermark'
+      - $ref: 'alarms_schema.yml#/components/schemas/disk_almost_full'

--- a/apps/omg_watcher_rpc/priv/swagger/security_critical_api_specs/swagger.yaml
+++ b/apps/omg_watcher_rpc/priv/swagger/security_critical_api_specs/swagger.yaml
@@ -33,6 +33,8 @@ servers:
 
 
 paths:
+  /alarm.get:
+    $ref: 'alarm/paths.yaml#/alarm.get'
   /status.get:
     $ref: 'status/paths.yaml#/status.get'
   /account.get_exitable_utxos:

--- a/bin/variables
+++ b/bin/variables
@@ -2,7 +2,7 @@
 export REPLACE_OS_VARS=true
 export NODE_HOST=127.0.0.1
 export ERLANG_COOKIE=develop
-export APP_ENV=devino
+export APP_ENV=local_development
 export HOSTNAME=yolo
 export DB_PATH=~/plasma-data/
 export ETHEREUM_RPC_URL=http://127.0.0.1:8545

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -76,7 +76,7 @@ services:
       - CHILD_CHAIN_URL=http://childchain:9656
       - ERLANG_COOKIE=develop
       - NODE_HOST=127.0.0.1
-      - APP_ENV=local_development_child_chain
+      - APP_ENV=local_development
       - DD_HOSTNAME=datadog
       - DD_DISABLED=true
       - DB_PATH=/app/.omg/data
@@ -113,7 +113,7 @@ services:
       - ERLANG_COOKIE=develop
       - NODE_HOST=127.0.0.1
       - PORT=7434
-      - APP_ENV=local_development_watcher
+      - APP_ENV=local_development
       - DD_HOSTNAME=datadog
       - DD_DISABLED=true
       - DB_PATH=/app/.omg/data
@@ -151,7 +151,7 @@ services:
       - ERLANG_COOKIE=develop
       - NODE_HOST=127.0.0.1
       - PORT=7534
-      - APP_ENV=local_development_watcher_info
+      - APP_ENV=local_development
       - DD_HOSTNAME=datadog
       - DD_DISABLED=true
       - DB_PATH=/app/.omg/data

--- a/priv/Makefile
+++ b/priv/Makefile
@@ -5,9 +5,6 @@ list:
 test:
 	mix white_bread.run
 
-reset_accounts:
-	rm /tmp/used_accounts
-
 clean:
 	docker-compose down && docker rm -f $$(docker ps -a -q) && docker volume rm $$(docker volume ls -q)
 

--- a/priv/apps/itest/lib/client.ex
+++ b/priv/apps/itest/lib/client.ex
@@ -21,6 +21,18 @@ defmodule Itest.Client do
   @gas 180_000
   @retry_count 60
 
+  def get_watcher_alarms() do
+    WatcherSecurityCriticalAPI.Api.Alarm.alarm_get(WatcherSecurityCriticalAPI.Connection.new())
+  end
+
+  def get_watcher_info_alarms() do
+    WatcherInfoAPI.Api.Alarm.alarm_get(WatcherInfoAPI.Connection.new())
+  end
+
+  def get_child_chain_alarms() do
+    ChildChainAPI.Api.Alarm.alarm_get(ChildChainAPI.Connection.new())
+  end
+
   def deposit(amount_in_wei, output_address, vault_address, currency \\ Currency.ether()) do
     deposit_transaction = deposit_transaction(amount_in_wei, output_address, currency)
 

--- a/priv/features/service_name.feature
+++ b/priv/features/service_name.feature
@@ -1,0 +1,8 @@
+Feature: Service Name
+  Scenario: Operator deploys Child Chain, Watcher and Watcher Info
+    When Operator deploys "Child Chain"
+    Then Operator can read it's service name as "child_chain"
+    When Operator deploys "Watcher"
+    Then Operator can read it's service name as "watcher"
+    When Operator deploys "Watcher Info"
+    Then Operator can read it's service name as "watcher_info"


### PR DESCRIPTION
https://github.com/omisego/devops/issues/221

## Overview

The re-purpose (not sure what the original APP_ENV purpose was, nothing important I presume) is to allow us to track metrics and signals coming to Datadog across deployments without changing filter. This way we can setup fixed dashboards and look at metrics through long periods of time.

## Changes

- Making APP_ENV mandatory in code

## Testing
`mix test`
