### PR TITLE
Add support for Görli testnet

### DIFF
--- a/apps/omg_eth/lib/omg_eth/release_tasks/set_contract.ex
+++ b/apps/omg_eth/lib/omg_eth/release_tasks/set_contract.ex
@@ -21,7 +21,7 @@ defmodule OMG.Eth.ReleaseTasks.SetContract do
   alias OMG.Eth.Encoding
 
   @app :omg_eth
-  @error "Set ETHEREUM_NETWORK to RINKEBY, ROPSTEN, MAINNET, or LOCALCHAIN with TXHASH_CONTRACT, AUTHORITY_ADDRESS and CONTRACT_ADDRESS environment variables or CONTRACT_EXCHANGER_URL."
+  @error "Set ETHEREUM_NETWORK to RINKEBY, ROPSTEN, GOERLI, MAINNET, or LOCALCHAIN with TXHASH_CONTRACT, AUTHORITY_ADDRESS and CONTRACT_ADDRESS environment variables or CONTRACT_EXCHANGER_URL."
 
   @doc """
   The contract values can currently come either from ENV variables for deployments in
@@ -90,6 +90,9 @@ defmodule OMG.Eth.ReleaseTasks.SetContract do
           network
 
         "ROPSTEN" = network ->
+          network
+
+        "GOERLI" = network ->
           network
 
         "MAINNET" = network ->


### PR DESCRIPTION
## Overview

Add support for the Görli Testnet

## Changes

Currently elixir-omg supports Ropsten and Rinkeby testnets. This PR adds support for the Görli testnet (https://goerli.net/). This is a simple change that allows the `ETHEREUM_NETWORK` env var to have `GOERLI` as a value.

## Testing

Childchain and Watcher should be able to start with `ETHEREUM_NETWORK` set to `GOERLI`. The smart contracts are already deployed on the testnet.