### PR TITLE
feat: Ethereum stalled sync detection and recovery

### DIFF
--- a/apps/omg_eth/config/config.exs
+++ b/apps/omg_eth/config/config.exs
@@ -17,6 +17,7 @@ config :omg_eth,
   child_block_interval: 1000,
   min_exit_period_seconds: 7 * 24 * 60 * 60,
   ws_url: "ws://localhost:8546/ws",
-  client_monitor_interval_ms: 10_000
+  client_monitor_interval_ms: 10_000,
+  stalled_sync_check_interval_ms: 20_000
 
 import_config "#{Mix.env()}.exs"

--- a/apps/omg_eth/lib/omg_eth/ethereum_height_monitor.ex
+++ b/apps/omg_eth/lib/omg_eth/ethereum_height_monitor.ex
@@ -1,0 +1,150 @@
+# Copyright 2019-2020 OmiseGO Pte Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defmodule OMG.Eth.EthereumHeightMonitor do
+  @moduledoc """
+  Monitors the Ethereum height and raises an alarm when new root chain blocks
+  are not received in a timely manner.
+
+  Note that this module monitors valid block numbers only. Errors are ignored.
+  To monitor connectivity errors, consider using `OMG.Eth.EthereumClientMonitor`.
+  """
+  use GenServer
+  require Logger
+
+  alias OMG.Eth.EthereumClientMonitor
+  alias OMG.Eth.EthereumHeight
+
+  @height_monitor __MODULE__
+
+  @default_interval Application.get_env(:omg_eth, :ethereum_stalled_sync_check_interval_ms)
+
+  @type t :: %__MODULE__{
+          interval: pos_integer(),
+          tref: reference() | nil,
+          alarm_module: module(),
+          raised: boolean(),
+          last_checked_height: non_neg_integer()
+        }
+  defstruct interval: @default_interval,
+            tref: nil,
+            alarm_module: nil,
+            raised: false,
+            last_checked_height: 0
+
+  def start_link(args) do
+    GenServer.start_link(__MODULE__, args, name: __MODULE__)
+  end
+
+  def init(opts) do
+    _ = Logger.info("Starting Ethereum height monitor.")
+    _ = install_alarm_handler()
+
+    state = %__MODULE__{
+      alarm_module: Keyword.fetch!(opts, :alarm_module)
+    }
+
+    {:ok, state, {:continue, :start_check}}
+  end
+
+  def handle_continue(:start_check, state) do
+    ethereum_height = EthereumHeight.get()
+    stalled = stalled?(ethereum_height, state.last_checked_height)
+    _ = raise_or_clear(state.alarm_module, state.raised, stalled)
+
+    {:ok, tref} = :timer.send_after(state.interval, :check_height)
+    {:ok, %{state | tref: tref, last_checked_height: ethereum_height}}
+  end
+
+  def handle_info(:check_height, state) do
+    ethereum_height = EthereumHeight.get()
+    stalled = stalled?(ethereum_height, state.last_checked_height)
+    _ = raise_or_clear(state.alarm_module, state.raised, stalled)
+
+    {:ok, tref} = :timer.send_after(state.interval, :check_height)
+    {:noreply, %{state | tref: tref, last_checked_height: ethereum_height}}
+  end
+
+  # Handles alarm events from AlarmHandler
+  def handle_cast(:clear_alarm, state) do
+    {:noreply, %{state | raised: false}}
+  end
+
+  def handle_cast(:set_alarm, state) do
+    {:noreply, %{state | raised: true}}
+  end
+
+  defmodule AlarmHandler do
+    @moduledoc """
+    Listens for :ethereum_stalled_sync alarm, triggers an EthereumClientMonitor restart,
+    and reflect the state back to EthereumHeightMonitor.
+    """
+    use GenServer
+
+    def init(_args) do
+      {:ok, %{}}
+    end
+
+    def handle_call(_request, state), do: {:ok, :ok, state}
+
+    def handle_event({:set_alarm, {:ethereum_stalled_sync, %{reporter: @height_monitor}}}, state) do
+      _ = Logger.warn(":ethereum_stalled_sync alarm raised. Restarting EthereumHeightMonitor.")
+      :ok = GenServer.stop(EthereumClientMonitor)
+      :ok = GenServer.cast(@height_monitor, :set_alarm)
+      {:ok, state}
+    end
+
+    def handle_event({:clear_alarm, {:ethereum_stalled_sync, %{reporter: @height_monitor}}}, state) do
+      _ = Logger.warn(":ethereum_stalled_sync alarm cleared.")
+      :ok = GenServer.cast(@height_monitor, :clear_alarm)
+      {:ok, state}
+    end
+
+    def handle_event(event, state) do
+      _ = Logger.info("EthereumHeightMonitor.AlarmHandler got event: #{inspect(event)}. Ignoring.")
+      {:ok, state}
+    end
+  end
+
+  # Consider the sync as healthy if the height increases between intervals.
+  # Ignoring any upstream errors, anything else is considered a stall.
+  defp stalled?(:error, _last_checked_height), do: :ignore
+
+  defp stalled?(_height, :error), do: :ignore
+
+  defp stalled?(height, last_checked_height) when height > last_checked_height, do: false
+
+  defp stalled?(_height, _last_checked_height), do: true
+
+  # if an alarm is raised, we don't have to raise it again.
+  # if an alarm is cleared, we don't need to clear it again
+  # we want to avoid pushing events again
+  @spec raise_or_clear(module(), boolean(), boolean() | :ignore) :: :ok | :duplicate
+  defp raise_or_clear(_alarm_module, _, :ignore), do: :ok
+
+  defp raise_or_clear(alarm_module, false, true),
+    do: alarm_module.set(alarm_module.ethereum_stalled_sync(__MODULE__))
+
+  defp raise_or_clear(alarm_module, true, false),
+    do: alarm_module.clear(alarm_module.ethereum_stalled_sync(__MODULE__))
+
+  defp raise_or_clear(_alarm_module, _, _), do: :ok
+
+  defp install_alarm_handler do
+    case Enum.member?(:gen_event.which_handlers(:alarm_handler), AlarmHandler) do
+      true -> :ok
+      _ -> :alarm_handler.add_alarm_handler(AlarmHandler)
+    end
+  end
+end

--- a/apps/omg_eth/lib/omg_eth/release_tasks/set_ethereum_stalled_sync_check_interval.ex
+++ b/apps/omg_eth/lib/omg_eth/release_tasks/set_ethereum_stalled_sync_check_interval.ex
@@ -1,0 +1,52 @@
+# Copyright 2019-2019 OmiseGO Pte Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defmodule OMG.Eth.ReleaseTasks.SetEthereumStalledSyncCheckInterval do
+  @moduledoc false
+  use Distillery.Releases.Config.Provider
+  require Logger
+  @app :omg_eth
+
+  @impl Provider
+  def init(_args) do
+    _ = Application.ensure_all_started(:logger)
+
+    stalled_sync_check_interval_ms = stalled_sync_check_interval_ms()
+
+    :ok =
+      Application.put_env(@app, :stalled_sync_check_interval_ms, stalled_sync_check_interval_ms, persistent: true)
+  end
+
+  defp stalled_sync_check_interval_ms() do
+    stalled_sync_check_interval_ms =
+      validate_integer(
+        get_env("ETHEREUM_STALLED_SYNC_CHECK_INTERVAL_MS"),
+        Application.get_env(@app, :stalled_sync_check_interval_ms)
+      )
+
+    _ =
+      Logger.info(
+        "CONFIGURATION: App: #{@app} Key: stalled_sync_check_interval_ms Value: #{
+          inspect(stalled_sync_check_interval_ms)
+        }."
+      )
+
+    stalled_sync_check_interval_ms
+  end
+
+  defp get_env(key), do: System.get_env(key)
+
+  defp validate_integer(value, _default) when is_binary(value), do: String.to_integer(value)
+  defp validate_integer(_, default), do: default
+end

--- a/apps/omg_eth/lib/omg_eth/supervisor.ex
+++ b/apps/omg_eth/lib/omg_eth/supervisor.ex
@@ -33,6 +33,10 @@ defmodule OMG.Eth.Supervisor do
          event_bus: OMG.Bus,
          ws_url: Application.get_env(:omg_eth, :ws_url)
        ]},
+      {OMG.Eth.EthereumHeightMonitor,
+       [
+         alarm_module: Alarm
+       ]},
       {OMG.Eth.EthereumHeight, [event_bus: OMG.Bus]}
     ]
 

--- a/apps/omg_status/lib/omg_status/alert/alarm.ex
+++ b/apps/omg_status/lib/omg_status/alert/alarm.ex
@@ -29,6 +29,7 @@ defmodule OMG.Status.Alert.Alarm do
   @type alarms ::
           {:boot_in_progress
            | :ethereum_client_connection
+           | :ethereum_stalled_sync
            | :invalid_fee_file
            | :statsd_client_connection
            | :main_supervisor_halted, alarm_detail}
@@ -37,6 +38,7 @@ defmodule OMG.Status.Alert.Alarm do
     do: [
       :boot_in_progress,
       :ethereum_client_connection,
+      :ethereum_stalled_sync,
       :invalid_fee_file,
       :statsd_client_connection,
       :main_supervisor_halted
@@ -49,6 +51,10 @@ defmodule OMG.Status.Alert.Alarm do
   @spec ethereum_client_connection(module()) :: {:ethereum_client_connection, alarm_detail}
   def ethereum_client_connection(reporter),
     do: {:ethereum_client_connection, %{node: Node.self(), reporter: reporter}}
+
+  @spec ethereum_stalled_sync(module()) :: {:ethereum_stalled_sync, alarm_detail}
+  def ethereum_stalled_sync(reporter),
+    do: {:ethereum_stalled_sync, %{node: Node.self(), reporter: reporter}}
 
   @spec boot_in_progress(module()) :: {:boot_in_progress, alarm_detail}
   def boot_in_progress(reporter),

--- a/bin/variables
+++ b/bin/variables
@@ -12,6 +12,7 @@ export ETHEREUM_NETWORK=LOCALCHAIN
 export DATABASE_URL=postgresql://omisego_dev:omisego_dev@127.0.0.1:5432/omisego_dev
 export CHILD_CHAIN_URL=http://127.0.0.1:9656
 export ETHEREUM_EVENTS_CHECK_INTERVAL_MS=800
+export ETHEREUM_STALLED_SYNC_CHECK_INTERVAL_MS=20000
 # expects it's executed from the root of the project
 FILE='./localchain_contract_addresses.env'
 while IFS= read -r line; do

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -77,6 +77,7 @@ services:
       - DD_DISABLED=true
       - DB_PATH=/app/.omg/data
       - ETHEREUM_EVENTS_CHECK_INTERVAL_MS=800
+      - ETHEREUM_STALLED_SYNC_CHECK_INTERVAL_MS=20000
     restart: always
     ports:
       - "9656:9656"
@@ -110,6 +111,7 @@ services:
       - DD_DISABLED=true
       - DB_PATH=/app/.omg/data
       - ETHEREUM_EVENTS_CHECK_INTERVAL_MS=800
+      - ETHEREUM_STALLED_SYNC_CHECK_INTERVAL_MS=20000
     restart: always
     ports:
       - "7434:7434"
@@ -144,6 +146,7 @@ services:
       - DD_DISABLED=true
       - DB_PATH=/app/.omg/data
       - ETHEREUM_EVENTS_CHECK_INTERVAL_MS=800
+      - ETHEREUM_STALLED_SYNC_CHECK_INTERVAL_MS=20000
     restart: always
     ports:
       - "7534:7534"

--- a/docs/deployment_configuration.md
+++ b/docs/deployment_configuration.md
@@ -15,7 +15,7 @@
 - "BATCH_SIZE" - Datadog batch size for APM
 - "SYNC_THRESHOLD" - Datadog sync threshold for APM
 - "ETHEREUM_EVENTS_CHECK_INTERVAL_MS" - the frequency of HTTP requests towards the Ethereum clients and scanning for interested events. Should be less then average block time (10 to 20 seconds) on Ethereum mainnet.
-
+- "ETHEREUM_STALLED_SYNC_CHECK_INTERVAL_MS" - the interval to check for Ethereum block height increase, before being considered a stalled sync. Should be slightly larger than the expected block time.
 
 ***Erlang VM configuration***
 

--- a/rel/config.exs
+++ b/rel/config.exs
@@ -46,6 +46,7 @@ release :watcher do
   set(
     config_providers: [
       {OMG.ReleaseTasks.SetEthereumEventsCheckInterval, []},
+      {OMG.Eth.ReleaseTasks.SetEthereumStalledSyncCheckInterval, []},
       {OMG.Eth.ReleaseTasks.SetEthereumClient, []},
       {OMG.Eth.ReleaseTasks.SetContract, []},
       {OMG.DB.ReleaseTasks.SetKeyValueDB, []},
@@ -88,6 +89,8 @@ release :watcher_info do
 
   set(
     config_providers: [
+      {OMG.ReleaseTasks.SetEthereumEventsCheckInterval, []},
+      {OMG.Eth.ReleaseTasks.SetEthereumStalledSyncCheckInterval, []},
       {OMG.Eth.ReleaseTasks.SetEthereumClient, []},
       {OMG.Eth.ReleaseTasks.SetContract, []},
       {OMG.DB.ReleaseTasks.SetKeyValueDB, []},
@@ -134,6 +137,7 @@ release :child_chain do
   set(
     config_providers: [
       {OMG.ReleaseTasks.SetEthereumEventsCheckInterval, []},
+      {OMG.Eth.ReleaseTasks.SetEthereumStalledSyncCheckInterval, []},
       {OMG.Eth.ReleaseTasks.SetEthereumClient, []},
       {OMG.Eth.ReleaseTasks.SetContract, []},
       {OMG.DB.ReleaseTasks.SetKeyValueDB, []},


### PR DESCRIPTION
Relates to #814 

## Overview

Checks for every specified interval if a new Ethereum block has been received. If not, raises an `:ethereum_stalled_sync` alarm and attempts to restart the `EthereumClientMonitor` where the connection to Ethereum is managed.

## Changes

- [x] Monitors for new Eth block height every interval
- [x] Restart the connection when block height stalls
- [x] Configurable interval environment variable
- [ ] Expose the `:ethereum_stalled_sync` event to /status.get

## Testing

Coming!