### PR TITLE
fix: add :jason and :omg as omg_watcher_info dependencies

### DIFF
--- a/apps/omg_watcher_info/mix.exs
+++ b/apps/omg_watcher_info/mix.exs
@@ -43,8 +43,10 @@ defmodule OMG.WatcherInfo.MixProject do
       {:spandex, "~> 2.4",
        git: "https://github.com/omisego/spandex.git", branch: "fix_dialyzer_in_macro", override: true},
       {:distillery, "~> 2.1", runtime: false},
+      {:jason, "~> 1.0"},
 
       # UMBRELLA
+      {:omg, in_umbrella: true},
       {:omg_status, in_umbrella: true},
       {:omg_utils, in_umbrella: true},
 


### PR DESCRIPTION
## Overview

Fixes mix commands not working within `omg_watcher_info` subapp by adding `:jason` and `:omg` to `omg_watcher_info` subapp deps.

## Changes

@okalouti reported problems running ecto migration generation within the `omg_watcher_info` subapp. And this command needs to be run from the subapp.

```
$ mix ecto.gen.migration index_block_timestamp
==> omg_status
Compiling 1 file (.ex)
warning: found Jason in your application configuration
for Phoenix JSON encoding, but failed to load the library.

(module Jason is not available).

Ensure Jason exists in your deps in mix.exs,
and you have configured Phoenix to use it for JSON encoding by
verifying the following exists in your config/config.exs:

    config :phoenix, :json_library, Jason


  (phoenix) lib/phoenix.ex:40: Phoenix.start/2
  (kernel) application_master.erl:277: :application_master.start_it_old/4

==> omg_watcher_info
Compiling 25 files (.ex)

== Compilation error in file lib/omg_watcher_info/utxo_selection.ex ==
** (CompileError) lib/omg_watcher_info/utxo_selection.ex:25: module OMG.State.Transaction is not loaded and could not be found
    (stdlib) erl_eval.erl:677: :erl_eval.do_apply/6
    (elixir) lib/kernel/parallel_compiler.ex:208: anonymous fn/4 in Kernel.ParallelCompiler.spawn_workers/6
```

The subapp uses `Jason` and `OMG.State.Transaction` but they are missing from `apps/omg_watcher_info/mix.exs` so they're not loaded when the subapp is started individually.

This PR adds `:jason` and `:omg` to the mixfile.

## Testing

Running this is now gives a successful migration response:

```
$ cd apps/omg_watcher_info
$ mix ecto.gen.migration some_new_migration_name
* creating priv/repo/migrations/20200130053905_some_new_migration_name.exs
```