### PR TITLE
refactor: clean up circleci config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,21 +47,6 @@ executors:
       - image: omisegoimages/elixir-omg-deploy:stable-20191024
     working_directory: ~/src
 
-  metal_child_chain:
-    machine: true
-    environment:
-      CHILD_CHAIN_IMAGE_NAME: "omisego/child_chain"
-
-  metal_watcher:
-    machine: true
-    environment:
-      WATCHER_IMAGE_NAME: "omisego/watcher"
-
-  metal_watcher_info:
-    machine: true
-    environment:
-      WATCHER_INFO_IMAGE_NAME: "omisego/watcher_info"
-
 commands:
   setup_elixir-omg_workspace:
     description: "Setup workspace"
@@ -224,7 +209,7 @@ jobs:
               mix coveralls.html --parallel --umbrella --include child_chain --exclude watcher --exclude watcher_info --exclude common --exclude test --trace
             else
               mix coveralls.circle --parallel --umbrella --include child_chain --exclude watcher --exclude watcher_info --exclude common --exclude test --trace ||
-                # if mix failed, then coveralls_merge won't run, so signal done here and return original exit status
+                # if mix failed, then coveralls_report won't run, so signal done here and return original exit status
                 (retval=$? && curl -k https://coveralls.io/webhook?repo_token=$COVERALLS_REPO_TOKEN -d "payload[build_num]=$CIRCLE_WORKFLOW_WORKSPACE_ID&payload[status]=done" && exit $retval)
             fi
 
@@ -250,7 +235,7 @@ jobs:
               mix coveralls.html --parallel --umbrella --include watcher --exclude watcher_info --exclude child_chain --exclude common --exclude test --trace
             else
               mix coveralls.circle --parallel --umbrella --include watcher --exclude watcher_info --exclude child_chain --exclude common --exclude test --trace ||
-                # if mix failed, then coveralls_merge won't run, so signal done here and return original exit status
+                # if mix failed, then coveralls_report won't run, so signal done here and return original exit status
                 (retval=$? && curl -k https://coveralls.io/webhook?repo_token=$COVERALLS_REPO_TOKEN -d "payload[build_num]=$CIRCLE_WORKFLOW_WORKSPACE_ID&payload[status]=done" && exit $retval)
             fi
 
@@ -275,7 +260,7 @@ jobs:
               mix coveralls.html --parallel --umbrella --include watcher_info --exclude watcher --exclude child_chain --exclude common --exclude test --trace
             else
               mix coveralls.circle --parallel --umbrella --include watcher_info --exclude watcher --exclude child_chain --exclude common --exclude test --trace ||
-                # if mix failed, then coveralls_merge won't run, so signal done here and return original exit status
+                # if mix failed, then coveralls_report won't run, so signal done here and return original exit status
                 (retval=$? && curl -k https://coveralls.io/webhook?repo_token=$COVERALLS_REPO_TOKEN -d "payload[build_num]=$CIRCLE_WORKFLOW_WORKSPACE_ID&payload[status]=done" && exit $retval)
             fi
 
@@ -301,7 +286,7 @@ jobs:
               mix coveralls.html --parallel --umbrella --include common --exclude watcher --exclude watcher_info --exclude child_chain --exclude test --trace
             else
               mix coveralls.circle --parallel --umbrella --include common --exclude watcher --exclude watcher_info --exclude child_chain --exclude test --trace ||
-                # if mix failed, then coveralls_merge won't run, so signal done here and return original exit status
+                # if mix failed, then coveralls_report won't run, so signal done here and return original exit status
                 (retval=$? && curl -k https://coveralls.io/webhook?repo_token=$COVERALLS_REPO_TOKEN -d "payload[build_num]=$CIRCLE_WORKFLOW_WORKSPACE_ID&payload[status]=done" && exit $retval)
             fi
 
@@ -327,7 +312,7 @@ jobs:
               mix coveralls.html --parallel --umbrella --trace
             else
               mix coveralls.circle --parallel --umbrella --trace ||
-                # if mix failed, then coveralls_merge won't run, so signal done here and return original exit status
+                # if mix failed, then coveralls_report won't run, so signal done here and return original exit status
                 (retval=$? && curl -k https://coveralls.io/webhook?repo_token=$COVERALLS_REPO_TOKEN -d "payload[build_num]=$CIRCLE_WORKFLOW_WORKSPACE_ID&payload[status]=done" && exit $retval)
             fi
 
@@ -416,13 +401,16 @@ jobs:
       - run: make docker-child_chain
       - run: make docker-watcher
       - run: make docker-watcher_info
-      - run: 
-          name: Run specs
+      - run:
+          name: Start daemon services
           command: |
             cd priv/
             make start_daemon_services
-      - run: docker image ls
-      - run: docker-compose ps
+      - run:
+          name: Print docker states
+          command: |
+            docker image ls
+            docker-compose ps
       - run:
           name: Install Erlang and Elixir
           command: |
@@ -527,10 +515,13 @@ jobs:
             make generate_api_code
             mix local.hex --force && mix local.rebar --force
             mix deps.get
-      - run: docker ps
-      - run: ps axww | grep watcher
-      - run: ps axww | grep watcher_info
-      - run: ps axww | grep child_chain
+      - run:
+          name: Print docker and process states
+          command: |
+            docker ps
+            ps axww | grep watcher
+            ps axww | grep watcher_info
+            ps axww | grep child_chain
       - run: sh .circleci/status.sh
       - run:
           name: Run specs
@@ -539,21 +530,27 @@ jobs:
             mix test
 
   publish_child_chain:
-    executor: metal_child_chain
+    executor: machine
+    environment:
+      CHILD_CHAIN_IMAGE_NAME: "omisego/child_chain"
     steps:
       - checkout
       - run: make docker-child_chain CHILD_CHAIN_IMAGE_NAME=$CHILD_CHAIN_IMAGE_NAME
       - run: IMAGE_NAME=$CHILD_CHAIN_IMAGE_NAME sh .circleci/ci_publish.sh
 
   publish_watcher:
-    executor: metal_watcher
+    executor: machine
+    environment:
+      WATCHER_IMAGE_NAME: "omisego/watcher"
     steps:
       - checkout
       - run: make docker-watcher WATCHER_IMAGE_NAME=$WATCHER_IMAGE_NAME
       - run: IMAGE_NAME=$WATCHER_IMAGE_NAME sh .circleci/ci_publish.sh
 
   publish_watcher_info:
-    executor: metal_watcher_info
+    executor: machine
+    environment:
+      WATCHER_INFO_IMAGE_NAME: "omisego/watcher_info"
     steps:
       - checkout
       - run: make docker-watcher_info WATCHER_INFO_IMAGE_NAME=$WATCHER_INFO_IMAGE_NAME
@@ -577,7 +574,7 @@ jobs:
       - checkout
       - run: DEPLOY=watcher_info sh .circleci/ci_deploy.sh
 
-  coveralls_merge:
+  coveralls_report:
     docker:
       # Ensure .tool-versions matches
       - image: omisegoimages/elixir-omg-circleci:v1.8-20190129-02
@@ -628,46 +625,6 @@ jobs:
               ] \
             }" ${SLACK_WEBHOOK}
 
-  build_and_deploy_staging:
-    docker:
-      - image: ubuntu:16.04
-    working_directory: ~/repo
-    steps:
-      - setup_remote_docker
-      - checkout
-      - run:
-          name: Install dependencies
-          command: |
-            apt-get update && apt-get install -y lsb-release curl cmake
-            curl -sSL https://get.docker.com/ > docker.sh && chmod +x docker.sh && ./docker.sh
-      - run:
-          name: Install gcloud SDK
-          command: |
-            export CLOUD_SDK_REPO="cloud-sdk-$(lsb_release -c -s)"
-            echo "deb http://packages.cloud.google.com/apt $CLOUD_SDK_REPO main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
-            curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
-            apt-get update -y && apt-get install -y google-cloud-sdk kubectl
-      - run:
-          name: Initialise & authenticate gcloud SDK
-          command: |
-            echo "${GCP_KEY_FILE}" | base64 --decode >> /tmp/gcp_key.json
-            gcloud auth activate-service-account --key-file /tmp/gcp_key.json
-            gcloud config set project ${GCP_ACCOUNT_ID}
-            gcloud config set compute/zone ${GCP_ZONE}
-            gcloud container clusters get-credentials ${GCP_CLUSTER_STAGING}
-      - run:
-          name: Build & Deploy Services
-          command: |
-            docker build -t elixir-omg .
-            echo $DOCKER_PWD | docker login -u $DOCKER_LOGIN --password-stdin
-            export DOCKER_IMAGE=jakebunce/elixir-omg:$CIRCLE_SHA1
-            docker tag elixir-omg $DOCKER_IMAGE
-            docker push jakebunce/elixir-omg:$CIRCLE_SHA1
-            kubectl set image statefulset childchain childchain=$DOCKER_IMAGE
-            while true; do if [ "$(kubectl get pods childchain-0 -o jsonpath=\"{.status.phase}\" | grep Running)" ]; then break; fi; done
-            kubectl set image statefulset watcher watcher=$DOCKER_IMAGE
-            kubectl set image statefulset watcher_info watcher_info=$DOCKER_IMAGE
-
 workflows:
   version: 2
   nightly:
@@ -699,7 +656,7 @@ workflows:
             branches:
               only:
                 - master
-      - coveralls_merge:
+      - coveralls_report:
           requires:
             - child_chain_coveralls_and_integration_tests
             - watcher_coveralls_and_integration_tests
@@ -726,22 +683,6 @@ workflows:
           requires: [build]
       - property_tests:
           requires: [build]
-      - build_and_deploy_staging:
-          requires:
-            - build
-            - lint
-            - sobelow
-            - dialyzer
-            - test
-            - child_chain_coveralls_and_integration_tests
-            - watcher_coveralls_and_integration_tests
-            - watcher_info_coveralls_and_integration_tests
-            - common_coveralls_and_integration_tests
-            - property_tests
-          filters:
-            branches:
-              only:
-                - v0.1
       # Publish in case of master branch.
       - publish_child_chain:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -494,7 +494,8 @@ jobs:
           name: Compile
           command: |
             set -e
-            make deps-elixir-omg &&
+            mix local.hex --force && mix local.rebar --force
+            make deps-elixir-omg
             mix compile
           no_output_timeout: 2400
       - run:
@@ -512,7 +513,6 @@ jobs:
             cd priv/
             make install
             make generate_api_code
-            mix local.hex --force && mix local.rebar --force
             mix deps.get
       - run:
           name: Print docker and process states

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -164,7 +164,6 @@ jobs:
       MIX_ENV: test
     steps:
       - setup_elixir-omg_workspace
-      - run: make init_test
       - run: mix do local.hex --force, local.rebar --force, compile --warnings-as-errors --force, credo, format --check-formatted --dry-run
 
   sobelow:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,7 @@ executors:
           POSTGRES_DB: omisego_test
     working_directory: ~/src
 
-  deploy:
+  deployer:
     docker:
       - image: omisegoimages/elixir-omg-deploy:stable-20191024
     working_directory: ~/src
@@ -560,19 +560,19 @@ jobs:
       - run: IMAGE_NAME=$WATCHER_INFO_IMAGE_NAME sh .circleci/ci_publish.sh
 
   deploy_child_chain:
-    executor: deploy
+    executor: deployer
     steps:
       - checkout
       - run: DEPLOY=child_chain sh .circleci/ci_deploy.sh
 
   deploy_watcher:
-    executor: deploy
+    executor: deployer
     steps:
       - checkout
       - run: DEPLOY=watcher sh .circleci/ci_deploy.sh
 
   deploy_watcher_info:
-    executor: deploy
+    executor: deployer
     steps:
       - checkout
       - run: DEPLOY=watcher_info sh .circleci/ci_deploy.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -159,13 +159,13 @@ jobs:
             - contract_addresses_template.env
 
   lint:
-    executor: builder_pg
+    executor: builder
     environment:
       MIX_ENV: test
     steps:
       - setup_elixir-omg_workspace
       - run: make init_test
-      - run: mix do local.hex --force, local.rebar --force, compile --warnings-as-errors --force, ecto.create, ecto.migrate, test --exclude test, credo, format --check-formatted --dry-run
+      - run: mix do local.hex --force, local.rebar --force, compile --warnings-as-errors --force, credo, format --check-formatted --dry-run
 
   sobelow:
     executor: builder_pg

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -530,7 +530,8 @@ jobs:
             mix test
 
   publish_child_chain:
-    executor: machine
+    machine:
+      image: ubuntu-1604:201903-01
     environment:
       CHILD_CHAIN_IMAGE_NAME: "omisego/child_chain"
     steps:
@@ -539,7 +540,8 @@ jobs:
       - run: IMAGE_NAME=$CHILD_CHAIN_IMAGE_NAME sh .circleci/ci_publish.sh
 
   publish_watcher:
-    executor: machine
+    machine:
+      image: ubuntu-1604:201903-01
     environment:
       WATCHER_IMAGE_NAME: "omisego/watcher"
     steps:
@@ -548,7 +550,8 @@ jobs:
       - run: IMAGE_NAME=$WATCHER_IMAGE_NAME sh .circleci/ci_publish.sh
 
   publish_watcher_info:
-    executor: machine
+    machine:
+      image: ubuntu-1604:201903-01
     environment:
       WATCHER_INFO_IMAGE_NAME: "omisego/watcher_info"
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -578,11 +578,9 @@ jobs:
 
   coveralls_report:
     docker:
-      # Ensure .tool-versions matches
       - image: omisegoimages/elixir-omg-circleci:v1.8-20190129-02
         environment:
           MIX_ENV: test
-
     steps:
       - run:
           name: Tell coveralls.io build is done
@@ -647,7 +645,7 @@ workflows:
           requires: [build]
       - test_barebone_release:
           requires: [build]
-  build-deploy:
+  build-test-deploy:
     jobs:
       - build
       - test_barebone_release:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,6 +54,29 @@ commands:
       - attach_workspace:
           name: Attach workspace
           at: .
+  install_hex_rebar:
+    # This mimicks `mix local.hex --force && mix local.rebar --force` but with version pinning.
+    #
+    # Because `mix local.hex` doesn't allow version pinning, we have to dig one level deeper and
+    # call `mix archive.install` directly. On the other hand, `mix local.rebar` does direct file download
+    # so we can't consistently use `mix archive.install` as we do with hex installation.
+    #
+    # See:
+    # - https://github.com/elixir-lang/elixir/blob/master/lib/mix/lib/mix/tasks/local.hex.ex
+    # - https://github.com/elixir-lang/elixir/blob/master/lib/mix/lib/mix/tasks/local.rebar.ex
+    description: "Install hex, rebar and rebar3"
+    parameters:
+      into:
+        description: The directory to install hex, rebar and rebar3 into, relative to the working directory.
+        type: string
+        default: .
+    steps:
+      - run:
+          command: |
+            cd << parameters.into >>
+            mix archive.install https://repo.hex.pm/installs/1.8.0/hex-0.20.5.ez --force --sha512 cb7fdddbc4e5051b403cfb5e874ceb5cb0ecbe981a2a1517b97f9f76c67d234692e901ff48ee10dc712f728ae6ed0a51b11b8bd65b5db5582896123de20e7d49
+            mix local.rebar rebar https://repo.hex.pm/installs/1.0.0/rebar-2.6.2 --force --sha512 ff1c5ddfce1fcfd73fd65b8bfc0ff1c13aefc2e98921d528cbc1f35e86c9caa1c9c4e848b9ce6404d9a81c50cfcf0e45dd0dddb23cd42708664c41fce6618900
+            mix local.rebar rebar3 https://repo.hex.pm/installs/1.0.0/rebar3-3.5.1 --force --sha512 86e998642991d384e9a6d4f216552609496da0e6ec4eb235df5b8b637d078c1a118bc7cdab501d1d54d24e0b6642adf32cc0c43019d948304301ceef227bedfd
 
 jobs:
   barebuild:
@@ -62,8 +85,8 @@ jobs:
       MIX_ENV: test
     steps:
       - checkout
+      - install_hex_rebar
       - run: echo 'export PATH=~/.cargo/bin:$PATH' >> $BASH_ENV
-      - run: mix do local.hex --force, local.rebar --force
       - run:
           command: ./bin/setup
           no_output_timeout: 2400
@@ -164,7 +187,8 @@ jobs:
       MIX_ENV: test
     steps:
       - setup_elixir-omg_workspace
-      - run: mix do local.hex --force, local.rebar --force, compile --warnings-as-errors --force, credo, format --check-formatted --dry-run
+      - install_hex_rebar
+      - run: mix do compile --warnings-as-errors --force, credo, format --check-formatted --dry-run
 
   sobelow:
     executor: builder_pg
@@ -423,17 +447,17 @@ jobs:
             sudo apt-get update &&
             sudo apt-get install esl-erlang=1:21.3.8.10-1
             sudo apt-get install elixir=1.8.2-1
-            mix do local.hex --force, local.rebar --force
       - run: sh .circleci/status.sh
       - restore_cache:
           key: v1-mix-specs-cache-{{ .Branch }}-{{ checksum "mix.lock" }}
+      - install_hex_rebar:
+          into: priv/
       - run:
           name: Run specs
           command: |
             cd priv/
             make install
             make generate_api_code
-            mix local.hex --force && mix local.rebar --force
             mix deps.get
             mix test
       - run:
@@ -445,8 +469,7 @@ jobs:
             mix format apps/child_chain_api/lib/child_chain_api/model/*.ex
             mix format apps/watcher_info_api/lib/watcher_info_api/model/*.ex
             mix format apps/watcher_security_critical_api/lib/watcher_security_critical_api/model/*.ex
-            mix local.hex --force && mix local.rebar --force
-            MIX_ENV=test mix do local.hex --force, local.rebar --force, compile --warnings-as-errors --ignore-module-conflict --force, test --exclude test
+            MIX_ENV=test mix do compile --warnings-as-errors --ignore-module-conflict --force, test --exclude test
       - save_cache:
           key: v1-mix-specs-cache-{{ .Branch }}-{{ checksum "mix.lock" }}
           paths:
@@ -490,11 +513,11 @@ jobs:
             sudo apt policy elixir
             ./bin/setup
           no_output_timeout: 2400
+      - install_hex_rebar
       - run:
           name: Compile
           command: |
             set -e
-            mix local.hex --force && mix local.rebar --force
             make deps-elixir-omg
             mix compile
           no_output_timeout: 2400

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,6 @@ services:
       - /bin/sh
       - -c
       - |
-          
           apk add --update curl
           # Configures geth with the deployer and authority accounts. This includes:
           #   1. Configuring the deployer's keystore
@@ -30,7 +29,6 @@ services:
           #   4. Unlocking the accounts by their indexes
           echo "" > /tmp/geth-blank-password
           # Starts geth
-          
           geth --syncmode 'fast' --miner.gastarget 7500000 \
             --miner.gasprice "10" \
             --nodiscover \
@@ -44,8 +42,7 @@ services:
             --unlock "0,1" \
             --rpc --rpcapi personal,web3,eth,net --rpcaddr 0.0.0.0 --rpcvhosts=* --rpcport=8545 \
             --ws --wsaddr 0.0.0.0 --wsorigins='*' \
-            --mine 
-            
+            --mine
     ports:
       - "8545:8545"
       - "8546:8546"
@@ -69,7 +66,6 @@ services:
       - ETHEREUM_NETWORK=LOCALCHAIN
       - ETHEREUM_RPC_URL=http://geth:8545
       - ETHEREUM_WS_RPC_URL=ws://geth:8546
-      - CHILD_CHAIN_URL=http://childchain:9656
       - ERLANG_COOKIE=develop
       - NODE_HOST=127.0.0.1
       - APP_ENV=local_development


### PR DESCRIPTION
## Overview

Clean up some unused and/or redundant CircleCI configs.

## Changes

Describe your changes and implementation choices. More details make PRs easier to review.

- Renamed `coveralls_merge` to `coveralls_report` because it's mainly doing reporting
- Removed executor `metal_child_chain`, `metal_watcher`, `metal_watcher_info`. They were stripped out and now left with only assigning a single env var each. Easier to move to the env var assignment to the actual job
- Removed `build_and_deploy_staging` job that was configured specifically for the ancient `v0.1` branch
- Grouped trivial states printing together so it's easier to browse in CircleCI
- Version-pinning hex and rebar installations

## Testing

CircleCI build still passes.
