### PR TITLE
refactor: build dir in docker

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -382,8 +382,8 @@ jobs:
       - run:
           name: Unpack PLT cache
           command: |
-            mkdir -p _build/test
-            cp plts/dialyxir*.plt _build/test/ || true
+            mkdir -p _build_docker/test
+            cp plts/dialyxir*.plt _build_docker/test/ || true
             mkdir -p ~/.mix
             cp plts/dialyxir*.plt ~/.mix/ || true
       - run: mix dialyzer --plt
@@ -391,7 +391,7 @@ jobs:
           name: Pack PLT cache
           command: |
             mkdir -p plts
-            cp _build/test/dialyxir*.plt plts/
+            cp _build_docker/test/dialyxir*.plt plts/
             cp ~/.mix/dialyxir*.plt plts/
       - save_cache:
           key: v2-plt-cache-{{ ".tool-versions" }}-{{ checksum "mix.lock" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -376,9 +376,9 @@ jobs:
       - setup_elixir-omg_workspace
       - restore_cache:
           keys:
-            - v2-plt-cache-{{ ".tool-versions" }}-{{ checksum "mix.lock" }}
-            - v2-plt-cache-{{ ".tool-versions" }}-{{ checksum "mix.exs" }}
-            - v2-plt-cache-{{ ".tool-versions" }}
+            - v3-plt-cache-{{ ".tool-versions" }}-{{ checksum "mix.lock" }}
+            - v3-plt-cache-{{ ".tool-versions" }}-{{ checksum "mix.exs" }}
+            - v3-plt-cache-{{ ".tool-versions" }}
       - run:
           name: Unpack PLT cache
           command: |
@@ -394,15 +394,15 @@ jobs:
             cp _build_docker/test/dialyxir*.plt plts/
             cp ~/.mix/dialyxir*.plt plts/
       - save_cache:
-          key: v2-plt-cache-{{ ".tool-versions" }}-{{ checksum "mix.lock" }}
+          key: v3-plt-cache-{{ ".tool-versions" }}-{{ checksum "mix.lock" }}
           paths:
             - plts
       - save_cache:
-          key: v2-plt-cache-{{ ".tool-versions" }}-{{ checksum "mix.exs" }}
+          key: v3-plt-cache-{{ ".tool-versions" }}-{{ checksum "mix.exs" }}
           paths:
             - plts
       - save_cache:
-          key: v2-plt-cache-{{ ".tool-versions" }}
+          key: v3-plt-cache-{{ ".tool-versions" }}
           paths:
             - plts
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,12 +19,12 @@ executors:
 
   builder:
     docker:
-      - image: omisegoimages/elixir-omg-builder:stable-20200104
+      - image: omisegoimages/elixir-omg-builder:dev-5735fd5
     working_directory: ~/src
 
   builder_pg:
     docker:
-      - image: omisegoimages/elixir-omg-builder:stable-20200104
+      - image: omisegoimages/elixir-omg-builder:dev-5735fd5
       - image: circleci/postgres:9.6-alpine
         environment:
           POSTGRES_USER: omisego_dev
@@ -34,7 +34,7 @@ executors:
 
   builder_pg_geth:
     docker:
-      - image: omisegoimages/elixir-omg-tester:stable-20200104
+      - image: omisegoimages/elixir-omg-tester:dev-5735fd5
       - image: circleci/postgres:9.6-alpine
         environment:
           POSTGRES_USER: omisego_dev
@@ -137,13 +137,13 @@ jobs:
       - run: ERLANG_ROCKSDB_BUILDOPTS='-j 2' make build-test
       - save_cache:
           key: v2-mix-cache-test-compile-{{ checksum "mix.lock" }}-{{ .Branch }}-{{ .Revision }}
-          paths: "_build"
+          paths: "_build_docker"
       - save_cache:
           key: v1-rocksdb-cache-{{ checksum "mix.lock" }}
           paths:
-            - "deps/rocksdb"
-            - "_build/test/lib/rocksdb/"
-            - "_build/test/dev/rocksdb/"
+            - "deps_docker/rocksdb"
+            - "_build_docker/test/lib/rocksdb/"
+            - "_build_docker/test/dev/rocksdb/"
       - persist_to_workspace:
           name: Persist workspace
           root: ~/src
@@ -151,12 +151,12 @@ jobs:
             - .circleci
             - dialyzer.ignore-warnings
             - .formatter.exs
-            - _build
+            - _build_docker
             - .credo.exs
             - apps
             - bin
             - config
-            - deps
+            - deps_docker
             - doc
             - mix.exs
             - mix.lock
@@ -496,6 +496,7 @@ jobs:
             sudo apt-get update &&
             sudo apt-get install esl-erlang=1:21.3.8.10-1 elixir=1.8.2-1 &&
             sudo apt-get install -y erlang-os-mon &&
+            sudo apt-get install -y erlang-parsetools &&
             ./bin/setup &&
             make deps-elixir-omg &&
             make start-child_chain OVERRIDING_START=start &&

--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,17 @@
 # The directory Mix will write compiled artifacts to.
 /_build/
 
+# The directory Mix will write compiled artifacts to when in docker.
+/_build_docker/
+
 # If you run "mix test --cover", coverage assets end up here.
 /cover/
 
 # app-specific coverage results go to their respective apps
 /apps/*/cover/
+
+# The directory Mix downloads your dependencies sources to when in docker.
+/deps_docker/
 
 # The directory Mix downloads your dependencies sources to.
 /deps/

--- a/Dockerfile.child_chain
+++ b/Dockerfile.child_chain
@@ -53,10 +53,10 @@ RUN set -xe \
 #rocksdb from builder image to deployer image
 RUN mkdir -p /usr/local/rocksdb/lib
 RUN mkdir /usr/local/rocksdb/include
-COPY --from=omisegoimages/elixir-omg-builder:stable-20200104 /usr/local/rocksdb/ /usr/local/rocksdb/
+COPY --from=omisegoimages/elixir-omg-builder:dev-5735fd5 /usr/local/rocksdb/ /usr/local/rocksdb/
 
 ARG release_version
-ADD _build/prod/rel/child_chain/releases/${release_version}/child_chain.tar.gz /app
+ADD _build_docker/prod/rel/child_chain/releases/${release_version}/child_chain.tar.gz /app
 RUN chown -R "${uid}:${gid}" /app
 WORKDIR /app
 

--- a/Dockerfile.watcher
+++ b/Dockerfile.watcher
@@ -54,10 +54,10 @@ RUN set -xe \
 #rocksdb from builder image to deployer image
 RUN mkdir -p /usr/local/rocksdb/lib
 RUN mkdir /usr/local/rocksdb/include
-COPY --from=omisegoimages/elixir-omg-builder:stable-20200104 /usr/local/rocksdb/ /usr/local/rocksdb/
+COPY --from=omisegoimages/elixir-omg-builder:dev-5735fd5 /usr/local/rocksdb/ /usr/local/rocksdb/
 
 ARG release_version
-ADD _build/prod/rel/watcher/releases/${release_version}/watcher.tar.gz /app
+ADD _build_docker/prod/rel/watcher/releases/${release_version}/watcher.tar.gz /app
 RUN chown -R "${uid}:${gid}" /app
 WORKDIR /app
 

--- a/Dockerfile.watcher_info
+++ b/Dockerfile.watcher_info
@@ -54,10 +54,10 @@ RUN set -xe \
 #rocksdb from builder image to deployer image
 RUN mkdir -p /usr/local/rocksdb/lib
 RUN mkdir /usr/local/rocksdb/include
-COPY --from=omisegoimages/elixir-omg-builder:stable-20200104 /usr/local/rocksdb/ /usr/local/rocksdb/
+COPY --from=omisegoimages/elixir-omg-builder:dev-5735fd5 /usr/local/rocksdb/ /usr/local/rocksdb/
 
 ARG release_version
-ADD _build/prod/rel/watcher_info/releases/${release_version}/watcher_info.tar.gz /app
+ADD _build_docker/prod/rel/watcher_info/releases/${release_version}/watcher_info.tar.gz /app
 RUN chown -R "${uid}:${gid}" /app
 WORKDIR /app
 

--- a/Makefile
+++ b/Makefile
@@ -474,10 +474,3 @@ diagnostics:
 	echo "\n ---------- END OF DIAGNOSTICS REPORT ----------"
 
 .PHONY: diagnostics
-
-### UTILS
-OSFLAG := ''
-UNAME_S := $(shell uname -s)
-ifeq ($(UNAME_S),Darwin)
-	OSFLAG = OSX
-endif

--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,7 @@ WATCHER_IMAGE_NAME      ?= "omisego/watcher:latest"
 WATCHER_INFO_IMAGE_NAME ?= "omisego/watcher_info:latest"
 CHILD_CHAIN_IMAGE_NAME  ?= "omisego/child_chain:latest"
 
-IMAGE_BUILDER   ?= "omisegoimages/elixir-omg-builder:stable-20200104"
+IMAGE_BUILDER   ?= "omisegoimages/elixir-omg-builder:dev-5735fd5"
 IMAGE_BUILD_DIR ?= $(PWD)
 
 ENV_DEV         ?= env MIX_ENV=dev
@@ -116,6 +116,8 @@ clean: clean-elixir-omg
 clean-elixir-omg:
 	rm -rf _build/*
 	rm -rf deps/*
+	rm -rf _build_docker/*
+	rm -rf deps_docker/*
 
 
 .PHONY: clean clean-elixir-omg
@@ -231,7 +233,6 @@ start-pre-lumphini-watcher:
 docker-child_chain-prod:
 	docker run --rm -it \
 		-v $(PWD):/app \
-		-v $(IMAGE_BUILD_DIR)/deps:/app/deps \
 		-u root \
 		--entrypoint /bin/sh \
 		$(IMAGE_BUILDER) \
@@ -240,7 +241,6 @@ docker-child_chain-prod:
 docker-watcher-prod:
 	docker run --rm -it \
 		-v $(PWD):/app \
-		-v $(IMAGE_BUILD_DIR)/deps:/app/deps \
 		-u root \
 		--entrypoint /bin/sh \
 		$(IMAGE_BUILDER) \
@@ -249,7 +249,6 @@ docker-watcher-prod:
 docker-watcher_info-prod:
 	docker run --rm -it \
 		-v $(PWD):/app \
-		-v $(IMAGE_BUILD_DIR)/deps:/app/deps \
 		-u root \
 		--entrypoint /bin/sh \
 		$(IMAGE_BUILDER) \

--- a/README.md
+++ b/README.md
@@ -76,9 +76,9 @@ make init_test
 
 # Testing & development
 
-You can setup the docker environment to run testing and development tasks:
+Docker building of source code and dependencies used to directly use common `mix` folders like `_build` and `deps`. To support workflows that switch between bare metal and Docker containers we've introduced `_build_docker` and `deps_docker` folders.
 
-(Note: If they exist, be sure to delete the `deps` and `_build` dirs from your host drive. Otherwise these dirs will get mapped into the docker container and can create build discrepancies and breakages.)
+You can setup the docker environment to run testing and development tasks:
 
 ```sh
 docker-compose -f docker-compose.yml -f docker-compose.dev.yml run --rm --entrypoint bash elixir-omg

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,7 +1,7 @@
 version: "2.3"
 services:
   elixir-omg:
-    image: omisegoimages/elixir-omg-builder:stable-20200104
+    image: omisegoimages/elixir-omg-builder:dev-5735fd5
     environment:
       DATABASE_URL: postgres://omisego_dev:omisego_dev@postgres:5432/omisego_dev
     volumes:

--- a/mix.exs
+++ b/mix.exs
@@ -16,6 +16,8 @@ defmodule OMG.Umbrella.MixProject do
         "coveralls.circle": :test,
         dialyzer: :test
       ],
+      build_path: "_build" <> docker(),
+      deps_path: "deps" <> docker(),
       dialyzer: dialyzer(),
       test_coverage: [tool: ExCoveralls],
       # gets all apps test folders for the sake of `mix coveralls --umbrella`
@@ -93,4 +95,6 @@ defmodule OMG.Umbrella.MixProject do
       :sentry,
       :vmstats
     ]
+
+  defp docker(), do: if(System.get_env("DOCKER"), do: "_docker", else: "")
 end

--- a/mix.exs
+++ b/mix.exs
@@ -69,12 +69,13 @@ defmodule OMG.Umbrella.MixProject do
     ]
   end
 
-  defp dialyzer do
+  defp dialyzer() do
     [
       flags: [:error_handling, :race_conditions, :underspecs, :unknown, :unmatched_returns],
       ignore_warnings: "dialyzer.ignore-warnings",
       list_unused_filters: true,
-      plt_add_apps: plt_apps()
+      plt_add_apps: plt_apps(),
+      paths: Enum.map(File.ls!("apps"), fn app -> "_build#{docker()}/#{Mix.env()}/lib/#{app}/ebin" end)
     ]
   end
 


### PR DESCRIPTION
https://github.com/omisego/elixir-omg/issues/1248
## Overview

This PR would identify a container build and use _build_docker and _deps_docker folders for compilation and dependencies.

## Changes

- builder and tester images now have an environment variables set called `DOCKER=true` https://github.com/omisego-images/docker-elixir-omg/pull/26
- if the ENV var is populated ^^, append `_docker` string in the directory name

## Testing

/
