### PR TITLE
refactor: move Account.get_exitable_utxos/1 into watcher security

### DIFF
--- a/apps/omg_watcher/lib/omg_watcher/api/account.ex
+++ b/apps/omg_watcher/lib/omg_watcher/api/account.ex
@@ -12,26 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-defmodule OMG.WatcherInfo.API.Account do
+defmodule OMG.Watcher.API.Account do
   @moduledoc """
   Module provides operations related to plasma accounts.
   """
 
-  alias OMG.WatcherInfo.DB
-
   @doc """
-  Returns a list of amounts of currencies that a given address owns
+  Gets all utxos belonging to the given address. Slow operation.
   """
-  @spec get_balance(OMG.Crypto.address_t()) :: list(DB.TxOutput.balance())
-  def get_balance(address) do
-    DB.TxOutput.get_balance(address)
-  end
+  @spec get_exitable_utxos(OMG.Crypto.address_t()) :: list(OMG.State.Core.exitable_utxos())
+  def get_exitable_utxos(address) do
+    # OMG.DB.utxos() takes a while.
+    {:ok, utxos} = OMG.DB.utxos()
 
-  @doc """
-  Gets all utxos belonging to the given address.
-  """
-  @spec get_utxos(OMG.Crypto.address_t()) :: list(%DB.TxOutput{})
-  def get_utxos(address) do
-    DB.TxOutput.get_utxos(address)
+    OMG.State.Core.standard_exitable_utxos(utxos, address)
   end
 end

--- a/apps/omg_watcher/test/omg_watcher/api/account_test.exs
+++ b/apps/omg_watcher/test/omg_watcher/api/account_test.exs
@@ -35,7 +35,7 @@ defmodule OMG.Watcher.API.AccountTest do
       alice = TestHelper.generate_entity()
       bob = TestHelper.generate_entity()
 
-      blknum = 10927
+      blknum = 1927
       txindex = 78
       oindex = 1
 

--- a/apps/omg_watcher/test/omg_watcher/api/account_test.exs
+++ b/apps/omg_watcher/test/omg_watcher/api/account_test.exs
@@ -1,0 +1,66 @@
+# Copyright 2019 OmiseGO Pte Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defmodule OMG.Watcher.API.AccountTest do
+  use ExUnitFixtures
+  use ExUnit.Case, async: false
+  use OMG.DB.Fixtures
+
+  alias OMG.TestHelper
+  alias OMG.Watcher.API.Account
+
+  @eth OMG.Eth.RootChain.eth_pseudo_address()
+  @payment_output_type OMG.WireFormatTypes.output_type_for(:output_payment_v1)
+
+  describe "get_exitable_utxos/1" do
+    @tag fixtures: [:db_initialized]
+    test "returns an empty list if the address does not have any utxo" do
+      alice = TestHelper.generate_entity()
+      assert Account.get_exitable_utxos(alice.addr) == []
+    end
+
+    @tag fixtures: [:db_initialized]
+    test "returns utxos for the given address" do
+      alice = TestHelper.generate_entity()
+      bob = TestHelper.generate_entity()
+
+      blknum = 10927
+      txindex = 78
+      oindex = 1
+
+      _ = OMG.DB.multi_update([
+        {:put, :utxo,
+         {
+           {blknum, txindex, oindex},
+           %{
+             output: %{amount: 333, currency: @eth, owner: alice.addr, output_type: @payment_output_type},
+             creating_txhash: nil
+           }
+         }},
+        {:put, :utxo,
+         {
+           {blknum, txindex, oindex + 1},
+           %{
+             output: %{amount: 999, currency: @eth, owner: bob.addr, output_type: @payment_output_type},
+             creating_txhash: nil
+           }
+         }}
+      ])
+
+      [utxo] = Account.get_exitable_utxos(alice.addr)
+
+      assert %{blknum: ^blknum, txindex: ^txindex, oindex: ^oindex} = utxo
+    end
+  end
+end

--- a/apps/omg_watcher/test/omg_watcher/api/account_test.exs
+++ b/apps/omg_watcher/test/omg_watcher/api/account_test.exs
@@ -39,24 +39,25 @@ defmodule OMG.Watcher.API.AccountTest do
       txindex = 78
       oindex = 1
 
-      _ = OMG.DB.multi_update([
-        {:put, :utxo,
-         {
-           {blknum, txindex, oindex},
-           %{
-             output: %{amount: 333, currency: @eth, owner: alice.addr, output_type: @payment_output_type},
-             creating_txhash: nil
-           }
-         }},
-        {:put, :utxo,
-         {
-           {blknum, txindex, oindex + 1},
-           %{
-             output: %{amount: 999, currency: @eth, owner: bob.addr, output_type: @payment_output_type},
-             creating_txhash: nil
-           }
-         }}
-      ])
+      _ =
+        OMG.DB.multi_update([
+          {:put, :utxo,
+           {
+             {blknum, txindex, oindex},
+             %{
+               output: %{amount: 333, currency: @eth, owner: alice.addr, output_type: @payment_output_type},
+               creating_txhash: nil
+             }
+           }},
+          {:put, :utxo,
+           {
+             {blknum, txindex, oindex + 1},
+             %{
+               output: %{amount: 999, currency: @eth, owner: bob.addr, output_type: @payment_output_type},
+               creating_txhash: nil
+             }
+           }}
+        ])
 
       [utxo] = Account.get_exitable_utxos(alice.addr)
 

--- a/apps/omg_watcher_rpc/lib/web/controllers/account.ex
+++ b/apps/omg_watcher_rpc/lib/web/controllers/account.ex
@@ -19,7 +19,8 @@ defmodule OMG.WatcherRPC.Web.Controller.Account do
 
   use OMG.WatcherRPC.Web, :controller
 
-  alias OMG.WatcherInfo.API.Account
+  alias OMG.Watcher.API, as: SecurityAPI
+  alias OMG.WatcherInfo.API, as: InfoAPI
 
   @doc """
   Gets plasma account balance
@@ -27,7 +28,7 @@ defmodule OMG.WatcherRPC.Web.Controller.Account do
   def get_balance(conn, params) do
     with {:ok, address} <- expect(params, "address", :address) do
       address
-      |> Account.get_balance()
+      |> InfoAPI.Account.get_balance()
       |> api_response(conn, :balance)
     end
   end
@@ -35,7 +36,7 @@ defmodule OMG.WatcherRPC.Web.Controller.Account do
   def get_utxos(conn, params) do
     with {:ok, address} <- expect(params, "address", :address) do
       address
-      |> Account.get_utxos()
+      |> InfoAPI.Account.get_utxos()
       |> api_response(conn, :utxos)
     end
   end
@@ -43,7 +44,7 @@ defmodule OMG.WatcherRPC.Web.Controller.Account do
   def get_exitable_utxos(conn, params) do
     with {:ok, address} <- expect(params, "address", :address) do
       address
-      |> Account.get_exitable_utxos()
+      |> SecurityAPI.Account.get_exitable_utxos()
       |> api_response(conn, :utxos)
     end
   end


### PR DESCRIPTION
## Overview

This PR moves `OMG.WatcherInfo.API.Account.get_exitable_utxos/1` to `OMG.Watcher`. 

Thanks to @jrhite for spotting this boundary breach:

> @jrhite: Just ran across this code in WatcherInfo. Seems strange that it's in Info using OMG.DB. Curious why it's in Info, what's the rationale for it? There's a simple query for the same info in db/transaction.ex, but currently it only filters unspent or unexited txoutputs. It could be extended to also filter out txoutputs in an IFE state or other various scenarios.
> 
> Thanks!
> 
> ```
>   @doc """
>   Gets all utxos belonging to the given address.
>   Slow operation, compatible with security-critical.
>   """
>   # TODO this seems weird and a breach of decoupling
>   @spec get_exitable_utxos(OMG.Crypto.address_t()) :: list(OMG.State.Core.exitable_utxos())
>   def get_exitable_utxos(address) do
>     # OMG.DB.utxos() takes a while.
>     {:ok, utxos} = OMG.DB.utxos()
>     OMG.State.Core.standard_exitable_utxos(utxos, address)
>   end
> ```

## Changes

- Move `OMG.WatcherInfo.API.Account.get_exitable_utxos/1` to `OMG.Watcher.API.Account`
- Tests

## Testing

These Too Should All Pass:

```
$ mix test test/omg_watcher/api/account_test.exs
$ mix test test/omg_watcher_rpc/web/controllers/account_test.exs
```