### PR TITLE
Refactor OMG.Output guards and usage

### DIFF
--- a/apps/omg/lib/omg/output.ex
+++ b/apps/omg/lib/omg/output.ex
@@ -58,6 +58,7 @@ defmodule OMG.Output do
 
   defp validate_data([raw_type, [owner, currency, amount]]) do
     with {:ok, _} <- RawData.parse_uint256(raw_type),
+         {:ok, _} <- valid_output_type?(raw_type),
          {:ok, _} <- RawData.parse_address(owner),
          {:ok, _} <- non_zero_owner?(owner),
          {:ok, _} <- RawData.parse_address(currency),
@@ -67,4 +68,7 @@ defmodule OMG.Output do
 
   defp non_zero_owner?(<<0::160>>), do: {:error, :output_guard_cant_be_zero}
   defp non_zero_owner?(_), do: {:ok, :valid}
+
+  defp valid_output_type?(<<1>>), do: {:ok, :valid}
+  defp valid_output_type?(_), do: {:error, :unrecognized_output_type}
 end

--- a/apps/omg/lib/omg/output.ex
+++ b/apps/omg/lib/omg/output.ex
@@ -41,7 +41,7 @@ defmodule OMG.Output do
     end
   end
 
-  def reconstruct(rlp_data), do: {:error, :malformed_outputs}
+  def reconstruct(_), do: {:error, :malformed_outputs}
 
   def from_db_value(%{owner: owner, currency: currency, amount: amount, output_type: output_type})
       when is_binary(owner) and is_binary(currency) and is_integer(amount) and is_integer(output_type) do

--- a/apps/omg/lib/omg/output.ex
+++ b/apps/omg/lib/omg/output.ex
@@ -80,9 +80,6 @@ defmodule OMG.Output do
     owner == witness
   end
 
-  def input_pointer(%__MODULE__{}, blknum, tx_index, oindex, _, _),
-    do: Utxo.position(blknum, tx_index, oindex)
-
   def to_db_value(%__MODULE__{owner: owner, currency: currency, amount: amount, output_type: output_type})
       when is_binary(owner) and is_binary(currency) and is_integer(amount) and is_integer(output_type) do
     %{owner: owner, currency: currency, amount: amount, output_type: output_type}

--- a/apps/omg/lib/omg/output.ex
+++ b/apps/omg/lib/omg/output.ex
@@ -57,13 +57,6 @@ defmodule OMG.Output do
     %__MODULE__{owner: owner, currency: currency, amount: amount, output_type: output_type}
   end
 
-  @doc """
-  For payment outputs, a binary witness is assumed to be a signature equal to the payment's output owner
-  """
-  def can_spend?(%__MODULE__{owner: owner}, witness, _raw_tx) when is_binary(witness) do
-    owner == witness
-  end
-
   def to_db_value(%__MODULE__{owner: owner, currency: currency, amount: amount, output_type: output_type})
       when is_binary(owner) and is_binary(currency) and is_integer(amount) and is_integer(output_type) do
     %{owner: owner, currency: currency, amount: amount, output_type: output_type}

--- a/apps/omg/lib/omg/output.ex
+++ b/apps/omg/lib/omg/output.ex
@@ -56,6 +56,8 @@ defmodule OMG.Output do
   def get_data_for_rlp(%__MODULE__{owner: owner, currency: currency, amount: amount, output_type: output_type}),
     do: [output_type, [owner, currency, amount]]
 
+  # TODO(achiurizo)
+  # remove the validation here and port the error tuple response handling into ex_plasma.
   defp validate_data([raw_type, [owner, currency, amount]]) do
     with {:ok, _} <- RawData.parse_uint256(raw_type),
          {:ok, _} <- valid_output_type?(raw_type),

--- a/apps/omg/lib/omg/output.ex
+++ b/apps/omg/lib/omg/output.ex
@@ -20,6 +20,7 @@ defmodule OMG.Output do
   This module specificially dispatches generic calls to the various specific types
   """
   alias OMG.Crypto
+  alias OMG.RawData
 
   @type t :: %__MODULE__{
           output_type: binary(),
@@ -29,14 +30,6 @@ defmodule OMG.Output do
         }
 
   defstruct [:output_type, :owner, :currency, :amount]
-
-  alias OMG.RawData
-  alias OMG.Utxo
-
-  require Utxo
-
-  @output_types_modules OMG.WireFormatTypes.output_type_modules()
-  @output_types Map.keys(@output_types_modules)
 
   @doc """
   Reconstructs the structure from a list of RLP items
@@ -49,8 +42,6 @@ defmodule OMG.Output do
   end
 
   def reconstruct(rlp_data), do: {:error, :malformed_outputs}
-
-  def from_db_value(%{type: output_type} = db_value), do: @output_types_modules[output_type].from_db_value(db_value)
 
   def from_db_value(%{owner: owner, currency: currency, amount: amount, output_type: output_type})
       when is_binary(owner) and is_binary(currency) and is_integer(amount) and is_integer(output_type) do

--- a/apps/omg/lib/omg/state/core.ex
+++ b/apps/omg/lib/omg/state/core.ex
@@ -425,7 +425,7 @@ defmodule OMG.State.Core do
     |> Transaction.get_outputs()
     |> Enum.with_index()
     |> Enum.map(fn {output, oindex} ->
-      {Output.input_pointer(output, blknum, tx_index, oindex, tx, hash), output}
+      {Utxo.position(blknum, tx_index, oindex), output}
     end)
     |> Enum.into(%{}, fn {input_pointer, output} ->
       {input_pointer, %Utxo{output: output, creating_txhash: hash}}

--- a/apps/omg/lib/omg/state/core.ex
+++ b/apps/omg/lib/omg/state/core.ex
@@ -52,7 +52,6 @@ defmodule OMG.State.Core do
   alias OMG.Crypto
   alias OMG.Fees
 
-  alias OMG.Output
   alias OMG.State.Core
   alias OMG.State.Transaction
   alias OMG.State.Transaction.Validator

--- a/apps/omg/lib/omg/state/transaction/validator.ex
+++ b/apps/omg/lib/omg/state/transaction/validator.ex
@@ -48,7 +48,7 @@ defmodule OMG.State.Transaction.Validator do
     with :ok <- validate_block_size(state),
          :ok <- inputs_not_from_future_block?(state, inputs),
          {:ok, outputs_spent} <- UtxoSet.get_by_inputs(utxos, inputs),
-         :ok <- authorized?(outputs_spent, witnesses, raw_tx),
+         :ok <- authorized?(outputs_spent, witnesses),
          {:ok, implicit_paid_fee_by_currency} <- Transaction.Protocol.can_apply?(raw_tx, outputs_spent),
          true <- Fees.covered?(implicit_paid_fee_by_currency, fees) || {:error, :fees_not_covered} do
       true
@@ -73,9 +73,9 @@ defmodule OMG.State.Transaction.Validator do
   end
 
   # Checks the outputs spent by this transaction have been authorized by correct witnesses
-  @spec authorized?(list(Output.t()), list(Transaction.Witness.t()), Transaction.Protocol.t()) ::
+  @spec authorized?(list(Output.t()), list(Transaction.Witness.t())) ::
           :ok | {:error, :unauthorized_spend}
-  defp authorized?(outputs_spent, witnesses, raw_tx) do
+  defp authorized?(outputs_spent, witnesses) do
     outputs_spent
     |> Enum.with_index()
     |> Enum.map(fn {output_spent, idx} -> can_spend?(output_spent, witnesses[idx]) end)

--- a/apps/omg/lib/omg/state/transaction/validator.ex
+++ b/apps/omg/lib/omg/state/transaction/validator.ex
@@ -78,8 +78,10 @@ defmodule OMG.State.Transaction.Validator do
   defp authorized?(outputs_spent, witnesses, raw_tx) do
     outputs_spent
     |> Enum.with_index()
-    |> Enum.map(fn {output_spent, idx} -> OMG.Output.can_spend?(output_spent, witnesses[idx], raw_tx) end)
+    |> Enum.map(fn {output_spent, idx} -> can_spend?(output_spent, witnesses[idx]) end)
     |> Enum.all?()
     |> if(do: :ok, else: {:error, :unauthorized_spend})
   end
+
+  defp can_spend?(%OMG.Output{owner: owner}, witness), do: owner == witness
 end

--- a/apps/omg/lib/omg/utxo.ex
+++ b/apps/omg/lib/omg/utxo.ex
@@ -50,11 +50,7 @@ defmodule OMG.Utxo do
                   is_position(elem(position, 1), elem(position, 2), elem(position, 3)) and
                   rem(elem(position, 1), @interval) != 0
 
-  defmacrop is_nil_or_binary(binary) do
-    quote do
-      is_binary(unquote(binary)) or is_nil(unquote(binary))
-    end
-  end
+  defguardp is_nil_or_binary(creating_tx_hash) when is_nil(creating_tx_hash) or is_binary(creating_tx_hash)
 
   # NOTE: we have no migrations, so we handle data compatibility here (make_db_update/1 and from_db_kv/1), OMG-421
   def to_db_value(%__MODULE__{output: output, creating_txhash: creating_txhash})

--- a/apps/omg/lib/omg/utxo.ex
+++ b/apps/omg/lib/omg/utxo.ex
@@ -36,20 +36,6 @@ defmodule OMG.Utxo do
     end
   end
 
-  defguard is_position(blknum, txindex, oindex)
-           when is_integer(blknum) and blknum >= 0 and
-                  is_integer(txindex) and txindex >= 0 and
-                  is_integer(oindex) and oindex >= 0
-
-  @interval elem(OMG.Eth.RootChain.get_child_block_interval(), 1)
-  @doc """
-  Based on the contract parameters determines whether UTXO position provided was created by a deposit
-  """
-  defguard is_deposit(position)
-           when is_tuple(position) and tuple_size(position) == 4 and
-                  is_position(elem(position, 1), elem(position, 2), elem(position, 3)) and
-                  rem(elem(position, 1), @interval) != 0
-
   defguardp is_nil_or_binary(creating_tx_hash) when is_nil(creating_tx_hash) or is_binary(creating_tx_hash)
 
   # NOTE: we have no migrations, so we handle data compatibility here (make_db_update/1 and from_db_kv/1), OMG-421

--- a/apps/omg/lib/omg/utxo/position.ex
+++ b/apps/omg/lib/omg/utxo/position.ex
@@ -24,8 +24,6 @@ defmodule OMG.Utxo.Position do
   alias OMG.Utxo
   require Utxo
 
-  import Utxo, only: [is_position: 3]
-
   @type t() :: {
           :utxo_position,
           # blknum
@@ -39,6 +37,11 @@ defmodule OMG.Utxo.Position do
   @type db_t() :: {non_neg_integer(), non_neg_integer(), non_neg_integer()}
 
   @type input_db_key_t() :: {:input_pointer, pos_integer(), db_t()}
+
+  defguardp is_position(blknum, txindex, oindex)
+            when is_integer(blknum) and blknum >= 0 and
+                   is_integer(txindex) and txindex >= 0 and
+                   is_integer(oindex) and oindex >= 0
 
   @doc """
   Encode an input utxo position into an integer value.

--- a/apps/omg/test/omg/output_test.exs
+++ b/apps/omg/test/omg/output_test.exs
@@ -1,0 +1,39 @@
+# Copyright 2019 OmiseGO Pte Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+defmodule OMG.OutputTest do
+  @moduledoc false
+
+  use ExUnit.Case, async: true
+  doctest OMG.Output
+
+  describe "reconstruct/1" do
+    test "returns an error if the output guard is invalid" do
+      rlp_data = [
+        <<1>>,
+        [
+          <<0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0>>,
+          <<0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0>>,
+          <<1>>
+        ]
+      ]
+
+      assert {:error, :output_guard_cant_be_zero} = OMG.Output.reconstruct(rlp_data)
+    end
+
+    test "returns an error if the output is malformed" do
+      rlp_data = []
+      assert {:error, :malformed_outputs} = OMG.Output.reconstruct(rlp_data)
+    end
+  end
+end

--- a/apps/omg/test/omg/utxo_test.exs
+++ b/apps/omg/test/omg/utxo_test.exs
@@ -1,0 +1,18 @@
+# Copyright 2019 OmiseGO Pte Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+defmodule OMG.UtxoTest do
+  @moduledoc false
+  use ExUnit.Case, async: true
+  doctest OMG.Utxo
+end

--- a/apps/omg_watcher/lib/omg_watcher/api/utxo.ex
+++ b/apps/omg_watcher/lib/omg_watcher/api/utxo.ex
@@ -32,7 +32,7 @@ defmodule OMG.Watcher.API.Utxo do
 
   @interval elem(OMG.Eth.RootChain.get_child_block_interval(), 1)
 
-  #Based on the contract parameters determines whether UTXO position provided was created by a deposit
+  # Based on the contract parameters determines whether UTXO position provided was created by a deposit
   defguardp is_deposit(blknum) when rem(blknum, @interval) != 0
 
   @doc """

--- a/apps/omg_watcher/lib/omg_watcher/api/utxo.ex
+++ b/apps/omg_watcher/lib/omg_watcher/api/utxo.ex
@@ -31,9 +31,8 @@ defmodule OMG.Watcher.API.Utxo do
         }
 
   @interval elem(OMG.Eth.RootChain.get_child_block_interval(), 1)
-  @doc """
-  Based on the contract parameters determines whether UTXO position provided was created by a deposit
-  """
+
+  #Based on the contract parameters determines whether UTXO position provided was created by a deposit
   defguardp is_deposit(blknum) when rem(blknum, @interval) != 0
 
   @doc """

--- a/apps/omg_watcher/lib/omg_watcher/api/utxo.ex
+++ b/apps/omg_watcher/lib/omg_watcher/api/utxo.ex
@@ -45,7 +45,7 @@ defmodule OMG.Watcher.API.Utxo do
   end
 
   @spec compose_utxo_exit(Utxo.Position.t()) :: {:ok, exit_t()} | {:error, :utxo_not_found}
-  def compose_utxo_exit({:utxo_position, blknum, _, _} = utxo_pos) when is_deposit(blknum) do
+  def compose_utxo_exit(Utxo.position(blknum, _, _) = utxo_pos) when is_deposit(blknum) do
     utxo_pos |> Utxo.Position.to_input_db_key() |> OMG.DB.utxo() |> Core.compose_deposit_standard_exit()
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -23,7 +23,7 @@
   "ex_abi": {:hex, :ex_abi, "0.2.1", "e8224ef22782b58d535bf3e29e73379af48df52cc9a941746980d14b32e793c2", [:mix], [{:exth_crypto, "~> 0.1.6", [hex: :exth_crypto, repo: "hexpm", optional: false]}], "hexpm"},
   "ex_doc": {:hex, :ex_doc, "0.20.2", "1bd0dfb0304bade58beb77f20f21ee3558cc3c753743ae0ddbb0fd7ba2912331", [:mix], [{:earmark, "~> 1.3", [hex: :earmark, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.10", [hex: :makeup_elixir, repo: "hexpm", optional: false]}], "hexpm"},
   "ex_machina": {:hex, :ex_machina, "2.3.0", "92a5ad0a8b10ea6314b876a99c8c9e3f25f4dde71a2a835845b136b9adaf199a", [:mix], [{:ecto, "~> 2.2 or ~> 3.0", [hex: :ecto, repo: "hexpm", optional: true]}, {:ecto_sql, "~> 3.0", [hex: :ecto_sql, repo: "hexpm", optional: true]}], "hexpm"},
-  "ex_plasma": {:git, "https://github.com/omisego/ex_plasma.git", "ecbba7da2f693d02642c8d8e20b8b16c9f80561a", []},
+  "ex_plasma": {:git, "https://github.com/omisego/ex_plasma.git", "fca260f98017ff1983ec13afff059ba59fd5070f", []},
   "ex_rlp": {:hex, :ex_rlp, "0.5.2", "7f4ce7bd55e543c054ce6d49629b01e9833c3462e3d547952be89865f39f2c58", [:mix], [], "hexpm"},
   "ex_unit_fixtures": {:git, "https://github.com/omisego/ex_unit_fixtures.git", "4a099c621dc70e0d65cb9619b38192e31ec5f504", [branch: "feature/require_files_not_load"]},
   "exactor": {:hex, :exactor, "2.2.4", "5efb4ddeb2c48d9a1d7c9b465a6fffdd82300eb9618ece5d34c3334d5d7245b1", [:mix], [], "hexpm"},


### PR DESCRIPTION
:clipboard: #1218 the first refactor series

## Overview

This refactors `OMG.Output` to de-tangle some of its coupling with the rest of the code. This is a small refactor to pave wave for a larger refactor of the `OMG.Utxo`, `OMG.Utxo.Position`, and `OMG.OUtput` tree.

## Changes

* Move guards into modules that use them. The guards that exist often are only used once. We should move them to where they are used.
* Leverage ExPlasma to do the RLP data -> struct conversion.
* Break out the error tuple generation into it's own method. Eventually we'll port this to `ex_plasma` to handle returning error messages around decoding.
* Remove `dispatching_reconstruct`. We only have 1 output to generate. For the future output models, we should be building these encoding structures into `ex_plasma`.
* Add test files for output and utxo. Currently not testing much but next PR will fill out the cases for `OMG.Utxo`.

## Testing

```elixir
mix test
mix test --only integration
# have CI run
```
