### PR TITLE
feat: info-level log every 1000 newHeads received

### DIFF
--- a/apps/omg_eth/lib/omg_eth/ethereum_client_monitor.ex
+++ b/apps/omg_eth/lib/omg_eth/ethereum_client_monitor.ex
@@ -123,7 +123,12 @@ defmodule OMG.Eth.EthereumClientMonitor do
     case is_binary(value) do
       true ->
         ethereum_height = Encoding.int_from_hex(value)
-        _ = Logger.debug("Ethereum client monitor got a newHeads event for new Ethereum height #{ethereum_height}.")
+        _ = Logger.debug("Got a newHeads event for new Ethereum height #{ethereum_height}.")
+
+        _ =
+          if rem(ethereum_height, 1000) == 0,
+            do: Logger.info("Got a newHeads event for new Ethereum height #{ethereum_height}. (log every 1000)")
+
         {:noreply, %{state | ethereum_height: ethereum_height}}
 
       false ->

--- a/apps/omg_eth/lib/omg_eth/ethereum_height.ex
+++ b/apps/omg_eth/lib/omg_eth/ethereum_height.ex
@@ -52,7 +52,12 @@ defmodule OMG.Eth.EthereumHeight do
     case is_binary(value) do
       true ->
         ethereum_height = Encoding.int_from_hex(value)
-        _ = Logger.debug("#{__MODULE__} got a newHeads event for new Ethereum height #{ethereum_height}.")
+        _ = Logger.debug("Got a newHeads event for new Ethereum height #{ethereum_height}.")
+
+        _ =
+          if rem(ethereum_height, 1000) == 0,
+            do: Logger.info("Got a newHeads event for new Ethereum height #{ethereum_height}. (log every 1000)")
+
         {:noreply, ethereum_height}
 
       false ->


### PR DESCRIPTION
https://github.com/omisego/devops/issues/308

## Overview

A quick suggestion following the discussion in the issue.

Add a higher level (`info`) log of `newHeads` every 1000 ethereum blocks.

Rudimentary because possibly #1255 happens, but needed to better debug problems with stalled watchers

## Changes

as above + I rephrased the logs a bit - the `__MODULE__` is logged anyway per logger format, so I think we can drop it from the `Logger` invocation itself.

## Testing

existing tests + we'll see the logs in dd