### PR TITLE
Clean block queue code

### DIFF
--- a/apps/omg_child_chain/lib/omg_child_chain/block_queue.ex
+++ b/apps/omg_child_chain/lib/omg_child_chain/block_queue.ex
@@ -83,10 +83,10 @@ defmodule OMG.ChildChain.BlockQueue do
       {:ok, state} =
         with {:ok, _state} = result <-
                Core.new(
-                 mined_num,
-                 Enum.zip(range, known_hashes),
-                 top_mined_hash,
-                 parent_height,
+                 mined_child_block_num: mined_num,
+                 known_hashes: Enum.zip(range, known_hashes),
+                 top_mined_hash: top_mined_hash,
+                 parent_height: parent_height,
                  child_block_interval: child_block_interval,
                  block_submit_every_nth: Application.fetch_env!(:omg_child_chain, :block_submit_every_nth),
                  finality_threshold: finality_threshold

--- a/apps/omg_child_chain/lib/omg_child_chain/block_queue.ex
+++ b/apps/omg_child_chain/lib/omg_child_chain/block_queue.ex
@@ -55,10 +55,13 @@ defmodule OMG.ChildChain.BlockQueue do
     def handle_continue(:setup, %{}) do
       _ = Logger.info("Starting #{__MODULE__} service.")
       :ok = Eth.node_ready()
+
+      # prevent booting if contracts are not ready
       :ok = Eth.RootChain.contract_ready()
+      {:ok, parent_start} = Eth.RootChain.get_root_deployment_height()
+
       {:ok, parent_height} = EthereumHeight.get()
       {:ok, mined_num} = Eth.RootChain.get_mined_child_block()
-      {:ok, parent_start} = Eth.RootChain.get_root_deployment_height()
       {:ok, child_block_interval} = Eth.RootChain.get_child_block_interval()
       {:ok, stored_child_top_num} = OMG.DB.get_single_value(:child_top_block_number)
       {:ok, finality_threshold} = Application.fetch_env(:omg_child_chain, :submission_finality_margin)
@@ -85,7 +88,6 @@ defmodule OMG.ChildChain.BlockQueue do
                  top_mined_hash: top_mined_hash,
                  parent_height: parent_height,
                  child_block_interval: child_block_interval,
-                 chain_start_parent_height: parent_start,
                  block_submit_every_nth: Application.fetch_env!(:omg_child_chain, :block_submit_every_nth),
                  finality_threshold: finality_threshold,
                  last_enqueued_block_at_height: parent_height

--- a/apps/omg_child_chain/lib/omg_child_chain/block_queue.ex
+++ b/apps/omg_child_chain/lib/omg_child_chain/block_queue.ex
@@ -83,14 +83,13 @@ defmodule OMG.ChildChain.BlockQueue do
       {:ok, state} =
         with {:ok, _state} = result <-
                Core.new(
-                 mined_child_block_num: mined_num,
-                 known_hashes: Enum.zip(range, known_hashes),
-                 top_mined_hash: top_mined_hash,
-                 parent_height: parent_height,
+                 mined_num,
+                 Enum.zip(range, known_hashes),
+                 top_mined_hash,
+                 parent_height,
                  child_block_interval: child_block_interval,
                  block_submit_every_nth: Application.fetch_env!(:omg_child_chain, :block_submit_every_nth),
-                 finality_threshold: finality_threshold,
-                 last_enqueued_block_at_height: parent_height
+                 finality_threshold: finality_threshold
                ) do
           result
         else

--- a/apps/omg_child_chain/lib/omg_child_chain/block_queue/core.ex
+++ b/apps/omg_child_chain/lib/omg_child_chain/block_queue/core.ex
@@ -126,8 +126,6 @@ defmodule OMG.ChildChain.BlockQueue.Core do
 
   @type submit_result_t() :: {:ok, <<_::256>>} | {:error, map}
 
-  def new, do: {:ok, %__MODULE__{blocks: Map.new()}}
-
   @spec new(keyword) ::
           {:ok, Core.t()} | {:error, :contract_ahead_of_db | :mined_blknum_not_found_in_db | :hashes_dont_match}
   def new(

--- a/apps/omg_child_chain/lib/omg_child_chain/block_queue/core.ex
+++ b/apps/omg_child_chain/lib/omg_child_chain/block_queue/core.ex
@@ -123,23 +123,20 @@ defmodule OMG.ChildChain.BlockQueue.Core do
 
   @type submit_result_t() :: {:ok, <<_::256>>} | {:error, map}
 
-  @spec new(
-          BlockSubmission.plasma_block_num(),
-          list({BlockSubmission.plasma_block_num(), BlockSubmission.hash()}),
-          BlockSubmission.hash(),
-          non_neg_integer(),
-          keyword
-        ) ::
+  @spec new(keyword()) ::
           {:ok, Core.t()} | {:error, :contract_ahead_of_db | :mined_blknum_not_found_in_db | :hashes_dont_match}
-  def new(mined_child_block_num, known_hashes, top_mined_hash, parent_height, opts \\ []) do
+  def new(opts \\ []) do
+    true = Keyword.has_key?(opts, :mined_child_block_num)
+    known_hashes = Keyword.fetch!(opts, :known_hashes)
+    top_mined_hash = Keyword.fetch!(opts, :top_mined_hash)
+    parent_height = Keyword.fetch!(opts, :parent_height)
+
     fields =
       opts
-      |> Keyword.put_new(:blocks, Map.new())
-      |> Keyword.put_new(:mined_child_block_num, mined_child_block_num)
-      |> Keyword.put_new(:parent_height, parent_height)
-      |> Keyword.put_new(:last_enqueued_block_at_height, parent_height)
-      |> Keyword.put_new(:wait_for_enqueue, false)
-      |> Keyword.put_new(:gas_price_adj_params, %GasPriceAdjustment{})
+      |> Keyword.put(:blocks, Map.new())
+      |> Keyword.put(:last_enqueued_block_at_height, parent_height)
+      |> Keyword.put(:wait_for_enqueue, false)
+      |> Keyword.drop([:known_hashes, :top_mined_hash])
 
     state = struct!(__MODULE__, fields)
     enqueue_existing_blocks(state, top_mined_hash, known_hashes)

--- a/apps/omg_child_chain/lib/omg_child_chain/block_queue/core.ex
+++ b/apps/omg_child_chain/lib/omg_child_chain/block_queue/core.ex
@@ -91,7 +91,6 @@ defmodule OMG.ChildChain.BlockQueue.Core do
     last_enqueued_block_at_height: 0,
     # config:
     child_block_interval: nil,
-    chain_start_parent_height: nil,
     block_submit_every_nth: 1,
     finality_threshold: 12,
     gas_price_adj_params: %GasPriceAdjustment{}
@@ -113,8 +112,6 @@ defmodule OMG.ChildChain.BlockQueue.Core do
           # CONFIG CONSTANTS below
           # spacing of child blocks in RootChain contract, being the amount of deposit decimals per child block
           child_block_interval: pos_integer(),
-          # Ethereum height at which first block was mined
-          chain_start_parent_height: pos_integer(),
           # configure to trigger forming a child chain block every this many Ethereum blocks are mined since enqueueing
           block_submit_every_nth: pos_integer(),
           # depth of max reorg we take into account
@@ -134,7 +131,6 @@ defmodule OMG.ChildChain.BlockQueue.Core do
         top_mined_hash: top_mined_hash,
         parent_height: parent_height,
         child_block_interval: child_block_interval,
-        chain_start_parent_height: child_start_parent_height,
         block_submit_every_nth: block_submit_every_nth,
         finality_threshold: finality_threshold,
         last_enqueued_block_at_height: last_enqueued_block_at_height
@@ -144,7 +140,6 @@ defmodule OMG.ChildChain.BlockQueue.Core do
       mined_child_block_num: mined_child_block_num,
       parent_height: parent_height,
       child_block_interval: child_block_interval,
-      chain_start_parent_height: child_start_parent_height,
       block_submit_every_nth: block_submit_every_nth,
       finality_threshold: finality_threshold,
       gas_price_adj_params: %GasPriceAdjustment{},

--- a/apps/omg_child_chain/test/omg_child_chain/block_queue/core_test.exs
+++ b/apps/omg_child_chain/test/omg_child_chain/block_queue/core_test.exs
@@ -233,10 +233,6 @@ defmodule OMG.ChildChain.BlockQueue.CoreTest do
       assert {:error, :mined_blknum_not_found_in_db} == recover([{5000, "5"}, {6000, "6"}], 7000)
     end
 
-    test "No submitBlock will be sent until properly initialized" do
-      catch_error(Core.get_blocks_to_submit(Core.new()))
-    end
-
     test "A new block is emitted ASAP", %{empty: empty} do
       assert [%{hash: "2", nonce: 2}] =
                empty

--- a/apps/omg_child_chain/test/omg_child_chain/block_queue/core_test.exs
+++ b/apps/omg_child_chain/test/omg_child_chain/block_queue/core_test.exs
@@ -294,6 +294,18 @@ defmodule OMG.ChildChain.BlockQueue.CoreTest do
   end
 
   describe "get_blocks_to_submit/1" do
+    test "Empty queue doesn't want to submit blocks", %{empty: empty} do
+      assert [] = Core.get_blocks_to_submit(empty)
+    end
+
+    test "Empty queue doesn't want to submit blocks, even if ethereum progresses", %{empty: empty} do
+      assert [] =
+               empty
+               |> Core.set_ethereum_status(10, 3000, false)
+               |> elem(1)
+               |> Core.get_blocks_to_submit()
+    end
+
     test "A new block is submitted after enqueuing", %{empty: empty} do
       assert [%{num: 2000}] =
                empty

--- a/apps/omg_child_chain/test/omg_child_chain/block_queue/core_test.exs
+++ b/apps/omg_child_chain/test/omg_child_chain/block_queue/core_test.exs
@@ -197,7 +197,6 @@ defmodule OMG.ChildChain.BlockQueue.CoreTest do
                  top_mined_hash: <<1::size(256)>>,
                  parent_height: 10,
                  child_block_interval: 1000,
-                 chain_start_parent_height: 1,
                  block_submit_every_nth: 1,
                  finality_threshold: 12,
                  last_enqueued_block_at_height: 0
@@ -219,11 +218,6 @@ defmodule OMG.ChildChain.BlockQueue.CoreTest do
                |> elem(1)
                |> Core.enqueue_block("10", 10 * @child_block_interval, 0)
                |> Core.get_blocks_to_submit()
-    end
-
-    # TODO(pdobacz, fixing in a follow-up PR): looks like dupe of 3 tests above
-    test "Recovery will fail if DB is corrupted" do
-      assert {:error, :mined_blknum_not_found_in_db} == recover([{5000, "5"}, {6000, "6"}], 7000)
     end
 
     test "A new block is emitted ASAP", %{empty: empty} do

--- a/apps/omg_child_chain/test/omg_child_chain/block_queue/core_test.exs
+++ b/apps/omg_child_chain/test/omg_child_chain/block_queue/core_test.exs
@@ -36,7 +36,6 @@ defmodule OMG.ChildChain.BlockQueue.CoreTest do
         top_mined_hash: <<0::256>>,
         parent_height: 0,
         child_block_interval: @child_block_interval,
-        chain_start_parent_height: 1,
         block_submit_every_nth: 1,
         finality_threshold: 12,
         last_enqueued_block_at_height: 0
@@ -65,7 +64,6 @@ defmodule OMG.ChildChain.BlockQueue.CoreTest do
       top_mined_hash: top_mined_hash,
       parent_height: 10,
       child_block_interval: 1000,
-      chain_start_parent_height: 1,
       block_submit_every_nth: 1,
       finality_threshold: 12,
       last_enqueued_block_at_height: 0
@@ -113,7 +111,6 @@ defmodule OMG.ChildChain.BlockQueue.CoreTest do
           top_mined_hash: "6",
           parent_height: 6,
           child_block_interval: @child_block_interval,
-          chain_start_parent_height: 1,
           block_submit_every_nth: 1,
           finality_threshold: finality_threshold,
           last_enqueued_block_at_height: 0
@@ -142,7 +139,6 @@ defmodule OMG.ChildChain.BlockQueue.CoreTest do
           top_mined_hash: <<0::size(256)>>,
           parent_height: 10,
           child_block_interval: 1000,
-          chain_start_parent_height: 1,
           block_submit_every_nth: 1,
           finality_threshold: 12,
           last_enqueued_block_at_height: 0
@@ -159,7 +155,6 @@ defmodule OMG.ChildChain.BlockQueue.CoreTest do
                  top_mined_hash: <<1::size(256)>>,
                  parent_height: 10,
                  child_block_interval: 1000,
-                 chain_start_parent_height: 1,
                  block_submit_every_nth: 1,
                  finality_threshold: 12,
                  last_enqueued_block_at_height: 0
@@ -174,7 +169,6 @@ defmodule OMG.ChildChain.BlockQueue.CoreTest do
                  top_mined_hash: <<1::size(256)>>,
                  parent_height: 10,
                  child_block_interval: 1000,
-                 chain_start_parent_height: 1,
                  block_submit_every_nth: 1,
                  finality_threshold: 12,
                  last_enqueued_block_at_height: 0
@@ -189,7 +183,6 @@ defmodule OMG.ChildChain.BlockQueue.CoreTest do
                  top_mined_hash: <<2::size(256)>>,
                  parent_height: 10,
                  child_block_interval: 1000,
-                 chain_start_parent_height: 1,
                  block_submit_every_nth: 1,
                  finality_threshold: 12,
                  last_enqueued_block_at_height: 0

--- a/apps/omg_child_chain/test/omg_child_chain/block_queue/core_test.exs
+++ b/apps/omg_child_chain/test/omg_child_chain/block_queue/core_test.exs
@@ -29,17 +29,7 @@ defmodule OMG.ChildChain.BlockQueue.CoreTest do
   @account_locked_response {:error, %{"code" => -32_000, "message" => "authentication needed: password or unlock"}}
 
   setup do
-    {:ok, empty} =
-      Core.new(
-        mined_child_block_num: 0,
-        known_hashes: [],
-        top_mined_hash: <<0::256>>,
-        parent_height: 0,
-        child_block_interval: @child_block_interval,
-        block_submit_every_nth: 1,
-        finality_threshold: 12,
-        last_enqueued_block_at_height: 0
-      )
+    {:ok, empty} = Core.new(0, [], <<0::256>>, 0, child_block_interval: @child_block_interval)
 
     empty_with_gas_params = %{empty | formed_child_block_num: 5 * @child_block_interval, gas_price_to_use: 100}
 
@@ -74,14 +64,11 @@ defmodule OMG.ChildChain.BlockQueue.CoreTest do
     test "Recovers after restart to proper mined height" do
       assert [%{hash: "8", nonce: 8}, %{hash: "9", nonce: 9}] =
                Core.new(
-                 mined_child_block_num: 7000,
-                 known_hashes: [{5000, "5"}, {6000, "6"}, {7000, "7"}, {8000, "8"}, {9000, "9"}],
-                 top_mined_hash: "7",
-                 parent_height: 10,
-                 child_block_interval: 1000,
-                 block_submit_every_nth: 1,
-                 finality_threshold: 12,
-                 last_enqueued_block_at_height: 0
+                 7000,
+                 [{5000, "5"}, {6000, "6"}, {7000, "7"}, {8000, "8"}, {9000, "9"}],
+                 "7",
+                 10,
+                 child_block_interval: @child_block_interval
                )
                |> elem(1)
                |> Core.get_blocks_to_submit()
@@ -99,14 +86,12 @@ defmodule OMG.ChildChain.BlockQueue.CoreTest do
 
       {:ok, state} =
         Core.new(
-          mined_child_block_num: mined_blknum,
-          known_hashes: Enum.zip(range, known_hashes),
-          top_mined_hash: "6",
-          parent_height: 6,
+          mined_blknum,
+          Enum.zip(range, known_hashes),
+          "6",
+          6,
           child_block_interval: @child_block_interval,
-          block_submit_every_nth: 1,
-          finality_threshold: finality_threshold,
-          last_enqueued_block_at_height: 0
+          finality_threshold: finality_threshold
         )
 
       assert [%{hash: "7", nonce: 7}, %{hash: "8", nonce: 8}, %{hash: "9", nonce: 9}] = Core.get_blocks_to_submit(state)
@@ -119,103 +104,50 @@ defmodule OMG.ChildChain.BlockQueue.CoreTest do
     test "Recovers after restart even when only empty blocks were mined" do
       assert [%{hash: "0", nonce: 8}, %{hash: "0", nonce: 9}] =
                Core.new(
-                 mined_child_block_num: 7000,
-                 known_hashes: [{5000, "0"}, {6000, "0"}, {7000, "0"}, {8000, "0"}, {9000, "0"}],
-                 top_mined_hash: "0",
-                 parent_height: 10,
-                 child_block_interval: 1000,
-                 block_submit_every_nth: 1,
-                 finality_threshold: 12,
-                 last_enqueued_block_at_height: 0
+                 7000,
+                 [{5000, "0"}, {6000, "0"}, {7000, "0"}, {8000, "0"}, {9000, "0"}],
+                 "0",
+                 10,
+                 child_block_interval: @child_block_interval
                )
                |> elem(1)
                |> Core.get_blocks_to_submit()
     end
 
     test "Recovers properly for fresh world state" do
-      {:ok, queue} =
-        Core.new(
-          mined_child_block_num: 0,
-          known_hashes: [],
-          top_mined_hash: <<0::size(256)>>,
-          parent_height: 10,
-          child_block_interval: 1000,
-          block_submit_every_nth: 1,
-          finality_threshold: 12,
-          last_enqueued_block_at_height: 0
-        )
-
+      {:ok, queue} = Core.new(0, [], <<0::size(256)>>, 10, child_block_interval: @child_block_interval)
       assert [] == Core.get_blocks_to_submit(queue)
     end
 
     test "Won't recover if is contract is ahead of db" do
       assert {:error, :contract_ahead_of_db} ==
-               Core.new(
-                 mined_child_block_num: 0,
-                 known_hashes: [],
-                 top_mined_hash: <<1::size(256)>>,
-                 parent_height: 10,
-                 child_block_interval: 1000,
-                 block_submit_every_nth: 1,
-                 finality_threshold: 12,
-                 last_enqueued_block_at_height: 0
-               )
+               Core.new(0, [], <<1::size(256)>>, 10, child_block_interval: @child_block_interval)
     end
 
     test "Won't recover if mined hash doesn't match with hash in db" do
       assert {:error, :hashes_dont_match} ==
-               Core.new(
-                 mined_child_block_num: 1000,
-                 known_hashes: [{1000, <<2::size(256)>>}],
-                 top_mined_hash: <<1::size(256)>>,
-                 parent_height: 10,
-                 child_block_interval: 1000,
-                 block_submit_every_nth: 1,
-                 finality_threshold: 12,
-                 last_enqueued_block_at_height: 0
+               Core.new(1000, [{1000, <<2::size(256)>>}], <<1::size(256)>>, 10,
+                 child_block_interval: @child_block_interval
                )
     end
 
     test "Won't recover if mined block number and hash don't match with db" do
       assert {:error, :mined_blknum_not_found_in_db} ==
-               Core.new(
-                 mined_child_block_num: 2000,
-                 known_hashes: [{1000, <<1::size(256)>>}],
-                 top_mined_hash: <<2::size(256)>>,
-                 parent_height: 10,
-                 child_block_interval: 1000,
-                 block_submit_every_nth: 1,
-                 finality_threshold: 12,
-                 last_enqueued_block_at_height: 0
+               Core.new(2000, [{1000, <<1::size(256)>>}], <<2::size(256)>>, 10,
+                 child_block_interval: @child_block_interval
                )
     end
 
     test "Won't recover if mined block number doesn't match with db" do
       assert {:error, :mined_blknum_not_found_in_db} ==
-               Core.new(
-                 mined_child_block_num: 2000,
-                 known_hashes: [{1000, <<1::size(256)>>}],
-                 top_mined_hash: <<1::size(256)>>,
-                 parent_height: 10,
-                 child_block_interval: 1000,
-                 block_submit_every_nth: 1,
-                 finality_threshold: 12,
-                 last_enqueued_block_at_height: 0
+               Core.new(2000, [{1000, <<1::size(256)>>}], <<1::size(256)>>, 10,
+                 child_block_interval: @child_block_interval
                )
     end
 
     test "Will recover if there are blocks in db but none in root chain" do
       assert {:ok, state} =
-               Core.new(
-                 mined_child_block_num: 0,
-                 known_hashes: [{1000, "1"}],
-                 top_mined_hash: <<0::size(256)>>,
-                 parent_height: 10,
-                 child_block_interval: 1000,
-                 block_submit_every_nth: 1,
-                 finality_threshold: 12,
-                 last_enqueued_block_at_height: 0
-               )
+               Core.new(0, [{1000, "1"}], <<0::size(256)>>, 10, child_block_interval: @child_block_interval)
 
       assert [%{hash: "1", nonce: 1}] = Core.get_blocks_to_submit(state)
 
@@ -226,14 +158,11 @@ defmodule OMG.ChildChain.BlockQueue.CoreTest do
     test "Recovers after restart and is able to process more blocks" do
       assert [%{hash: "8", nonce: 8}, %{hash: "9", nonce: 9}, %{hash: "10", nonce: 10}] =
                Core.new(
-                 mined_child_block_num: 7000,
-                 known_hashes: [{5000, "5"}, {6000, "6"}, {7000, "7"}, {8000, "8"}, {9000, "9"}],
-                 top_mined_hash: "7",
-                 parent_height: 10,
-                 child_block_interval: 1000,
-                 block_submit_every_nth: 1,
-                 finality_threshold: 12,
-                 last_enqueued_block_at_height: 0
+                 7000,
+                 [{5000, "5"}, {6000, "6"}, {7000, "7"}, {8000, "8"}, {9000, "9"}],
+                 "7",
+                 10,
+                 child_block_interval: @child_block_interval
                )
                |> elem(1)
                |> Core.enqueue_block("10", 10 * @child_block_interval, 0)
@@ -602,16 +531,7 @@ defmodule OMG.ChildChain.BlockQueue.CoreTest do
   describe "process_submit_result/3" do
     test "everything might be ok" do
       [submission] =
-        Core.new(
-          mined_child_block_num: 0,
-          known_hashes: [{1000, "1"}],
-          top_mined_hash: <<0::size(256)>>,
-          parent_height: 10,
-          child_block_interval: 1000,
-          block_submit_every_nth: 1,
-          finality_threshold: 12,
-          last_enqueued_block_at_height: 0
-        )
+        Core.new(0, [{1000, "1"}], <<0::size(256)>>, 10, child_block_interval: @child_block_interval)
         |> elem(1)
         |> Core.get_blocks_to_submit()
 
@@ -624,16 +544,7 @@ defmodule OMG.ChildChain.BlockQueue.CoreTest do
 
     test "benign reports / warnings from geth" do
       [submission] =
-        Core.new(
-          mined_child_block_num: 0,
-          known_hashes: [{1000, "1"}],
-          top_mined_hash: <<0::size(256)>>,
-          parent_height: 10,
-          child_block_interval: 1000,
-          block_submit_every_nth: 1,
-          finality_threshold: 12,
-          last_enqueued_block_at_height: 0
-        )
+        Core.new(0, [{1000, "1"}], <<0::size(256)>>, 10, child_block_interval: @child_block_interval)
         |> elem(1)
         |> Core.get_blocks_to_submit()
 
@@ -645,16 +556,7 @@ defmodule OMG.ChildChain.BlockQueue.CoreTest do
 
     test "benign nonce too low error - related to our tx being mined, since the mined blknum advanced" do
       [submission] =
-        Core.new(
-          mined_child_block_num: 0,
-          known_hashes: [{1000, "1"}],
-          top_mined_hash: <<0::size(256)>>,
-          parent_height: 10,
-          child_block_interval: 1000,
-          block_submit_every_nth: 1,
-          finality_threshold: 12,
-          last_enqueued_block_at_height: 0
-        )
+        Core.new(0, [{1000, "1"}], <<0::size(256)>>, 10, child_block_interval: @child_block_interval)
         |> elem(1)
         |> Core.get_blocks_to_submit()
 
@@ -664,16 +566,7 @@ defmodule OMG.ChildChain.BlockQueue.CoreTest do
 
     test "real nonce too low error" do
       [submission] =
-        Core.new(
-          mined_child_block_num: 0,
-          known_hashes: [{1000, "1"}],
-          top_mined_hash: <<0::size(256)>>,
-          parent_height: 10,
-          child_block_interval: 1000,
-          block_submit_every_nth: 1,
-          finality_threshold: 12,
-          last_enqueued_block_at_height: 0
-        )
+        Core.new(0, [{1000, "1"}], <<0::size(256)>>, 10, child_block_interval: @child_block_interval)
         |> elem(1)
         |> Core.get_blocks_to_submit()
 
@@ -689,16 +582,7 @@ defmodule OMG.ChildChain.BlockQueue.CoreTest do
 
     test "other fatal errors" do
       [submission] =
-        Core.new(
-          mined_child_block_num: 0,
-          known_hashes: [{1000, "1"}],
-          top_mined_hash: <<0::size(256)>>,
-          parent_height: 10,
-          child_block_interval: 1000,
-          block_submit_every_nth: 1,
-          finality_threshold: 12,
-          last_enqueued_block_at_height: 0
-        )
+        Core.new(0, [{1000, "1"}], <<0::size(256)>>, 10, child_block_interval: @child_block_interval)
         |> elem(1)
         |> Core.get_blocks_to_submit()
 


### PR DESCRIPTION


## Overview

BlockQueue.Core (especially tests) aged a bit, which I spotted when solving #1136. This should give those a significant refactor.

As far as I can tell, this shouldn't change `BlockQueue`'s behavior in any way.

## Changes

This is a set of interleaving implementation and test changes. It might be **most convenient** to review commit-by-commit or in small batches
- **removing some dead code**
  - refactor: remove BlockQueue.Core.new/0 which wasn't really used
  - refactor: get rid of child_start_parent_height handling
- **mechanical and simple tidies to `CoreTests`**
  - test: remove duplicate test and tighten the one that remained after
  - style: rearrange existing BlockQueue.CoreTests into function `describe` blocks
  - refactor: ditch the recover/3 helper in test
- **larger refactor cleaning `Core.new/1` that had a multitude of named args**
  - refactor: hideoptional config parameters in tests and make consistent …
- **tidies of tests now grouped in the new `describe` blocks, adding some new ones** 
  - test: tidy new/1 tests
  - style: replace the confusing x * @child_block_interval DRYing
  - test: tidy enqueue_block and set_ethereum_height tests
  - test: simple tidies of get_blocks_to_submit/1 tests
- **large refactor/revamp of gas price tests** (actually, this was my biggest itch in here. Those tests used a lot of internal stuffs to test uncleanly. Now they are tested based on public API calls and observable actions like ethereum progressing/new blocks etc. 
  - refactor: change gas price tests to not use internals

**NOTE** on the gas price test refactors. This actually uncovered a bunch of surprising behaviors, so careful review required on the last commit :point_up: . So far I haven't attempted to "fix" this, since there hasn't been an issue with the mechanism as a whole. For now I only solidified existing behavior in the tests.

Overall, this aims to get closer to the `ExUnit` style we have, reduce the use of test helpers and make tests more approachable (hopefully).

## Testing

`mix test test/omg_child_chain` and :eyes: 