### PR TITLE
Configurable IGNORE_FEES env var

### DIFF
--- a/apps/omg_child_chain/lib/omg_child_chain/release_tasks/set_ignore_fees.ex
+++ b/apps/omg_child_chain/lib/omg_child_chain/release_tasks/set_ignore_fees.ex
@@ -26,7 +26,7 @@ defmodule OMG.ChildChain.ReleaseTasks.SetIgnoreFees do
     _ = Application.ensure_all_started(:logger)
     ignore_fees = ignore_fees()
 
-    :ok = Application.put_env(@app, @config_key, interval_ms, persistent: true)
+    :ok = Application.put_env(@app, @config_key, ignore_fees, persistent: true)
   end
 
   defp ignore_fees() do

--- a/apps/omg_child_chain/lib/omg_child_chain/release_tasks/set_ignore_fees.ex
+++ b/apps/omg_child_chain/lib/omg_child_chain/release_tasks/set_ignore_fees.ex
@@ -1,0 +1,50 @@
+# Copyright 2019-2019 OmiseGO Pte Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defmodule OMG.ChildChain.ReleaseTasks.SetIgnoreFees do
+  @moduledoc false
+  use Distillery.Releases.Config.Provider
+  require Logger
+
+  @app :omg_child_chain
+  @config_key :ignore_fees
+  @env_name "IGNORE_FEES"
+
+  @impl Provider
+  def init(_args) do
+    _ = Application.ensure_all_started(:logger)
+    ignore_fees = ignore_fees()
+
+    :ok = Application.put_env(@app, @config_key, interval_ms, persistent: true)
+  end
+
+  defp ignore_fees() do
+    ignore_fees =
+      validate_boolean(
+        get_env(@env_name),
+        Application.get_env(@app, @config_key)
+      )
+
+    _ = Logger.info("CONFIGURATION: App: #{@app} Key: #{@config_key} Value: #{inspect(ignore_fees)}.")
+
+    ignore_fees
+  end
+
+  defp get_env(key), do: System.get_env(key)
+
+  defp validate_boolean("true", _default), do: true
+  defp validate_boolean("false", _default), do: false
+  defp validate_boolean(nil, default), do: default
+  defp validate_boolean(_, _default), do: exit("#{@env_name} can only be \"true\" or \"false\" or unset.")
+end

--- a/apps/omg_child_chain/lib/omg_child_chain/release_tasks/set_ignore_fees.ex
+++ b/apps/omg_child_chain/lib/omg_child_chain/release_tasks/set_ignore_fees.ex
@@ -46,5 +46,5 @@ defmodule OMG.ChildChain.ReleaseTasks.SetIgnoreFees do
   defp validate_boolean("true", _default), do: true
   defp validate_boolean("false", _default), do: false
   defp validate_boolean(nil, default), do: default
-  defp validate_boolean(_, _default), do: exit("#{@env_name} can only be \"true\" or \"false\" or unset.")
+  defp validate_boolean(_, _default), do: exit(~s/#{@env_name} can only be "true" or "false" or unset./)
 end

--- a/apps/omg_child_chain/test/omg_child_chain/release_tasks/set_ignore_fees_test.exs
+++ b/apps/omg_child_chain/test/omg_child_chain/release_tasks/set_ignore_fees_test.exs
@@ -1,0 +1,66 @@
+# Copyright 2019-2020 OmiseGO Pte Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defmodule OMG.ChildChain.ReleaseTasks.SetIgnoreFeesTest do
+  use ExUnit.Case, async: false
+  alias OMG.ChildChain.ReleaseTasks.SetIgnoreFees
+
+  @app :omg_child_chain
+  @config_key :ignore_fees
+  @configuration_old Application.get_all_env(@app)
+
+  setup do
+    on_exit(fn ->
+      # configuration is global state so we reset it to known values in case
+      # it got fiddled before
+
+      :ok =
+        Enum.each(@configuration_old, fn {key, value} -> Application.put_env(@app, key, value, persistent: true) end)
+    end)
+
+    :ok
+  end
+
+  test "that :ignore_fees is set to true when given IGNORE_FEES=true" do
+    :ok = System.put_env("IGNORE_FEES", "true")
+    :ok = SetIgnoreFees.init([])
+    assert Application.get_env(@app, @config_key) == true
+    :ok = System.delete_env("IGNORE_FEES")
+  end
+
+  test "that :ignore_fees is set to false when given IGNORE_FEES=false" do
+    :ok = System.put_env("IGNORE_FEES", "false")
+    :ok = SetIgnoreFees.init([])
+    assert Application.get_env(@app, @config_key) == false
+    :ok = System.delete_env("IGNORE_FEES")
+  end
+
+  test "that no other configurations got affected" do
+    :ok = System.put_env("IGNORE_FEES", "true")
+    :ok = SetIgnoreFees.init([])
+    new_configs = @app |> Application.get_all_env() |> Keyword.delete(@config_key) |> Enum.sort()
+    old_configs = @configuration_old |> Keyword.delete(@config_key) |> Enum.sort()
+
+    assert new_configs == old_configs
+  end
+
+  test "that default configuration is used when there's no environment variables" do
+    :ok = System.delete_env("IGNORE_FEES")
+    :ok = SetIgnoreFees.init([])
+    new_configs = @app |> Application.get_all_env() |> Enum.sort()
+    old_configs = @configuration_old |> Enum.sort()
+
+    assert new_configs == old_configs
+  end
+end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -77,6 +77,7 @@ services:
       - DD_DISABLED=true
       - DB_PATH=/app/.omg/data
       - ETHEREUM_EVENTS_CHECK_INTERVAL_MS=800
+      - IGNORE_FEES=false
     restart: always
     ports:
       - "9656:9656"

--- a/docs/deployment_configuration.md
+++ b/docs/deployment_configuration.md
@@ -70,6 +70,10 @@ The contract addresses that are required to be included in the `contract_addr` f
 }
 ```
 
+***Child Chain only***
+
+- "IGNORE_FEES" - Allows transactions to be submitted without requiring fees if set to _true_. Defaults to _false_ (fee is required).
+
 ***Watcher security-critical only***
 
 - "CHILD_CHAIN_URL" - Location of the Child Chain API *mandatory*

--- a/rel/config.exs
+++ b/rel/config.exs
@@ -137,6 +137,7 @@ release :child_chain do
       {OMG.Eth.ReleaseTasks.SetEthereumClient, []},
       {OMG.Eth.ReleaseTasks.SetContract, []},
       {OMG.DB.ReleaseTasks.SetKeyValueDB, []},
+      {OMG.ChildChain.ReleaseTasks.SetIgnoreFees, []},
       {OMG.ChildChainRPC.ReleaseTasks.SetEndpoint, []},
       {OMG.ChildChainRPC.ReleaseTasks.SetTracer, []},
       {OMG.Status.ReleaseTasks.SetSentry, []},


### PR DESCRIPTION
## Overview

Allows configurable :ignore_fees config via `IGNORE_FEES` env var.

## Changes

Added the `OMG.ChildChain.ReleaseTasks.SetIgnoreFees` release task that retrieves the env var and set to the config.

Allows either `IGNORE_FEES="true"` or `IGNORE_FEES="false"` or the env var must be unset, otherwise an error is raised.

## Testing

To ignore the fees, set the environment variable to `true` on application startup:

```
export IGNORE_FEES=true
```

Then proceed to submit a transaction without a fee.