### PR TITLE
fix: solidity install

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,10 +73,10 @@ jobs:
       - run:
           name: Integration Tests
           command: |
-            # Slow, serial integration test, run nightly. Here to make sure the standard `mix test --trace --only integration` works
+            # Slow, serial integration test, run nightly. Here to make sure the standard `mix test --only integration --trace` works
             export SHELL=/bin/bash
             make init_test
-            mix test --trace --only integration
+            mix test --only integration --trace
           no_output_timeout: 30m
   barebuild_macos:
     executor: metal_macos

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -535,6 +535,7 @@ jobs:
             sudo apt-get install --yes --no-install-recommends --no-install-suggests erlang-tools
             sudo apt-get install --yes --no-install-recommends --no-install-suggests elixir=1.8.2-1
             sudo apt policy elixir
+            mix local.hex --force && mix local.rebar --force
             ./bin/setup
           no_output_timeout: 2400
       - run: make install-hex-rebar
@@ -691,8 +692,6 @@ workflows:
     jobs:
       - build
       - integration_tests:
-          requires: [build]
-      - barebuild:
           requires: [build]
       - barebuild_macos:
           requires: [build]

--- a/apps/omg_performance/lib/omg_performance/generators.ex
+++ b/apps/omg_performance/lib/omg_performance/generators.ex
@@ -146,7 +146,7 @@ defmodule OMG.Performance.Generators do
 
   defp poll_get_block(block_hash, child_chain_url, retry) do
     case Client.get_block(block_hash, child_chain_url) do
-      {:ok, block} = result ->
+      {:ok, _block} = result ->
         result
 
       _ ->

--- a/apps/omg_performance/test/omg_performance/byzantine_event_test.exs
+++ b/apps/omg_performance/test/omg_performance/byzantine_event_test.exs
@@ -27,7 +27,7 @@ defmodule OMG.Performance.ByzantineEventsTest do
   @moduletag :integration
   @moduletag timeout: 180_000
 
-  @number_of_transactions_to_send 50
+  @number_of_transactions_to_send 10
 
   # NOTE: still bound to fixtures :(, because of the child chain setup, but this will go eventually, so leaving as is
   deffixture perf_test(contract) do

--- a/apps/omg_performance/test/omg_performance/byzantine_event_test.exs
+++ b/apps/omg_performance/test/omg_performance/byzantine_event_test.exs
@@ -27,7 +27,7 @@ defmodule OMG.Performance.ByzantineEventsTest do
   @moduletag :integration
   @moduletag timeout: 180_000
 
-  @number_of_transactions_to_send 80
+  @number_of_transactions_to_send 50
 
   # NOTE: still bound to fixtures :(, because of the child chain setup, but this will go eventually, so leaving as is
   deffixture perf_test(contract) do

--- a/apps/omg_performance/test/omg_performance/byzantine_event_test.exs
+++ b/apps/omg_performance/test/omg_performance/byzantine_event_test.exs
@@ -27,6 +27,8 @@ defmodule OMG.Performance.ByzantineEventsTest do
   @moduletag :integration
   @moduletag timeout: 180_000
 
+  @number_of_transactions_to_send 80
+
   # NOTE: still bound to fixtures :(, because of the child chain setup, but this will go eventually, so leaving as is
   deffixture perf_test(contract) do
     %{contract_addr: contract_addr} = contract
@@ -40,7 +42,9 @@ defmodule OMG.Performance.ByzantineEventsTest do
     spenders = Generators.generate_users(2)
     alice = Enum.at(spenders, 0)
 
-    :ok = Performance.ExtendedPerftest.start(100, spenders, randomized: false, destdir: destdir)
+    :ok =
+      Performance.ExtendedPerftest.start(@number_of_transactions_to_send, spenders, randomized: false, destdir: destdir)
+
     :ok = ByzantineEvents.watcher_synchronize()
 
     ByzantineEvents.get_exitable_utxos(alice.addr, take: 20)
@@ -52,7 +56,9 @@ defmodule OMG.Performance.ByzantineEventsTest do
     spenders = Generators.generate_users(2)
     alice = Enum.at(spenders, 0)
 
-    :ok = Performance.ExtendedPerftest.start(100, spenders, randomized: false, destdir: destdir)
+    :ok =
+      Performance.ExtendedPerftest.start(@number_of_transactions_to_send, spenders, randomized: false, destdir: destdir)
+
     :ok = ByzantineEvents.watcher_synchronize()
 
     {:ok, %{"status" => "0x1", "blockNumber" => last_exit_height}} =
@@ -70,7 +76,9 @@ defmodule OMG.Performance.ByzantineEventsTest do
     spenders = Generators.generate_users(2)
     alice = Enum.at(spenders, 0)
 
-    :ok = Performance.ExtendedPerftest.start(100, spenders, randomized: true, destdir: destdir)
+    :ok =
+      Performance.ExtendedPerftest.start(@number_of_transactions_to_send, spenders, randomized: true, destdir: destdir)
+
     :ok = ByzantineEvents.watcher_synchronize()
 
     {:ok, %{"status" => "0x1", "blockNumber" => last_exit_height}} =
@@ -88,7 +96,9 @@ defmodule OMG.Performance.ByzantineEventsTest do
     spenders = Generators.generate_users(2)
     alice = Enum.at(spenders, 0)
 
-    :ok = Performance.ExtendedPerftest.start(100, spenders, randomized: true, destdir: destdir)
+    :ok =
+      Performance.ExtendedPerftest.start(@number_of_transactions_to_send, spenders, randomized: true, destdir: destdir)
+
     :ok = ByzantineEvents.watcher_synchronize()
 
     {:ok, %{"status" => "0x1", "blockNumber" => last_exit_height}} =
@@ -112,7 +122,9 @@ defmodule OMG.Performance.ByzantineEventsTest do
     spenders = Generators.generate_users(2)
     alice = Enum.at(spenders, 0)
 
-    :ok = Performance.ExtendedPerftest.start(100, spenders, randomized: true, destdir: destdir)
+    :ok =
+      Performance.ExtendedPerftest.start(@number_of_transactions_to_send, spenders, randomized: true, destdir: destdir)
+
     :ok = ByzantineEvents.watcher_synchronize()
 
     {:ok, %{"status" => "0x1", "blockNumber" => last_exit_height}} =

--- a/apps/omg_watcher_rpc/test/omg_watcher_rpc/web/controllers/transaction_test.exs
+++ b/apps/omg_watcher_rpc/test/omg_watcher_rpc/web/controllers/transaction_test.exs
@@ -54,7 +54,6 @@ defmodule OMG.WatcherRPC.Web.Controller.TransactionTest do
 
     @tag fixtures: [:phoenix_ecto_sandbox]
     test "returns transaction in expected format" do
-<<<<<<< HEAD
       deposit_1 = build(:txoutput) |> with_deposit()
       deposit_2 = build(:txoutput) |> with_deposit()
 
@@ -130,83 +129,6 @@ defmodule OMG.WatcherRPC.Web.Controller.TransactionTest do
       response = WatcherHelper.success?("transaction.get", %{"id" => Encoding.to_hex(spending_transaction.txhash)})
 
       assert response == expected_response
-=======
-      block = insert(:block)
-      input_1 = insert(:txoutput)
-      input_2 = insert(:txoutput)
-      output_1 = insert(:txoutput)
-      output_2 = insert(:txoutput)
-      transaction = insert(:transaction, block: block, inputs: [input_1, input_2], outputs: [output_1, output_2])
-
-      response = WatcherHelper.success?("transaction.get", %{"id" => Encoding.to_hex(transaction.txhash)})
-      # inputs: ^from(txo in DB.TxOutput, order_by: :spending_tx_oindex),
-      # outputs: ^from(txo in DB.TxOutput, order_by: :oindex)
-      inputs = [
-        %{
-          "amount" => input_1.amount,
-          "blknum" => input_1.blknum,
-          "currency" => Encoding.to_hex(input_1.currency),
-          "oindex" => input_1.oindex,
-          "owner" => Encoding.to_hex(input_1.owner),
-          "txindex" => input_1.txindex,
-          "utxo_pos" => Utxo.Position.encode({:utxo_position, input_1.blknum, input_1.txindex, input_1.oindex}),
-          "creating_txhash" => Encoding.to_hex(input_1.creating_txhash),
-          "spending_txhash" => Encoding.to_hex(transaction.txhash)
-        },
-        %{
-          "amount" => input_2.amount,
-          "blknum" => input_2.blknum,
-          "currency" => Encoding.to_hex(input_2.currency),
-          "oindex" => input_2.oindex,
-          "owner" => Encoding.to_hex(input_2.owner),
-          "txindex" => input_2.txindex,
-          "utxo_pos" => Utxo.Position.encode({:utxo_position, input_2.blknum, input_2.txindex, input_2.oindex}),
-          "creating_txhash" => Encoding.to_hex(input_2.creating_txhash),
-          "spending_txhash" => Encoding.to_hex(transaction.txhash)
-        }
-      ]
-
-      outputs = [
-        %{
-          "amount" => output_1.amount,
-          "blknum" => output_1.blknum,
-          "currency" => Encoding.to_hex(output_1.currency),
-          "oindex" => output_1.oindex,
-          "owner" => Encoding.to_hex(output_1.owner),
-          "txindex" => output_1.txindex,
-          "utxo_pos" => Utxo.Position.encode({:utxo_position, output_1.blknum, output_1.txindex, output_1.oindex}),
-          "creating_txhash" => Encoding.to_hex(transaction.txhash),
-          "spending_txhash" => nil
-        },
-        %{
-          "amount" => output_2.amount,
-          "blknum" => output_2.blknum,
-          "currency" => Encoding.to_hex(output_2.currency),
-          "oindex" => output_2.oindex,
-          "owner" => Encoding.to_hex(output_2.owner),
-          "txindex" => output_2.txindex,
-          "utxo_pos" => Utxo.Position.encode({:utxo_position, output_2.blknum, output_2.txindex, output_2.oindex}),
-          "creating_txhash" => Encoding.to_hex(transaction.txhash),
-          "spending_txhash" => nil
-        }
-      ]
-
-      assert response == %{
-               "block" => %{
-                 "blknum" => block.blknum,
-                 "eth_height" => block.eth_height,
-                 "hash" => Encoding.to_hex(block.hash),
-                 "timestamp" => block.timestamp,
-                 "tx_count" => 1
-               },
-               "inputs" => Enum.sort_by(inputs, fn input -> input["utxo_pos"] end),
-               "outputs" => Enum.sort_by(outputs, fn output -> output["utxo_pos"] end),
-               "txhash" => Encoding.to_hex(transaction.txhash),
-               "txbytes" => Encoding.to_hex(transaction.txbytes),
-               "txindex" => transaction.txindex,
-               "metadata" => Encoding.to_hex(transaction.metadata)
-             }
->>>>>>> fix: ordering of inputs and outputs
     end
 
     @tag fixtures: [:blocks_inserter, :initial_deposits, :alice, :bob]

--- a/apps/omg_watcher_rpc/test/omg_watcher_rpc/web/controllers/transaction_test.exs
+++ b/apps/omg_watcher_rpc/test/omg_watcher_rpc/web/controllers/transaction_test.exs
@@ -199,8 +199,8 @@ defmodule OMG.WatcherRPC.Web.Controller.TransactionTest do
                  "timestamp" => block.timestamp,
                  "tx_count" => 1
                },
-               "inputs" => Enum.sort_by(inputs, fn input -> input["utxo_pos"] end, &>=/2),
-               "outputs" => Enum.sort_by(outputs, fn output -> output["utxo_pos"] end, &>=/2),
+               "inputs" => Enum.sort_by(inputs, fn input -> input["utxo_pos"] end),
+               "outputs" => Enum.sort_by(outputs, fn output -> output["utxo_pos"] end),
                "txhash" => Encoding.to_hex(transaction.txhash),
                "txbytes" => Encoding.to_hex(transaction.txbytes),
                "txindex" => transaction.txindex,

--- a/apps/omg_watcher_rpc/test/omg_watcher_rpc/web/controllers/transaction_test.exs
+++ b/apps/omg_watcher_rpc/test/omg_watcher_rpc/web/controllers/transaction_test.exs
@@ -14,12 +14,12 @@
 
 defmodule OMG.WatcherRPC.Web.Controller.TransactionTest do
   use ExUnitFixtures
-  use ExUnit.Case, async: false
+  use ExUnit.Case, async: true
   use OMG.Fixtures
   use OMG.WatcherInfo.Fixtures
   use OMG.Watcher.Fixtures
 
-  import OMG.WatcherInfo.Factory, only: [insert: 1, insert: 2]
+  import OMG.WatcherInfo.Factory, only: [build: 1, with_deposit: 1, insert: 1, with_inputs: 2, with_outputs: 2]
 
   alias OMG.State.Transaction
   alias OMG.TestHelper, as: Test
@@ -54,8 +54,8 @@ defmodule OMG.WatcherRPC.Web.Controller.TransactionTest do
 
     @tag fixtures: [:phoenix_ecto_sandbox]
     test "returns transaction in expected format" do
-      deposit_1 = build(:txoutput) |> with_deposit()
-      deposit_2 = build(:txoutput) |> with_deposit()
+      deposit_1 = with_deposit(build(:txoutput))
+      deposit_2 = with_deposit(build(:txoutput))
 
       input_1 = build(:txoutput)
       input_2 = build(:txoutput)
@@ -153,7 +153,7 @@ defmodule OMG.WatcherRPC.Web.Controller.TransactionTest do
            ]}
         ])
 
-      txhash = txhash |> Encoding.to_hex()
+      txhash = Encoding.to_hex(txhash)
 
       assert %{
                "inputs" => [%{"amount" => 10}, %{"amount" => 20}, %{"amount" => 30}, %{"amount" => 40}],
@@ -165,7 +165,7 @@ defmodule OMG.WatcherRPC.Web.Controller.TransactionTest do
 
     @tag fixtures: [:phoenix_ecto_sandbox]
     test "returns error for non existing transaction" do
-      txhash = <<0::256>> |> Encoding.to_hex()
+      txhash = Encoding.to_hex(<<0::256>>)
 
       assert %{
                "object" => "error",
@@ -196,8 +196,8 @@ defmodule OMG.WatcherRPC.Web.Controller.TransactionTest do
       {blknum, txindex, txhash, _recovered_tx} = initial_blocks |> Enum.reverse() |> hd()
 
       %DB.Block{timestamp: timestamp, eth_height: eth_height, hash: block_hash} = get_block(blknum)
-      txhash = txhash |> Encoding.to_hex()
-      block_hash = block_hash |> Encoding.to_hex()
+      txhash = Encoding.to_hex(txhash)
+      block_hash = Encoding.to_hex(block_hash)
 
       assert [
                %{
@@ -277,7 +277,7 @@ defmodule OMG.WatcherRPC.Web.Controller.TransactionTest do
          ]}
       ])
 
-      address = bob.addr |> Encoding.to_hex()
+      address = Encoding.to_hex(bob.addr)
 
       assert [%{"block" => %{"blknum" => 2000}, "txindex" => 1}] =
                transaction_all_result(%{"address" => address, "blknum" => 2000})
@@ -296,7 +296,7 @@ defmodule OMG.WatcherRPC.Web.Controller.TransactionTest do
          ]}
       ])
 
-      address = alice.addr |> Encoding.to_hex()
+      address = Encoding.to_hex(alice.addr)
 
       assert [%{"block" => %{"blknum" => 1000}, "txindex" => 0}] = transaction_all_result(%{"address" => address})
     end
@@ -317,8 +317,8 @@ defmodule OMG.WatcherRPC.Web.Controller.TransactionTest do
          ]}
       ])
 
-      alice_addr = alice.addr |> Encoding.to_hex()
-      carol_addr = carol.addr |> Encoding.to_hex()
+      alice_addr = Encoding.to_hex(alice.addr)
+      carol_addr = Encoding.to_hex(carol.addr)
 
       assert [%{"block" => %{"blknum" => 1000}, "txindex" => 2}, %{"block" => %{"blknum" => 1000}, "txindex" => 0}] =
                transaction_all_result(%{"address" => alice_addr})
@@ -339,7 +339,7 @@ defmodule OMG.WatcherRPC.Web.Controller.TransactionTest do
          ]}
       ])
 
-      address = alice.addr |> Encoding.to_hex()
+      address = Encoding.to_hex(alice.addr)
 
       assert [%{"block" => %{"blknum" => 1000}, "txindex" => 0}] = transaction_all_result(%{"address" => address})
     end
@@ -356,7 +356,7 @@ defmodule OMG.WatcherRPC.Web.Controller.TransactionTest do
          ]}
       ])
 
-      address = alice.addr |> Encoding.to_hex()
+      address = Encoding.to_hex(alice.addr)
 
       assert [%{"block" => %{"blknum" => 1000}, "txindex" => 0}] = transaction_all_result(%{"address" => address})
     end
@@ -373,16 +373,16 @@ defmodule OMG.WatcherRPC.Web.Controller.TransactionTest do
          ]}
       ])
 
-      address = alice.addr |> Encoding.to_hex()
+      address = Encoding.to_hex(alice.addr)
 
       assert [%{"block" => %{"blknum" => 1000}, "txindex" => 0}] = transaction_all_result(%{"address" => address})
     end
 
     @tag fixtures: [:initial_blocks]
     test "returns transactions containing metadata", %{initial_blocks: initial_blocks} do
-      {blknum, txindex, txhash, recovered_tx} = initial_blocks |> Enum.find(&match?({2000, 0, _, _}, &1))
+      {blknum, txindex, txhash, recovered_tx} = Enum.find(initial_blocks, &match?({2000, 0, _, _}, &1))
 
-      expected_metadata = recovered_tx.signed_tx.raw_tx.metadata |> Encoding.to_hex()
+      expected_metadata = Encoding.to_hex(recovered_tx.signed_tx.raw_tx.metadata)
       expected_txhash = Encoding.to_hex(txhash)
 
       assert [
@@ -440,7 +440,7 @@ defmodule OMG.WatcherRPC.Web.Controller.TransactionTest do
          ]}
       ])
 
-      alice_addr = alice.addr |> Encoding.to_hex()
+      alice_addr = Encoding.to_hex(alice.addr)
 
       assert {
                [%{"block" => %{"blknum" => 2000}, "txindex" => 0}, %{"block" => %{"blknum" => 1000}, "txindex" => 1}],
@@ -450,7 +450,7 @@ defmodule OMG.WatcherRPC.Web.Controller.TransactionTest do
       assert {[%{"block" => %{"blknum" => 2000}, "txindex" => 0}, %{"block" => %{"blknum" => 1000}, "txindex" => 0}],
               %{"limit" => 2, "page" => 1}} = transaction_all_with_paging(%{address: alice_addr, limit: 2})
 
-      bob_addr = bob.addr |> Encoding.to_hex()
+      bob_addr = Encoding.to_hex(bob.addr)
 
       assert {[%{"block" => %{"blknum" => 1000}, "txindex" => 0}], %{"limit" => 2, "page" => 2}} =
                transaction_all_with_paging(%{address: bob_addr, limit: 2, page: 2})
@@ -589,7 +589,7 @@ defmodule OMG.WatcherRPC.Web.Controller.TransactionTest do
           "output3" => %{"owner" => @eth_hex, "currency" => @eth_hex, "amount" => 0},
           "metadata" => Encoding.to_hex(<<0::256>>)
         },
-        "signatures" => List.duplicate(<<127::520>>, 2) |> Enum.map(&Encoding.to_hex/1)
+        "signatures" => <<127::520>> |> List.duplicate(2) |> Enum.map(&Encoding.to_hex/1)
       }
     end
 
@@ -641,9 +641,7 @@ defmodule OMG.WatcherRPC.Web.Controller.TransactionTest do
     @tag fixtures: [:phoenix_ecto_sandbox, :typed_data_request]
     test "input & sigs count should match", %{typed_data_request: typed_data_request} do
       # Providing 2 non-zero inputs & 1 signature
-      too_little_sigs =
-        typed_data_request
-        |> Map.update!("signatures", fn sigs -> Enum.take(sigs, 1) end)
+      too_little_sigs = Map.update!(typed_data_request, "signatures", fn sigs -> Enum.take(sigs, 1) end)
 
       assert %{
                "code" => "submit_typed:missing_signature",
@@ -654,9 +652,7 @@ defmodule OMG.WatcherRPC.Web.Controller.TransactionTest do
              } == WatcherHelper.no_success?("transaction.submit_typed", too_little_sigs)
 
       # Providing 2 non-zero inputs & 4 signatures
-      too_many_sigs =
-        typed_data_request
-        |> Map.update!("signatures", fn sigs -> sigs ++ sigs end)
+      too_many_sigs = Map.update!(typed_data_request, "signatures", fn sigs -> sigs ++ sigs end)
 
       assert %{
                "code" => "submit_typed:superfluous_signature",
@@ -690,7 +686,7 @@ defmodule OMG.WatcherRPC.Web.Controller.TransactionTest do
       ]
     }
     deffixture more_utxos(alice, blocks_inserter) do
-      [
+      blocks_inserter.([
         {5000,
          [
            Test.create_recovered([], @eth, [{alice, 40}, {alice, 42}, {alice, 43}, {alice, 44}]),
@@ -698,8 +694,7 @@ defmodule OMG.WatcherRPC.Web.Controller.TransactionTest do
            Test.create_recovered([], @other_token, [{alice, 5}, {alice, 110}, {alice, 15}]),
            Test.create_recovered([], @other_token, [{alice, 105}, {alice, 10}, {alice, 115}])
          ]}
-      ]
-      |> blocks_inserter.()
+      ])
     end
 
     @tag fixtures: [:alice, :bob, :more_utxos]
@@ -755,7 +750,7 @@ defmodule OMG.WatcherRPC.Web.Controller.TransactionTest do
                  }
                )
 
-      assert Utxo.position(blknum, txindex, oindex) |> Utxo.Position.encode() == utxo_pos
+      assert Utxo.Position.encode(Utxo.position(blknum, txindex, oindex)) == utxo_pos
     end
 
     @tag fixtures: [:alice, :bob, :more_utxos]
@@ -792,8 +787,8 @@ defmodule OMG.WatcherRPC.Web.Controller.TransactionTest do
 
       verbose_tx =
         Transaction.Payment.new(
-          verbose_inputs |> Enum.map(&{&1["blknum"], &1["txindex"], &1["oindex"]}),
-          verbose_outputs |> Enum.map(&{from_hex!(&1["owner"]), from_hex!(&1["currency"]), &1["amount"]}),
+          Enum.map(verbose_inputs, &{&1["blknum"], &1["txindex"], &1["oindex"]}),
+          Enum.map(verbose_outputs, &{from_hex!(&1["owner"]), from_hex!(&1["currency"]), &1["amount"]}),
           from_hex!(verbose_metadata)
         )
 
@@ -1242,7 +1237,8 @@ defmodule OMG.WatcherRPC.Web.Controller.TransactionTest do
     defp max_amount_spendable_in_single_tx(address, token) do
       currency = Encoding.to_hex(token)
 
-      WatcherHelper.get_utxos(address)
+      address
+      |> WatcherHelper.get_utxos()
       |> Stream.filter(&(&1["currency"] == currency))
       |> Enum.sort_by(& &1["amount"], &>=/2)
       |> Stream.take(Transaction.Payment.max_inputs())
@@ -1255,8 +1251,7 @@ defmodule OMG.WatcherRPC.Web.Controller.TransactionTest do
       alias OMG.State.Transaction
 
       recovered_txs =
-        txs_bytes
-        |> Enum.map(fn "0x" <> tx ->
+        Enum.map(txs_bytes, fn "0x" <> tx ->
           raw_tx = tx |> Base.decode16!(case: :lower) |> Transaction.decode!()
           n_inputs = raw_tx |> Transaction.get_inputs() |> length
 
@@ -1266,7 +1261,7 @@ defmodule OMG.WatcherRPC.Web.Controller.TransactionTest do
           |> Transaction.Recovered.recover_from!()
         end)
 
-      [{blknum, recovered_txs}] |> blocks_inserter.()
+      blocks_inserter.([{blknum, recovered_txs}])
     end
 
     defp prepare_test_server(context, response) do

--- a/apps/omg_watcher_rpc/test/omg_watcher_rpc/web/controllers/transaction_test.exs
+++ b/apps/omg_watcher_rpc/test/omg_watcher_rpc/web/controllers/transaction_test.exs
@@ -54,6 +54,7 @@ defmodule OMG.WatcherRPC.Web.Controller.TransactionTest do
 
     @tag fixtures: [:phoenix_ecto_sandbox]
     test "returns transaction in expected format" do
+<<<<<<< HEAD
       deposit_1 = build(:txoutput) |> with_deposit()
       deposit_2 = build(:txoutput) |> with_deposit()
 
@@ -129,6 +130,83 @@ defmodule OMG.WatcherRPC.Web.Controller.TransactionTest do
       response = WatcherHelper.success?("transaction.get", %{"id" => Encoding.to_hex(spending_transaction.txhash)})
 
       assert response == expected_response
+=======
+      block = insert(:block)
+      input_1 = insert(:txoutput)
+      input_2 = insert(:txoutput)
+      output_1 = insert(:txoutput)
+      output_2 = insert(:txoutput)
+      transaction = insert(:transaction, block: block, inputs: [input_1, input_2], outputs: [output_1, output_2])
+
+      response = WatcherHelper.success?("transaction.get", %{"id" => Encoding.to_hex(transaction.txhash)})
+      # inputs: ^from(txo in DB.TxOutput, order_by: :spending_tx_oindex),
+      # outputs: ^from(txo in DB.TxOutput, order_by: :oindex)
+      inputs = [
+        %{
+          "amount" => input_1.amount,
+          "blknum" => input_1.blknum,
+          "currency" => Encoding.to_hex(input_1.currency),
+          "oindex" => input_1.oindex,
+          "owner" => Encoding.to_hex(input_1.owner),
+          "txindex" => input_1.txindex,
+          "utxo_pos" => Utxo.Position.encode({:utxo_position, input_1.blknum, input_1.txindex, input_1.oindex}),
+          "creating_txhash" => Encoding.to_hex(input_1.creating_txhash),
+          "spending_txhash" => Encoding.to_hex(transaction.txhash)
+        },
+        %{
+          "amount" => input_2.amount,
+          "blknum" => input_2.blknum,
+          "currency" => Encoding.to_hex(input_2.currency),
+          "oindex" => input_2.oindex,
+          "owner" => Encoding.to_hex(input_2.owner),
+          "txindex" => input_2.txindex,
+          "utxo_pos" => Utxo.Position.encode({:utxo_position, input_2.blknum, input_2.txindex, input_2.oindex}),
+          "creating_txhash" => Encoding.to_hex(input_2.creating_txhash),
+          "spending_txhash" => Encoding.to_hex(transaction.txhash)
+        }
+      ]
+
+      outputs = [
+        %{
+          "amount" => output_1.amount,
+          "blknum" => output_1.blknum,
+          "currency" => Encoding.to_hex(output_1.currency),
+          "oindex" => output_1.oindex,
+          "owner" => Encoding.to_hex(output_1.owner),
+          "txindex" => output_1.txindex,
+          "utxo_pos" => Utxo.Position.encode({:utxo_position, output_1.blknum, output_1.txindex, output_1.oindex}),
+          "creating_txhash" => Encoding.to_hex(transaction.txhash),
+          "spending_txhash" => nil
+        },
+        %{
+          "amount" => output_2.amount,
+          "blknum" => output_2.blknum,
+          "currency" => Encoding.to_hex(output_2.currency),
+          "oindex" => output_2.oindex,
+          "owner" => Encoding.to_hex(output_2.owner),
+          "txindex" => output_2.txindex,
+          "utxo_pos" => Utxo.Position.encode({:utxo_position, output_2.blknum, output_2.txindex, output_2.oindex}),
+          "creating_txhash" => Encoding.to_hex(transaction.txhash),
+          "spending_txhash" => nil
+        }
+      ]
+
+      assert response == %{
+               "block" => %{
+                 "blknum" => block.blknum,
+                 "eth_height" => block.eth_height,
+                 "hash" => Encoding.to_hex(block.hash),
+                 "timestamp" => block.timestamp,
+                 "tx_count" => 1
+               },
+               "inputs" => Enum.sort_by(inputs, fn input -> input["utxo_pos"] end, &>=/2),
+               "outputs" => Enum.sort_by(outputs, fn output -> output["utxo_pos"] end, &>=/2),
+               "txhash" => Encoding.to_hex(transaction.txhash),
+               "txbytes" => Encoding.to_hex(transaction.txbytes),
+               "txindex" => transaction.txindex,
+               "metadata" => Encoding.to_hex(transaction.metadata)
+             }
+>>>>>>> fix: ordering of inputs and outputs
     end
 
     @tag fixtures: [:blocks_inserter, :initial_deposits, :alice, :bob]

--- a/apps/omg_watcher_rpc/test/omg_watcher_rpc/web/controllers/transaction_test.exs
+++ b/apps/omg_watcher_rpc/test/omg_watcher_rpc/web/controllers/transaction_test.exs
@@ -19,7 +19,7 @@ defmodule OMG.WatcherRPC.Web.Controller.TransactionTest do
   use OMG.WatcherInfo.Fixtures
   use OMG.Watcher.Fixtures
 
-  import OMG.WatcherInfo.Factory
+  import OMG.WatcherInfo.Factory, only: [insert: 1, insert: 2]
 
   alias OMG.State.Transaction
   alias OMG.TestHelper, as: Test

--- a/bin/setup
+++ b/bin/setup
@@ -84,8 +84,6 @@ brew "cmake"
 brew "rocksdb"
 brew "wget"
 EOF
-    # Pins solidity to 0.5.11
-    brew  install "https://raw.githubusercontent.com/ethereum/homebrew-ethereum/7fa7027f20cca27f76c679d0c5b35ee3c565f284/solidity.rb" || true
 }
 
 install_deps() {

--- a/bin/setup
+++ b/bin/setup
@@ -83,9 +83,10 @@ brew "libtool"
 brew "cmake"
 brew "rocksdb"
 brew "wget"
-# Pins solidity to 0.5.11
-brew "https://raw.githubusercontent.com/ethereum/homebrew-ethereum/7fa7027f20cca27f76c679d0c5b35ee3c565f284/solidity.rb"
 EOF
+    # Pins solidity to 0.5.11
+    brew  install "https://raw.githubusercontent.com/ethereum/homebrew-ethereum/7fa7027f20cca27f76c679d0c5b35ee3c565f284/solidity.rb"
+
 }
 
 install_deps() {

--- a/bin/setup
+++ b/bin/setup
@@ -85,8 +85,7 @@ brew "rocksdb"
 brew "wget"
 EOF
     # Pins solidity to 0.5.11
-    brew  install "https://raw.githubusercontent.com/ethereum/homebrew-ethereum/7fa7027f20cca27f76c679d0c5b35ee3c565f284/solidity.rb"
-
+    brew  install "https://raw.githubusercontent.com/ethereum/homebrew-ethereum/7fa7027f20cca27f76c679d0c5b35ee3c565f284/solidity.rb" || true
 }
 
 install_deps() {


### PR DESCRIPTION
Fixing nightly builds and moving them to main build but they're not mandatory for merge.
This way they're easier to observe when they get broken by PRs.


## Overview

Mac build and barebone build fixes

## Changes

- Input and ouput sort as per DB query
- Install Solidity 5.11 via RB url 

## Testing
Tests were already failing. Hopefully they'll pass now.
