### PR TITLE
fix unspent utxo challenging attempt crashing ExitProcessor

### DIFF
--- a/apps/omg_child_chain_rpc/config/test.exs
+++ b/apps/omg_child_chain_rpc/config/test.exs
@@ -3,7 +3,7 @@ use Mix.Config
 # We need to start OMG.ChildChainRPC.Web.Endpoint with HTTP server for Performance and Watcher tests to work
 # as a drawback lightweight (without HTTP server) controller tests are no longer an option.
 config :omg_child_chain_rpc, OMG.ChildChainRPC.Web.Endpoint,
-  http: [port: 9656],
+  http: [port: 9657],
   server: true
 
 config :omg_child_chain_rpc, OMG.ChildChainRPC.Tracer,

--- a/apps/omg_db/lib/db.ex
+++ b/apps/omg_db/lib/db.ex
@@ -30,29 +30,29 @@ defmodule OMG.DB do
   @callback multi_update(term()) :: :ok | {:error, any}
   @callback blocks(block_to_fetch :: list()) :: {:ok, list(term)}
   @callback utxos() :: {:ok, list({utxo_pos_db_t, term})}
-  @callback utxo(utxo_pos_db_t) :: {:ok, term}
+  @callback utxo(utxo_pos_db_t) :: {:ok, term} | :not_found
   @callback exit_infos() :: {:ok, list(term)}
   @callback in_flight_exits_info() :: {:ok, list(term)}
   @callback competitors_info() :: {:ok, list(term)}
-  @callback exit_info({pos_integer, non_neg_integer, non_neg_integer}) :: {:ok, map} | {:error, atom}
-  @callback spent_blknum(utxo_pos_db_t()) :: {:ok, pos_integer} | {:error, atom}
-  @callback block_hashes(integer()) :: list()
-  @callback child_top_block_number() :: {:ok, non_neg_integer()}
+  @callback exit_info({pos_integer, non_neg_integer, non_neg_integer}) :: {:ok, map} | :not_found
+  @callback spent_blknum(utxo_pos_db_t()) :: {:ok, pos_integer} | :not_found
+  @callback block_hashes(integer()) :: {:ok, list()}
+  @callback child_top_block_number() :: {:ok, non_neg_integer()} | :not_found
 
   # callbacks useful for injecting a specific server implementation
   @callback initiation_multiupdate(GenServer.server()) :: :ok | {:error, any}
   @callback multi_update(term(), GenServer.server()) :: :ok | {:error, any}
   @callback blocks(block_to_fetch :: list(), GenServer.server()) :: {:ok, list()} | {:error, any}
   @callback utxos(GenServer.server()) :: {:ok, list({utxo_pos_db_t, term})} | {:error, any}
-  @callback utxo(utxo_pos_db_t, GenServer.server()) :: {:ok, term} | {:error, any}
+  @callback utxo(utxo_pos_db_t, GenServer.server()) :: {:ok, term} | :not_found
   @callback exit_infos(GenServer.server()) :: {:ok, list(term)} | {:error, any}
   @callback in_flight_exits_info(GenServer.server()) :: {:ok, list(term)} | {:error, any}
   @callback competitors_info(GenServer.server()) :: {:ok, list(term)} | {:error, any}
   @callback exit_info({pos_integer, non_neg_integer, non_neg_integer}, GenServer.server()) ::
-              {:ok, map} | {:error, atom}
-  @callback spent_blknum(utxo_pos_db_t(), GenServer.server()) :: {:ok, pos_integer} | {:error, atom}
-  @callback block_hashes(integer(), GenServer.server()) :: list()
-  @callback child_top_block_number(GenServer.server()) :: {:ok, non_neg_integer()}
+              {:ok, map} | :not_found
+  @callback spent_blknum(utxo_pos_db_t(), GenServer.server()) :: {:ok, pos_integer} | :not_found
+  @callback block_hashes(integer(), GenServer.server()) :: {:ok, list()}
+  @callback child_top_block_number(GenServer.server()) :: {:ok, non_neg_integer()} | :not_found
   @optional_callbacks child_spec: 1,
                       initiation_multiupdate: 1,
                       multi_update: 2,

--- a/apps/omg_db/lib/omg_db/rocks_db.ex
+++ b/apps/omg_db/lib/omg_db/rocks_db.ex
@@ -92,12 +92,10 @@ if Code.ensure_loaded?(:rocksdb) do
       GenServer.call(server_name, :competitors_info, @one_minute)
     end
 
-    @spec exit_info({pos_integer, non_neg_integer, non_neg_integer}, atom) :: {:ok, map} | {:error, atom}
     def exit_info(utxo_pos, server_name \\ @server_name) do
       GenServer.call(server_name, {:exit_info, utxo_pos})
     end
 
-    @spec spent_blknum(utxo_pos_db_t(), atom) :: {:ok, pos_integer} | {:error, atom}
     def spent_blknum(utxo_pos, server_name \\ @server_name) do
       GenServer.call(server_name, {:spent_blknum, utxo_pos})
     end

--- a/apps/omg_performance/lib/performance.ex
+++ b/apps/omg_performance/lib/performance.ex
@@ -60,7 +60,7 @@ defmodule OMG.Performance do
     iex> Performance.init(watcher_url: "http://elsewhere:7434")
     :ok
     iex> Application.get_env(:omg_watcher, :child_chain_url)
-    "http://localhost:9656"
+    "http://localhost:9657"
     iex> Application.get_env(:omg_performance, :watcher_url)
     "http://elsewhere:7434"
   """

--- a/apps/omg_watcher/config/test.exs
+++ b/apps/omg_watcher/config/test.exs
@@ -1,6 +1,6 @@
 use Mix.Config
 
-config :omg_watcher, child_chain_url: "http://localhost:9656"
+config :omg_watcher, child_chain_url: "http://localhost:9657"
 
 config :omg_watcher,
   block_getter_loops_interval_ms: 50,

--- a/apps/omg_watcher/lib/omg_watcher/exit_processor.ex
+++ b/apps/omg_watcher/lib/omg_watcher/exit_processor.ex
@@ -372,11 +372,12 @@ defmodule OMG.Watcher.ExitProcessor do
 
   def handle_call({:create_challenge, exiting_utxo_pos}, _from, state) do
     request = %ExitProcessor.Request{se_exiting_pos: exiting_utxo_pos}
+    exiting_utxo_exists = State.utxo_exists?(exiting_utxo_pos)
 
     response =
-      with {:ok, request_with_queries} <- Core.determine_standard_challenge_queries(request, state),
+      with {:ok, request} <- Core.determine_standard_challenge_queries(request, state, exiting_utxo_exists),
            do:
-             request_with_queries
+             request
              |> fill_request_with_standard_challenge_data()
              |> Core.create_challenge(state)
 
@@ -466,8 +467,7 @@ defmodule OMG.Watcher.ExitProcessor do
   end
 
   defp do_get_spent_blknum(position) do
-    {:ok, spend_blknum} = position |> Utxo.Position.to_input_db_key() |> OMG.DB.spent_blknum()
-    spend_blknum
+    position |> Utxo.Position.to_input_db_key() |> OMG.DB.spent_blknum()
   end
 
   defp collect_invalidities_and_state_db_updates(

--- a/apps/omg_watcher/lib/omg_watcher/exit_processor/core.ex
+++ b/apps/omg_watcher/lib/omg_watcher/exit_processor/core.ex
@@ -87,7 +87,7 @@ defmodule OMG.Watcher.ExitProcessor.Core do
 
   @type check_validity_result_t :: {:ok | {:error, :unchallenged_exit}, list(Event.byzantine_t())}
 
-  @type spent_blknum_result_t() :: pos_integer | :not_found
+  @type spent_blknum_result_t() :: {:ok, pos_integer} | :not_found
 
   @type in_flight_exit_response_t() :: %{
           txhash: binary(),
@@ -396,7 +396,7 @@ defmodule OMG.Watcher.ExitProcessor.Core do
       Stream.zip(spent_positions_to_get, spent_blknum_result)
       |> Enum.split_with(fn {_utxo_pos, result} -> result == :not_found end)
 
-    {_, blknums_to_get} = Enum.unzip(founds)
+    blknums_to_get = founds |> Enum.unzip() |> elem(1) |> Enum.map(fn {:ok, blknum} -> blknum end)
 
     warn? = !Enum.empty?(not_founds)
     _ = if warn?, do: Logger.warn("UTXO doesn't exists but no spend registered (spent in exit?) #{inspect(not_founds)}")
@@ -476,7 +476,7 @@ defmodule OMG.Watcher.ExitProcessor.Core do
   defdelegate get_input_challenge_data(request, state, txbytes, input_index), to: ExitProcessor.Piggyback
   defdelegate get_output_challenge_data(request, state, txbytes, output_index), to: ExitProcessor.Piggyback
 
-  defdelegate determine_standard_challenge_queries(request, state), to: ExitProcessor.StandardExit
+  defdelegate determine_standard_challenge_queries(request, state, exiting_utxo_exists), to: ExitProcessor.StandardExit
   defdelegate create_challenge(request, state), to: ExitProcessor.StandardExit
 
   @spec get_ifes_to_piggyback(t()) :: list(InFlightExitInfo.t())

--- a/apps/omg_watcher/lib/omg_watcher/exit_processor/standard_exit.ex
+++ b/apps/omg_watcher/lib/omg_watcher/exit_processor/standard_exit.ex
@@ -91,14 +91,22 @@ defmodule OMG.Watcher.ExitProcessor.StandardExit do
   Determines the utxo-creating and utxo-spending blocks to get from `OMG.DB`
   `se_spending_blocks_to_get` are requested by the UTXO position they spend
   """
-  @spec determine_standard_challenge_queries(ExitProcessor.Request.t(), Core.t()) ::
-          {:ok, ExitProcessor.Request.t()} | {:error, :exit_not_found}
+  @spec determine_standard_challenge_queries(ExitProcessor.Request.t(), Core.t(), boolean()) ::
+          {:ok, ExitProcessor.Request.t()} | {:error, :exit_not_found | :utxo_not_spent}
   def determine_standard_challenge_queries(
         %ExitProcessor.Request{se_exiting_pos: Utxo.position(_, _, _) = exiting_pos} = request,
-        %Core{exits: exits} = state
+        %Core{exits: exits} = state,
+        exiting_utxo_exists
       ) do
-    with {:ok, _exit_info} <- get_exit(exits, exiting_pos) do
-      spending_blocks_to_get = if get_ife_based_on_utxo(exiting_pos, state), do: [], else: [exiting_pos]
+    with {:ok, _exit_info} <- get_exit(exits, exiting_pos),
+         # once figured out the exit exists, check if it is spent in an IFE?
+         ife_based_on_utxo = get_ife_based_on_utxo(exiting_pos, state),
+         # To be challengable, the exit utxo must be spent in either an IFE or missing from the `OMG.State`.
+         # In the latter case we'll go on looking for the spending tx in the `OMG.DB`
+         true <- !is_nil(ife_based_on_utxo) || !exiting_utxo_exists || {:error, :utxo_not_spent} do
+      # if the exit utxo is spent in an IFE no need to bother with looking for the spending tx in the blocks
+      spending_blocks_to_get = if ife_based_on_utxo, do: [], else: [exiting_pos]
+
       {:ok, %ExitProcessor.Request{request | se_spending_blocks_to_get: spending_blocks_to_get}}
     end
   end

--- a/apps/omg_watcher/test/omg_watcher/exit_processor/core_test.exs
+++ b/apps/omg_watcher/test/omg_watcher/exit_processor/core_test.exs
@@ -173,18 +173,18 @@ defmodule OMG.Watcher.ExitProcessor.CoreTest do
 
   describe "handling of spent blknums result" do
     test "asks for the right blocks when all are spent correctly" do
-      assert [1000] = Core.handle_spent_blknum_result([1000], [@utxo_pos1])
+      assert [1000] = Core.handle_spent_blknum_result([{:ok, 1000}], [@utxo_pos1])
       assert [] = Core.handle_spent_blknum_result([], [])
-      assert [2000, 1000] = Core.handle_spent_blknum_result([2000, 1000], [@utxo_pos2, @utxo_pos1])
+      assert [2000, 1000] = Core.handle_spent_blknum_result([{:ok, 2000}, {:ok, 1000}], [@utxo_pos2, @utxo_pos1])
     end
 
     test "asks for blocks just once" do
-      assert [1000] = Core.handle_spent_blknum_result([1000, 1000], [@utxo_pos2, @utxo_pos1])
+      assert [1000] = Core.handle_spent_blknum_result([{:ok, 1000}, {:ok, 1000}], [@utxo_pos2, @utxo_pos1])
     end
 
     @tag :capture_log
     test "asks for the right blocks if some spends are missing" do
-      assert [1000] = Core.handle_spent_blknum_result([:not_found, 1000], [@utxo_pos2, @utxo_pos1])
+      assert [1000] = Core.handle_spent_blknum_result([:not_found, {:ok, 1000}], [@utxo_pos2, @utxo_pos1])
     end
   end
 

--- a/apps/omg_watcher_info/config/test.exs
+++ b/apps/omg_watcher_info/config/test.exs
@@ -1,6 +1,6 @@
 use Mix.Config
 
-config :omg_watcher_info, child_chain_url: "http://localhost:9656"
+config :omg_watcher_info, child_chain_url: "http://localhost:9657"
 
 config :omg_watcher_info, OMG.WatcherInfo.DB.Repo,
   ownership_timeout: 180_000,


### PR DESCRIPTION
Fixes #1180 

## Overview

The problem lied in incorrect handling of a spending_block `:not_found` - `{:ok, :not_found}` was expected, but this form was since long deprecated in favor of the former.

Also this was uncleanly realized too late, so a peek into `OMG.State` was added to figure out the challengeability of the requested exit.

## Changes

- fix the bug, sprinkle some tests
- change the **`test`** env `ChildChainRPC` port number to `9657` to avoid the super-annoying clash with the default
- groom the specs in `OMG.DB`

## Testing

`mix test`