### PR TITLE
feat: add linting to enforce function parentheses

### DIFF
--- a/apps/omg/lib/omg/ethereum_event_listener.ex
+++ b/apps/omg/lib/omg/ethereum_event_listener.ex
@@ -142,7 +142,7 @@ defmodule OMG.EthereumEventListener do
   @decorate span(service: :ethereum_event_listener, type: :backend, name: "maybe_update_event_cache/2")
   defp maybe_update_event_cache({:dont_fetch_events, state}, _callback), do: state
 
-  defp schedule_get_events do
+  defp schedule_get_events() do
     Application.fetch_env!(:omg, :ethereum_events_check_interval_ms)
     |> :timer.send_after(self(), :sync)
   end

--- a/apps/omg/lib/omg/ethereum_event_listener/measure.ex
+++ b/apps/omg/lib/omg/ethereum_event_listener/measure.ex
@@ -32,7 +32,7 @@ defmodule OMG.EthereumEventListener.Measure do
     [:trace, OMG.EthereumEventListener],
     [:trace, OMG.EthereumEventListener.Core]
   ]
-  def supported_events, do: @supported_events
+  def supported_events(), do: @supported_events
 
   def handle_event([:process, OMG.EthereumEventListener], %{events: events}, state, _config) do
     _ = Datadog.gauge(name(state.service_name, :events), length(events))

--- a/apps/omg/lib/omg/root_chain_coordinator.ex
+++ b/apps/omg/lib/omg/root_chain_coordinator.ex
@@ -59,7 +59,7 @@ defmodule OMG.RootChainCoordinator do
   """
   @decorate span(service: :ethereum_event_listener, type: :backend, name: "get_sync_info/0")
   @spec get_sync_info() :: SyncGuide.t() | :nosync
-  def get_sync_info do
+  def get_sync_info() do
     GenServer.call(__MODULE__, :get_sync_info)
   end
 
@@ -67,7 +67,7 @@ defmodule OMG.RootChainCoordinator do
   Gets all the current synced height for all the services checked in
   """
   @spec get_ethereum_heights() :: {:ok, Core.ethereum_heights_result_t()}
-  def get_ethereum_heights do
+  def get_ethereum_heights() do
     GenServer.call(__MODULE__, :get_ethereum_heights)
   end
 

--- a/apps/omg/lib/omg/state.ex
+++ b/apps/omg/lib/omg/state.ex
@@ -48,7 +48,7 @@ defmodule OMG.State do
     GenServer.call(__MODULE__, {:exec, tx, input_fees})
   end
 
-  def form_block do
+  def form_block() do
     GenServer.cast(__MODULE__, :form_block)
   end
 
@@ -79,8 +79,8 @@ defmodule OMG.State do
     GenServer.call(__MODULE__, {:utxo_exists, utxo})
   end
 
-  @spec get_status :: {non_neg_integer(), boolean()}
-  def get_status do
+  @spec get_status() :: {non_neg_integer(), boolean()}
+  def get_status() do
     GenServer.call(__MODULE__, :get_status)
   end
 

--- a/apps/omg/lib/omg/state/measure.ex
+++ b/apps/omg/lib/omg/state/measure.ex
@@ -24,7 +24,7 @@ defmodule OMG.State.Measure do
   alias OMG.Status.Metric.Datadog
 
   @supported_events [[:process, OMG.State]]
-  def supported_events, do: @supported_events
+  def supported_events(), do: @supported_events
 
   def handle_event([:process, OMG.State], _, %Core{} = state, _config) do
     execute = fn ->

--- a/apps/omg/lib/omg/typed_data_hash/config.ex
+++ b/apps/omg/lib/omg/typed_data_hash/config.ex
@@ -42,7 +42,7 @@ defmodule OMG.TypedDataHash.Config do
   This value is taken to structured hash computation when no domain separator is passed.
   """
   @spec domain_separator_from_config() :: OMG.Crypto.hash_t()
-  def domain_separator_from_config do
+  def domain_separator_from_config() do
     Tools.domain_separator(domain_data_from_config())
   end
 end

--- a/apps/omg/lib/omg/typed_data_hash/types.ex
+++ b/apps/omg/lib/omg/typed_data_hash/types.ex
@@ -62,7 +62,7 @@ defmodule OMG.TypedDataHash.Types do
     Output: @output_spec
   }
 
-  def eip712_types_specification,
+  def eip712_types_specification(),
     do: %{
       types: @types,
       primaryType: "Transaction"

--- a/apps/omg/mix.exs
+++ b/apps/omg/mix.exs
@@ -1,7 +1,7 @@
 defmodule OMG.MixProject do
   use Mix.Project
 
-  def project do
+  def project() do
     [
       app: :omg,
       version: "#{String.trim(File.read!("../../VERSION"))}",
@@ -17,7 +17,7 @@ defmodule OMG.MixProject do
     ]
   end
 
-  def application do
+  def application() do
     [
       mod: {OMG.Application, []},
       extra_applications: [:logger, :sentry, :telemetry]
@@ -30,7 +30,7 @@ defmodule OMG.MixProject do
   defp elixirc_paths(:dev), do: ["lib", "test/support"]
   defp elixirc_paths(:test), do: ["lib", "test/support"]
 
-  defp deps do
+  defp deps() do
     [
       {:ex_plasma, git: "https://github.com/omisego/ex_plasma.git"},
       {:ex_rlp, "~> 0.5.2"},

--- a/apps/omg/test/omg/block_test.exs
+++ b/apps/omg/test/omg/block_test.exs
@@ -23,7 +23,7 @@ defmodule OMG.BlockTest do
   alias OMG.Block
   alias OMG.TestHelper
 
-  defp eth, do: OMG.Eth.RootChain.eth_pseudo_address()
+  defp eth(), do: OMG.Eth.RootChain.eth_pseudo_address()
 
   describe "hashed_txs_at/2" do
     @tag fixtures: [:stable_alice, :stable_bob]

--- a/apps/omg/test/support/dev_crypto.ex
+++ b/apps/omg/test/support/dev_crypto.ex
@@ -27,7 +27,7 @@ defmodule OMG.DevCrypto do
   Generates private key. Internally uses OpenSSL RAND_bytes. May throw if there is not enough entropy.
   """
   @spec generate_private_key() :: {:ok, Crypto.priv_key_t()}
-  def generate_private_key, do: {:ok, :crypto.strong_rand_bytes(32)}
+  def generate_private_key(), do: {:ok, :crypto.strong_rand_bytes(32)}
 
   @doc """
   Given a private key, returns public key.

--- a/apps/omg/test/support/test_helper.ex
+++ b/apps/omg/test/support/test_helper.ex
@@ -24,7 +24,7 @@ defmodule OMG.TestHelper do
   @empty_metadata <<0::256>>
 
   # Deterministic entities. Use only when truly needed.
-  def entities_stable,
+  def entities_stable(),
     do: %{
       stable_alice: %{
         priv:
@@ -46,7 +46,7 @@ defmodule OMG.TestHelper do
       }
     }
 
-  def entities,
+  def entities(),
     do:
       Map.merge(
         %{
@@ -58,7 +58,7 @@ defmodule OMG.TestHelper do
       )
 
   @spec generate_entity :: entity()
-  def generate_entity do
+  def generate_entity() do
     {:ok, priv} = DevCrypto.generate_private_key()
     {:ok, pub} = DevCrypto.generate_public_key(priv)
     {:ok, address} = Crypto.generate_address(pub)

--- a/apps/omg_bus/lib/omg_bus/supervisor.ex
+++ b/apps/omg_bus/lib/omg_bus/supervisor.ex
@@ -19,7 +19,7 @@ defmodule OMG.Bus.Supervisor do
   use Supervisor
   require Logger
 
-  def start_link do
+  def start_link() do
     Supervisor.start_link(__MODULE__, :ok, name: __MODULE__)
   end
 

--- a/apps/omg_bus/mix.exs
+++ b/apps/omg_bus/mix.exs
@@ -1,7 +1,7 @@
 defmodule OMG.Bus.MixProject do
   use Mix.Project
 
-  def project do
+  def project() do
     [
       app: :omg_bus,
       version: "#{String.trim(File.read!("../../VERSION"))}",
@@ -17,7 +17,7 @@ defmodule OMG.Bus.MixProject do
     ]
   end
 
-  def application do
+  def application() do
     [
       mod: {OMG.Bus.Application, []},
       extra_applications: [:logger],
@@ -30,5 +30,5 @@ defmodule OMG.Bus.MixProject do
   defp elixirc_paths(:dev), do: ["lib"]
   defp elixirc_paths(:test), do: ["lib", "test/support"]
 
-  defp deps, do: [{:phoenix_pubsub, "~> 1.0"}]
+  defp deps(), do: [{:phoenix_pubsub, "~> 1.0"}]
 end

--- a/apps/omg_child_chain/lib/omg_child_chain/block_queue.ex
+++ b/apps/omg_child_chain/lib/omg_child_chain/block_queue.ex
@@ -208,7 +208,7 @@ defmodule OMG.ChildChain.BlockQueue do
       log_eth_node_error()
     end
 
-    defp log_eth_node_error do
+    defp log_eth_node_error() do
       eth_node_diagnostics = Eth.Diagnostics.get_node_diagnostics()
       Logger.error("Ethereum operation failed, additional diagnostics: #{inspect(eth_node_diagnostics)}")
     end

--- a/apps/omg_child_chain/lib/omg_child_chain/supervisor.ex
+++ b/apps/omg_child_chain/lib/omg_child_chain/supervisor.ex
@@ -26,7 +26,7 @@ defmodule OMG.ChildChain.Supervisor do
   alias OMG.State
   alias OMG.Status.Alert.Alarm
 
-  def start_link do
+  def start_link() do
     Supervisor.start_link(__MODULE__, :ok, name: __MODULE__)
   end
 

--- a/apps/omg_child_chain/mix.exs
+++ b/apps/omg_child_chain/mix.exs
@@ -1,7 +1,7 @@
 defmodule OMG.ChildChain.MixProject do
   use Mix.Project
 
-  def project do
+  def project() do
     [
       app: :omg_child_chain,
       version: "#{String.trim(File.read!("../../VERSION"))}",
@@ -17,7 +17,7 @@ defmodule OMG.ChildChain.MixProject do
     ]
   end
 
-  def application do
+  def application() do
     [
       extra_applications: [:logger, :telemetry],
       start_phases: [{:boot_done, []}, {:attach_telemetry, []}],
@@ -30,7 +30,7 @@ defmodule OMG.ChildChain.MixProject do
   defp elixirc_paths(:dev), do: ["lib"]
   defp elixirc_paths(:test), do: ["lib", "test/support"]
 
-  defp deps do
+  defp deps() do
     [
       {:ex_rlp, "~> 0.5.2"},
       {:telemetry, "~> 0.4.0"},

--- a/apps/omg_child_chain/test/omg_child_chain/integration/fee_server_test.exs
+++ b/apps/omg_child_chain/test/omg_child_chain/integration/fee_server_test.exs
@@ -187,7 +187,7 @@ defmodule OMG.ChildChain.Integration.FeeServerTest do
     end
   end
 
-  defp start_fee_server do
+  defp start_fee_server() do
     log = capture_log(fn -> GenServer.start(FeeServer, [], name: TestFeeServer) end)
 
     case GenServer.whereis(TestFeeServer) do

--- a/apps/omg_child_chain/test/omg_child_chain/integration/monitor_test.exs
+++ b/apps/omg_child_chain/test/omg_child_chain/integration/monitor_test.exs
@@ -118,7 +118,7 @@ defmodule OMG.ChildChain.MonitorTest do
     use GenServer
 
     @spec prepare_child() :: %{id: atom(), start: tuple()}
-    def prepare_child do
+    def prepare_child() do
       %{id: __MODULE__, start: {__MODULE__, :start_link, [[]]}}
     end
 

--- a/apps/omg_child_chain_rpc/lib/omg_child_chain_rpc/release_tasks/set_endpoint.ex
+++ b/apps/omg_child_chain_rpc/lib/omg_child_chain_rpc/release_tasks/set_endpoint.ex
@@ -46,7 +46,7 @@ defmodule OMG.ChildChainRPC.ReleaseTasks.SetEndpoint do
     :ok = Application.put_env(@app, OMG.ChildChainRPC.Web.Endpoint, Enum.sort(config), persistent: true)
   end
 
-  defp get_port do
+  defp get_port() do
     port =
       validate_integer(
         get_env("PORT"),
@@ -57,7 +57,7 @@ defmodule OMG.ChildChainRPC.ReleaseTasks.SetEndpoint do
     {:port, port}
   end
 
-  defp get_hostname do
+  defp get_hostname() do
     hostname =
       validate_string(
         get_env("HOSTNAME"),

--- a/apps/omg_child_chain_rpc/lib/omg_child_chain_rpc/web.ex
+++ b/apps/omg_child_chain_rpc/lib/omg_child_chain_rpc/web.ex
@@ -31,7 +31,7 @@ defmodule OMG.ChildChainRPC.Web do
   and import those modules here.
   """
 
-  def controller do
+  def controller() do
     quote do
       use Phoenix.Controller, namespace: OMG.ChildChainRPC.Web
 
@@ -68,7 +68,7 @@ defmodule OMG.ChildChainRPC.Web do
     end
   end
 
-  def view do
+  def view() do
     quote do
       use Phoenix.View,
         root: "lib/omg_child_chain_rpc_web/templates",
@@ -76,7 +76,7 @@ defmodule OMG.ChildChainRPC.Web do
     end
   end
 
-  def router do
+  def router() do
     quote do
       use Phoenix.Router
       import Plug.Conn

--- a/apps/omg_child_chain_rpc/mix.exs
+++ b/apps/omg_child_chain_rpc/mix.exs
@@ -1,7 +1,7 @@
 defmodule OMG.ChildChainRPC.MixProject do
   use Mix.Project
 
-  def project do
+  def project() do
     [
       app: :omg_child_chain_rpc,
       version: "#{String.trim(File.read!("../../VERSION"))}",
@@ -21,7 +21,7 @@ defmodule OMG.ChildChainRPC.MixProject do
   # Configuration for the OTP application.
   #
   # Type `mix help compile.app` for more information.
-  def application do
+  def application() do
     [
       mod: {OMG.ChildChainRPC.Application, []},
       extra_applications: [:logger, :runtime_tools, :sasl, :telemetry]
@@ -36,7 +36,7 @@ defmodule OMG.ChildChainRPC.MixProject do
   # Specifies your project dependencies.
   #
   # Type `mix help deps` for examples and options.
-  defp deps do
+  defp deps() do
     [
       {:phoenix, "~> 1.3"},
       {:plug_cowboy, "~> 1.0"},

--- a/apps/omg_conformance/mix.exs
+++ b/apps/omg_conformance/mix.exs
@@ -1,7 +1,7 @@
 defmodule OMG.Conformance.MixProject do
   use Mix.Project
 
-  def project do
+  def project() do
     [
       app: :omg_conformance,
       version: "#{String.trim(File.read!("../../VERSION"))}",
@@ -17,7 +17,7 @@ defmodule OMG.Conformance.MixProject do
     ]
   end
 
-  def application do
+  def application() do
     [
       extra_applications: [:logger]
     ]
@@ -27,7 +27,7 @@ defmodule OMG.Conformance.MixProject do
   defp elixirc_paths(:dev), do: ["lib"]
   defp elixirc_paths(:test), do: ["lib", "test/support"]
 
-  defp deps do
+  defp deps() do
     [
       {:propcheck, "~> 1.1", only: [:test]},
       {:omg, in_umbrella: true}

--- a/apps/omg_db/lib/db.ex
+++ b/apps/omg_db/lib/db.ex
@@ -69,14 +69,14 @@ defmodule OMG.DB do
 
   def start_link(args), do: driver().start_link(args)
 
-  def child_spec, do: driver().child_spec()
+  def child_spec(), do: driver().child_spec()
   def child_spec(args), do: driver().child_spec(args)
 
   def init(path) do
     driver().init(path)
   end
 
-  def init do
+  def init() do
     driver().init()
   end
 
@@ -84,7 +84,7 @@ defmodule OMG.DB do
   Puts all zeroes and other init values to a generically initialized `OMG.DB`
   """
 
-  def initiation_multiupdate, do: driver().initiation_multiupdate
+  def initiation_multiupdate(), do: driver().initiation_multiupdate
   def initiation_multiupdate(server), do: driver().initiation_multiupdate(server)
 
   @decorate span(service: :ethereum_event_listener, type: :backend, name: "multi_update/1")
@@ -94,19 +94,19 @@ defmodule OMG.DB do
   def blocks(blocks_to_fetch), do: driver().blocks(blocks_to_fetch)
   def blocks(blocks_to_fetch, server), do: driver().blocks(blocks_to_fetch, server)
 
-  def utxos, do: driver().utxos()
+  def utxos(), do: driver().utxos()
   def utxos(server), do: driver().utxos(server)
 
   def utxo(utxo_pos), do: driver().utxo(utxo_pos)
   def utxo(utxo_pos, server), do: driver().utxo(utxo_pos, server)
 
-  def exit_infos, do: driver().exit_infos
+  def exit_infos(), do: driver().exit_infos
   def exit_infos(server), do: driver().exit_infos(server)
 
-  def in_flight_exits_info, do: driver().in_flight_exits_info()
+  def in_flight_exits_info(), do: driver().in_flight_exits_info()
   def in_flight_exits_info(server), do: driver().in_flight_exits_info(server)
 
-  def competitors_info, do: driver().competitors_info
+  def competitors_info(), do: driver().competitors_info
   def competitors_info(server), do: driver().competitors_info(server)
 
   def exit_info(utxo_pos), do: driver().exit_info(utxo_pos)
@@ -117,7 +117,7 @@ defmodule OMG.DB do
   def block_hashes(block_numbers_to_fetch), do: driver().block_hashes(block_numbers_to_fetch)
   def block_hashes(block_numbers_to_fetch, server), do: driver().block_hashes(block_numbers_to_fetch, server)
 
-  def child_top_block_number, do: driver().child_top_block_number
+  def child_top_block_number(), do: driver().child_top_block_number
 
   def get_single_value(parameter_name), do: driver().get_single_value(parameter_name)
   def get_single_value(parameter_name, server), do: driver().get_single_value(parameter_name, server)
@@ -125,7 +125,7 @@ defmodule OMG.DB do
   @doc """
   A list of all atoms that we use as single-values stored in the database (i.e. markers/flags of all kinds)
   """
-  def single_value_parameter_names do
+  def single_value_parameter_names() do
     [
       # child chain - used at block forming
       :child_top_block_number,
@@ -148,5 +148,5 @@ defmodule OMG.DB do
     ]
   end
 
-  defp driver, do: OMG.DB.RocksDB
+  defp driver(), do: OMG.DB.RocksDB
 end

--- a/apps/omg_db/lib/omg_db/measure.ex
+++ b/apps/omg_db/lib/omg_db/measure.ex
@@ -34,7 +34,7 @@ defmodule OMG.DB.Measure do
                           [:update_multiread, service]
                         ]
                     end)
-  def supported_events, do: @supported_events
+  def supported_events(), do: @supported_events
 
   def handle_event([:process, service_name], _, state, _config) when service_name in @services do
     value =

--- a/apps/omg_db/lib/omg_db/release_tasks/init_key_value_db.ex
+++ b/apps/omg_db/lib/omg_db/release_tasks/init_key_value_db.ex
@@ -20,7 +20,7 @@ defmodule OMG.DB.ReleaseTasks.InitKeyValueDB do
   @start_apps [:logger, :crypto, :ssl]
   require Logger
 
-  def run do
+  def run() do
     _ = Application.load(:omg_db)
     path = Application.get_env(:omg_db, :path)
     process(path)

--- a/apps/omg_db/lib/omg_db/rocks_db.ex
+++ b/apps/omg_db/lib/omg_db/rocks_db.ex
@@ -33,7 +33,7 @@ if Code.ensure_loaded?(:rocksdb) do
       @server_name.start_link(args)
     end
 
-    def child_spec do
+    def child_spec() do
       db_path = Application.fetch_env!(:omg_db, :path)
       [server_module: server_module, server_name: server_name] = Application.fetch_env!(:omg_db, :rocksdb)
       args = [db_path: db_path, name: server_name]
@@ -125,7 +125,7 @@ if Code.ensure_loaded?(:rocksdb) do
     @doc """
     Does all of the initialization of `OMG.DB` based on the configured path
     """
-    def init, do: do_init(@server_name, Application.fetch_env!(:omg_db, :path))
+    def init(), do: do_init(@server_name, Application.fetch_env!(:omg_db, :path))
     def init(path) when is_binary(path), do: do_init(@server_name, path)
     def init(server_name), do: do_init(server_name, Application.fetch_env!(:omg_db, :path))
     def init(server_name, path), do: do_init(server_name, path)

--- a/apps/omg_db/lib/omg_db/rocksdb/server.ex
+++ b/apps/omg_db/lib/omg_db/rocksdb/server.ex
@@ -200,7 +200,7 @@ if Code.ensure_loaded?(:rocksdb) do
       end
     end
 
-    defp table_settings, do: [:named_table, :set, :public, write_concurrency: true]
+    defp table_settings(), do: [:named_table, :set, :public, write_concurrency: true]
 
     # Argument order flipping tools :(
     # write options

--- a/apps/omg_db/mix.exs
+++ b/apps/omg_db/mix.exs
@@ -1,7 +1,7 @@
 defmodule OMG.DB.MixProject do
   use Mix.Project
 
-  def project do
+  def project() do
     [
       app: :omg_db,
       version: "#{String.trim(File.read!("../../VERSION"))}",
@@ -17,7 +17,7 @@ defmodule OMG.DB.MixProject do
     ]
   end
 
-  def application do
+  def application() do
     [
       extra_applications: [:logger, :telemetry],
       start_phases: [{:attach_telemetry, []}],
@@ -30,7 +30,7 @@ defmodule OMG.DB.MixProject do
   defp elixirc_paths(:dev), do: ["lib"]
   defp elixirc_paths(:test), do: ["lib", "test/support"]
 
-  defp deps do
+  defp deps() do
     [
       {:rocksdb, "~> 1.3", system_env: [{"ERLANG_ROCKSDB_OPTS", "-DWITH_SYSTEM_ROCKSDB=ON"}]},
       {:omg_status, in_umbrella: true},

--- a/apps/omg_eth/lib/eth.ex
+++ b/apps/omg_eth/lib/eth.ex
@@ -41,7 +41,7 @@ defmodule OMG.Eth do
   @type send_transaction_option() :: {:passphrase, binary()}
 
   @spec node_ready() :: :ok | {:error, :geth_still_syncing | :geth_not_listening}
-  def node_ready do
+  def node_ready() do
     case Ethereumex.HttpClient.eth_syncing() do
       {:ok, false} -> :ok
       {:ok, _} -> {:error, :geth_still_syncing}
@@ -56,9 +56,9 @@ defmodule OMG.Eth do
   * true  - geth is still syncing.
   """
   @spec syncing?() :: boolean
-  def syncing?, do: node_ready() != :ok
+  def syncing?(), do: node_ready() != :ok
 
-  def get_ethereum_height do
+  def get_ethereum_height() do
     case Ethereumex.HttpClient.eth_block_number() do
       {:ok, height_hex} ->
         {:ok, int_from_hex(height_hex)}
@@ -81,8 +81,8 @@ defmodule OMG.Eth do
   @doc """
   Returns placeholder for non-existent Ethereum address
   """
-  @spec zero_address :: address()
-  def zero_address, do: <<0::160>>
+  @spec zero_address() :: address()
+  def zero_address(), do: <<0::160>>
 
   def call_contract(contract, signature, args, return_types) do
     data = signature |> ABI.encode(args)

--- a/apps/omg_eth/lib/omg_eth/ethereum_client_monitor.ex
+++ b/apps/omg_eth/lib/omg_eth/ethereum_client_monitor.ex
@@ -170,7 +170,7 @@ defmodule OMG.Eth.EthereumClientMonitor do
   end
 
   @spec check :: non_neg_integer() | :error
-  defp check do
+  defp check() do
     {:ok, rootchain_height} = eth().get_ethereum_height()
     rootchain_height
   rescue
@@ -191,9 +191,9 @@ defmodule OMG.Eth.EthereumClientMonitor do
 
   defp raise_clear(_alarm_module, false, _), do: :ok
 
-  defp eth, do: Application.get_env(:omg_child_chain, :eth_integration_module, Eth)
+  defp eth(), do: Application.get_env(:omg_child_chain, :eth_integration_module, Eth)
 
-  defp install_alarm_handler do
+  defp install_alarm_handler() do
     case Enum.member?(:gen_event.which_handlers(:alarm_handler), __MODULE__) do
       true -> :ok
       _ -> :alarm_handler.add_alarm_handler(__MODULE__)

--- a/apps/omg_eth/lib/omg_eth/ethereum_height.ex
+++ b/apps/omg_eth/lib/omg_eth/ethereum_height.ex
@@ -24,7 +24,7 @@ defmodule OMG.Eth.EthereumHeight do
   alias OMG.Eth.Encoding
 
   @spec get() :: {:ok, non_neg_integer()} | {:error, :error_ethereum_height}
-  def get do
+  def get() do
     GenServer.call(__MODULE__, :get)
   end
 
@@ -65,13 +65,13 @@ defmodule OMG.Eth.EthereumHeight do
     end
   end
 
-  @spec get_ethereum_height :: non_neg_integer() | :error_ethereum_height
-  defp get_ethereum_height do
+  @spec get_ethereum_height() :: non_neg_integer() | :error_ethereum_height
+  defp get_ethereum_height() do
     {:ok, rootchain_height} = eth().get_ethereum_height()
     rootchain_height
   rescue
     _check_error -> :error_ethereum_height
   end
 
-  defp eth, do: Application.get_env(:omg_eth, :eth_integration_module, Eth)
+  defp eth(), do: Application.get_env(:omg_eth, :eth_integration_module, Eth)
 end

--- a/apps/omg_eth/lib/omg_eth/release_tasks/set_ethereum_client.ex
+++ b/apps/omg_eth/lib/omg_eth/release_tasks/set_ethereum_client.ex
@@ -34,14 +34,14 @@ defmodule OMG.Eth.ReleaseTasks.SetEthereumClient do
     :ok
   end
 
-  defp get_ethereum_rpc_url do
+  defp get_ethereum_rpc_url() do
     url = validate_string(get_env("ETHEREUM_RPC_URL"), Application.get_env(:ethereumex, :url))
     _ = Logger.info("CONFIGURATION: App: #{@app} Key: ETHEREUM_RPC_URL Value: #{inspect(url)}.")
 
     url
   end
 
-  defp get_ethereum_ws_rpc_url do
+  defp get_ethereum_ws_rpc_url() do
     url = validate_string(get_env("ETHEREUM_WS_RPC_URL"), Application.get_env(@app, :ws_url))
 
     _ = Logger.info("CONFIGURATION: App: #{@app} Key: ETHEREUM_WS_RPC_URL Value: #{inspect(url)}.")
@@ -49,7 +49,7 @@ defmodule OMG.Eth.ReleaseTasks.SetEthereumClient do
     url
   end
 
-  defp get_rpc_client_type do
+  defp get_rpc_client_type() do
     rpc_client_type = validate_rpc_client_type(get_env("ETH_NODE"), Application.get_env(@app, :eth_node))
     _ = Logger.info("CONFIGURATION: App: #{@app} Key: ETH_NODE Value: #{inspect(rpc_client_type)}.")
 

--- a/apps/omg_eth/lib/omg_eth/supervisor.ex
+++ b/apps/omg_eth/lib/omg_eth/supervisor.ex
@@ -21,7 +21,7 @@ defmodule OMG.Eth.Supervisor do
   alias OMG.Status.Alert.Alarm
   require Logger
 
-  def start_link do
+  def start_link() do
     Supervisor.start_link(__MODULE__, :ok, name: __MODULE__)
   end
 

--- a/apps/omg_eth/mix.exs
+++ b/apps/omg_eth/mix.exs
@@ -3,7 +3,7 @@ defmodule OMG.Eth.MixProject do
 
   require Logger
 
-  def project do
+  def project() do
     [
       app: :omg_eth,
       version: "#{String.trim(File.read!("../../VERSION"))}",
@@ -19,7 +19,7 @@ defmodule OMG.Eth.MixProject do
     ]
   end
 
-  def application do
+  def application() do
     [
       mod: {OMG.Eth.Application, []},
       extra_applications: [:sasl, :logger]
@@ -32,7 +32,7 @@ defmodule OMG.Eth.MixProject do
   defp elixirc_paths(:dev), do: ["lib", "test/support"]
   defp elixirc_paths(:test), do: ["lib", "test/support"]
 
-  defp deps do
+  defp deps() do
     [
       {:ex_abi, "~> 0.2.1"},
       {:ethereumex, "~> 0.5.5"},

--- a/apps/omg_eth/test/omg_eth/ethereum_client_monitor_test.exs
+++ b/apps/omg_eth/test/omg_eth/ethereum_client_monitor_test.exs
@@ -162,15 +162,15 @@ defmodule OMG.Eth.EthereumClientMonitorTest do
     Mocking the ETH module integration point.
     """
     use GenServer
-    def start_link, do: GenServer.start_link(__MODULE__, [], name: __MODULE__)
+    def start_link(), do: GenServer.start_link(__MODULE__, [], name: __MODULE__)
 
-    def get_ethereum_height, do: GenServer.call(__MODULE__, :get_ethereum_height)
+    def get_ethereum_height(), do: GenServer.call(__MODULE__, :get_ethereum_height)
 
-    def set_faulty_response, do: GenServer.call(__MODULE__, :set_faulty_response)
+    def set_faulty_response(), do: GenServer.call(__MODULE__, :set_faulty_response)
 
     def set_long_response(milliseconds), do: GenServer.call(__MODULE__, {:set_long_response, milliseconds})
 
-    def stop, do: GenServer.stop(__MODULE__, :normal)
+    def stop(), do: GenServer.stop(__MODULE__, :normal)
 
     def init(_), do: {:ok, %{}}
 
@@ -216,7 +216,7 @@ defmodule OMG.Eth.EthereumClientMonitorTest do
       Plug.Adapters.Cowboy.shutdown(ref)
     end
 
-    defp dispatch do
+    defp dispatch() do
       [{:_, [{"/ws", WebSockexMockTestSocket, []}]}]
     end
 

--- a/apps/omg_eth/test/omg_eth/subscription_worker_test.exs
+++ b/apps/omg_eth/test/omg_eth/subscription_worker_test.exs
@@ -89,7 +89,7 @@ defmodule OMG.Eth.SubscriptionWorkerTest do
       Plug.Adapters.Cowboy.shutdown(ref)
     end
 
-    defp dispatch do
+    defp dispatch() do
       [{:_, [{"/ws", WebSockexMockTestSocket, []}]}]
     end
 

--- a/apps/omg_performance/mix.exs
+++ b/apps/omg_performance/mix.exs
@@ -1,7 +1,7 @@
 defmodule OMG.Performance.MixProject do
   use Mix.Project
 
-  def project do
+  def project() do
     [
       app: :omg_performance,
       version: "#{String.trim(File.read!("../../VERSION"))}",
@@ -17,7 +17,7 @@ defmodule OMG.Performance.MixProject do
     ]
   end
 
-  def application do
+  def application() do
     [
       extra_applications: [:logger, :tools]
     ]
@@ -29,7 +29,7 @@ defmodule OMG.Performance.MixProject do
   defp elixirc_paths(:dev), do: ["lib"]
   defp elixirc_paths(:test), do: ["lib", "test/support"]
 
-  defp deps do
+  defp deps() do
     [
       # TEST ONLY
       {:briefly, "~> 0.3.0", only: [:dev, :test]},

--- a/apps/omg_status/lib/omg_status/alert/alarm_handler.ex
+++ b/apps/omg_status/lib/omg_status/alert/alarm_handler.ex
@@ -75,11 +75,11 @@ defmodule OMG.Status.Alert.AlarmHandler do
   def terminate(:swap, state), do: {__MODULE__, state}
   def terminate(_, _), do: :ok
 
-  defp table_setup do
+  defp table_setup() do
     _ = if :undefined == :ets.info(@table_name), do: @table_name = :ets.new(@table_name, table_settings())
   end
 
-  defp table_settings, do: [:named_table, :set, :protected, read_concurrency: true]
+  defp table_settings(), do: [:named_table, :set, :protected, read_concurrency: true]
 
   defp write_raise(alarm) when is_tuple(alarm), do: write_raise(elem(alarm, 0))
   defp write_raise(key) when is_atom(key), do: :ets.update_counter(@table_name, key, {2, 1, 1, 1}, {key, 0})

--- a/apps/omg_status/lib/omg_status/application.ex
+++ b/apps/omg_status/lib/omg_status/application.ex
@@ -53,7 +53,7 @@ defmodule OMG.Status.Application do
   @spec is_disabled?() :: boolean()
   defp is_disabled?(), do: Application.get_env(:omg_status, Tracer)[:disabled?]
 
-  defp spandex_datadog_options do
+  defp spandex_datadog_options() do
     config = Application.get_all_env(:spandex_datadog)
     config_host = config[:host]
     config_port = config[:port]

--- a/apps/omg_status/lib/omg_status/metric/datadog.ex
+++ b/apps/omg_status/lib/omg_status/metric/datadog.ex
@@ -27,7 +27,7 @@ defmodule OMG.Status.Metric.Datadog do
   use GenServer
   require Logger
 
-  def start_link, do: GenServer.start_link(__MODULE__, [], [])
+  def start_link(), do: GenServer.start_link(__MODULE__, [], [])
 
   def init(_opts) do
     _ = Process.flag(:trap_exit, true)

--- a/apps/omg_status/lib/omg_status/metric/statix.ex
+++ b/apps/omg_status/lib/omg_status/metric/statix.ex
@@ -18,7 +18,7 @@ defmodule OMG.Status.Metric.Statix do
   defmacro __using__(_opts) do
     quote location: :keep do
       @behaviour Statix
-      def connect, do: :ok
+      def connect(), do: :ok
 
       def increment(_), do: :ok
       def increment(_, _, options \\ []), do: :ok
@@ -39,7 +39,7 @@ defmodule OMG.Status.Metric.Statix do
 
       def service_check(key, val, options), do: :ok
 
-      def current_conn, do: %Statix.Conn{sock: __MODULE__}
+      def current_conn(), do: %Statix.Conn{sock: __MODULE__}
     end
   end
 end

--- a/apps/omg_status/lib/omg_status/metric/statsd_monitor.ex
+++ b/apps/omg_status/lib/omg_status/metric/statsd_monitor.ex
@@ -127,7 +127,7 @@ defmodule OMG.Status.Metric.StatsdMonitor do
 
   defp raise_clear(_alarm_module, false, _), do: :ok
 
-  defp install_alarm_handler do
+  defp install_alarm_handler() do
     case Enum.member?(:gen_event.which_handlers(:alarm_handler), __MODULE__) do
       true -> :ok
       _ -> :alarm_handler.add_alarm_handler(__MODULE__)

--- a/apps/omg_status/lib/omg_status/metric/vmstats_sink.ex
+++ b/apps/omg_status/lib/omg_status/metric/vmstats_sink.ex
@@ -23,11 +23,11 @@ defmodule OMG.Status.Metric.VmstatsSink do
   Returns child_specs for the given metric setup, to be included e.g. in Supervisor's children.
   """
   @spec prepare_child() :: %{id: :vmstats_sup, start: vm_stat()}
-  def prepare_child do
+  def prepare_child() do
     %{id: :vmstats_sup, start: {:vmstats_sup, :start_link, [__MODULE__, base_key()]}}
   end
 
-  defp base_key, do: Application.get_env(:vmstats, :base_key)
+  defp base_key(), do: Application.get_env(:vmstats, :base_key)
   # statix currently does not support `count` or `monotonic_count`, only increment and decrement
   # because of that, we're sending counters as gauges
   def collect(:counter, key, value), do: _ = Datadog.gauge(key, value)

--- a/apps/omg_status/lib/omg_status/release_tasks/set_sentry.ex
+++ b/apps/omg_status/lib/omg_status/release_tasks/set_sentry.ex
@@ -60,13 +60,13 @@ defmodule OMG.Status.ReleaseTasks.SetSentry do
       end
   end
 
-  defp get_app_env do
+  defp get_app_env() do
     env = validate_string(get_env("APP_ENV"), Application.get_env(@app, :environment_name))
     _ = Logger.info("CONFIGURATION: App: #{@app} Key: APP_ENV Value: #{inspect(env)}.")
     env
   end
 
-  defp get_hostname do
+  defp get_hostname() do
     hostname =
       validate_string(
         get_env("HOSTNAME"),
@@ -77,7 +77,7 @@ defmodule OMG.Status.ReleaseTasks.SetSentry do
     hostname
   end
 
-  defp get_application do
+  defp get_application() do
     app =
       case Code.ensure_loaded?(OMG.Watcher) do
         true -> :watcher
@@ -89,7 +89,7 @@ defmodule OMG.Status.ReleaseTasks.SetSentry do
     app
   end
 
-  defp get_rpc_client_type do
+  defp get_rpc_client_type() do
     rpc_client_type = validate_rpc_client_type(get_env("ETH_NODE"), Application.get_env(@app, :tags)[:eth_node])
     _ = Logger.info("CONFIGURATION: App: #{@app} Key: ETH_NODE Value: #{inspect(rpc_client_type)}.")
 

--- a/apps/omg_status/lib/omg_status/release_tasks/set_tracer.ex
+++ b/apps/omg_status/lib/omg_status/release_tasks/set_tracer.ex
@@ -46,7 +46,7 @@ defmodule OMG.Status.ReleaseTasks.SetTracer do
     :ok = Application.put_env(:spandex_datadog, :sync_threshold, get_sync_threshold(), persistent: true)
   end
 
-  defp get_dd_disabled do
+  defp get_dd_disabled() do
     dd_disabled? =
       validate_bool(
         get_env("DD_DISABLED"),
@@ -57,7 +57,7 @@ defmodule OMG.Status.ReleaseTasks.SetTracer do
     dd_disabled?
   end
 
-  defp get_app_env do
+  defp get_app_env() do
     env = validate_string(get_env("APP_ENV"), Application.get_env(@app, Tracer)[:env])
     _ = Logger.info("CONFIGURATION: App: #{@app} Key: APP_ENV Value: #{inspect(env)}.")
     env
@@ -81,14 +81,14 @@ defmodule OMG.Status.ReleaseTasks.SetTracer do
     dd_spandex_port
   end
 
-  def get_batch_size do
+  def get_batch_size() do
     batch_size = validate_integer(get_env("BATCH_SIZE"), Application.get_env(:spandex_datadog, :batch_size))
 
     _ = Logger.info("CONFIGURATION: App: #{@app} Key: BATCH_SIZE Value: #{inspect(batch_size)}.")
     batch_size
   end
 
-  def get_sync_threshold do
+  def get_sync_threshold() do
     sync_threshold =
       validate_integer(
         get_env("SYNC_THRESHOLD"),

--- a/apps/omg_status/mix.exs
+++ b/apps/omg_status/mix.exs
@@ -1,7 +1,7 @@
 defmodule OMG.Status.Mixfile do
   use Mix.Project
 
-  def project do
+  def project() do
     [
       app: :omg_status,
       version: "#{String.trim(File.read!("../../VERSION"))}",
@@ -22,7 +22,7 @@ defmodule OMG.Status.Mixfile do
   defp elixirc_paths(:dev), do: ["lib"]
   defp elixirc_paths(:test), do: ["lib", "test/support"]
 
-  def application do
+  def application() do
     [
       mod: {OMG.Status.Application, []},
       start_phases: [{:install_alarm_handler, []}],
@@ -31,7 +31,7 @@ defmodule OMG.Status.Mixfile do
     ]
   end
 
-  defp deps,
+  defp deps(),
     do: [
       {:telemetry, "~> 0.4.0"},
       {:sentry, "~> 7.0"},

--- a/apps/omg_status/test/omg_status/metric/statsd_monitor_test.exs
+++ b/apps/omg_status/test/omg_status/metric/statsd_monitor_test.exs
@@ -88,7 +88,7 @@ defmodule OMG.Status.Metric.StatsdMonitorTest do
   defmodule StasdWrapper do
     use GenServer
 
-    def start_link do
+    def start_link() do
       GenServer.start_link(__MODULE__, [], [])
     end
 

--- a/apps/omg_utils/mix.exs
+++ b/apps/omg_utils/mix.exs
@@ -1,7 +1,7 @@
 defmodule Utils.MixProject do
   use Mix.Project
 
-  def project do
+  def project() do
     [
       app: :omg_utils,
       version: "#{String.trim(File.read!("../../VERSION"))}",
@@ -17,7 +17,7 @@ defmodule Utils.MixProject do
     ]
   end
 
-  def application do
+  def application() do
     []
   end
 

--- a/apps/omg_utils/test/omg_utils/http_rpc/response_test.exs
+++ b/apps/omg_utils/test/omg_utils/http_rpc/response_test.exs
@@ -165,11 +165,11 @@ defmodule OMG.Utils.HttpRPC.ResponseTest do
     end
   end
 
-  defp unload_ecto do
+  defp unload_ecto() do
     :code.purge(Ecto)
     :code.delete(Ecto)
     false = :code.is_loaded(Ecto)
   end
 
-  defp load_ecto, do: true = Code.ensure_loaded?(Ecto)
+  defp load_ecto(), do: true = Code.ensure_loaded?(Ecto)
 end

--- a/apps/omg_watcher/lib/omg_watcher/api/alarm.ex
+++ b/apps/omg_watcher/lib/omg_watcher/api/alarm.ex
@@ -20,5 +20,5 @@ defmodule OMG.Watcher.API.Alarm do
   alias OMG.Status.Alert.Alarm
 
   @spec get_alarms() :: {:ok, Alarm.alarms()}
-  def get_alarms, do: {:ok, Alarm.all()}
+  def get_alarms(), do: {:ok, Alarm.all()}
 end

--- a/apps/omg_watcher/lib/omg_watcher/api/status.ex
+++ b/apps/omg_watcher/lib/omg_watcher/api/status.ex
@@ -47,7 +47,7 @@ defmodule OMG.Watcher.API.Status do
   services are unavailable, it will crash
   """
   @spec get_status() :: {:ok, t()}
-  def get_status do
+  def get_status() do
     {:ok, eth_block_number} = EthereumHeight.get()
     {:ok, eth_block_timestamp} = Eth.get_block_timestamp_by_number(eth_block_number)
     eth_syncing = Eth.syncing?()
@@ -84,7 +84,7 @@ defmodule OMG.Watcher.API.Status do
     {:ok, status}
   end
 
-  defp get_validated_child_block_number do
+  defp get_validated_child_block_number() do
     {:ok, child_block_interval} = Eth.RootChain.get_child_block_interval()
     {state_current_block, _} = State.get_status()
     state_current_block - child_block_interval

--- a/apps/omg_watcher/lib/omg_watcher/application.ex
+++ b/apps/omg_watcher/lib/omg_watcher/application.ex
@@ -26,7 +26,7 @@ defmodule OMG.Watcher.Application do
     start_root_supervisor()
   end
 
-  def start_root_supervisor do
+  def start_root_supervisor() do
     # root supervisor must stop whenever any of its children supervisors goes down (children carry the load of restarts)
     children = [
       %{

--- a/apps/omg_watcher/lib/omg_watcher/block_getter.ex
+++ b/apps/omg_watcher/lib/omg_watcher/block_getter.ex
@@ -45,7 +45,7 @@ defmodule OMG.Watcher.BlockGetter do
   Retrieves the freshest information about `OMG.Watcher.BlockGetter`'s status, as stored by the slave process `Status`
   """
   @spec get_events() :: {:ok, Core.chain_ok_response_t()}
-  def get_events, do: __MODULE__.Status.get_events()
+  def get_events(), do: __MODULE__.Status.get_events()
 
   def init(_opts) do
     {:ok, %{}, {:continue, :setup}}
@@ -274,12 +274,12 @@ defmodule OMG.Watcher.BlockGetter do
     new_state
   end
 
-  defp schedule_sync_height do
+  defp schedule_sync_height() do
     Application.fetch_env!(:omg_watcher, :block_getter_loops_interval_ms)
     |> :timer.send_after(self(), :sync)
   end
 
-  defp schedule_producer do
+  defp schedule_producer() do
     Application.fetch_env!(:omg_watcher, :block_getter_loops_interval_ms)
     |> :timer.send_after(self(), :producer)
   end

--- a/apps/omg_watcher/lib/omg_watcher/block_getter/measure.ex
+++ b/apps/omg_watcher/lib/omg_watcher/block_getter/measure.ex
@@ -21,7 +21,7 @@ defmodule OMG.Watcher.BlockGetter.Measure do
   alias OMG.Status.Metric.Datadog
 
   @supported_events [[:process, OMG.Watcher.BlockGetter]]
-  def supported_events, do: @supported_events
+  def supported_events(), do: @supported_events
 
   def handle_event([:process, OMG.Watcher.BlockGetter], _, _state, _config) do
     value =

--- a/apps/omg_watcher/lib/omg_watcher/block_getter/status.ex
+++ b/apps/omg_watcher/lib/omg_watcher/block_getter/status.ex
@@ -24,7 +24,7 @@ defmodule OMG.Watcher.BlockGetter.Status do
 
   alias OMG.Watcher.BlockGetter.Core
 
-  def start_link do
+  def start_link() do
     Agent.start_link(fn -> nil end, name: __MODULE__)
   end
 
@@ -39,5 +39,5 @@ defmodule OMG.Watcher.BlockGetter.Status do
   Prefer `OMG.Watcher.BlockGetter.get_events/0` to this
   """
   @spec get_events() :: {:ok, Core.chain_ok_response_t()}
-  def get_events, do: Agent.get(__MODULE__, fn status -> {:ok, status} end)
+  def get_events(), do: Agent.get(__MODULE__, fn status -> {:ok, status} end)
 end

--- a/apps/omg_watcher/lib/omg_watcher/block_getter/supervisor.ex
+++ b/apps/omg_watcher/lib/omg_watcher/block_getter/supervisor.ex
@@ -20,7 +20,7 @@ defmodule OMG.Watcher.BlockGetter.Supervisor do
   use Supervisor
   use OMG.Utils.LoggerExt
 
-  def start_link do
+  def start_link() do
     Supervisor.start_link(__MODULE__, :ok, name: __MODULE__)
   end
 

--- a/apps/omg_watcher/lib/omg_watcher/coordinator_setup.ex
+++ b/apps/omg_watcher/lib/omg_watcher/coordinator_setup.ex
@@ -18,7 +18,7 @@ defmodule OMG.Watcher.CoordinatorSetup do
   """
   alias OMG.Configuration
 
-  def coordinator_setup do
+  def coordinator_setup() do
     deposit_finality_margin = Configuration.deposit_finality_margin()
     finality_margin = Application.fetch_env!(:omg_watcher, :exit_finality_margin)
 

--- a/apps/omg_watcher/lib/omg_watcher/exit_processor.ex
+++ b/apps/omg_watcher/lib/omg_watcher/exit_processor.ex
@@ -148,7 +148,7 @@ defmodule OMG.Watcher.ExitProcessor do
   This function may also update some internal caches to make subsequent calls not redo the work,
   but under unchanged conditions, it should have unchanged behavior from POV of an outside caller.
   """
-  def check_validity do
+  def check_validity() do
     GenServer.call(__MODULE__, :check_validity)
   end
 
@@ -156,7 +156,7 @@ defmodule OMG.Watcher.ExitProcessor do
   Returns a map of requested in flight exits, keyed by transaction hash
   """
   @spec get_active_in_flight_exits() :: {:ok, Core.in_flight_exits_response_t()}
-  def get_active_in_flight_exits do
+  def get_active_in_flight_exits() do
     GenServer.call(__MODULE__, :get_active_in_flight_exits)
   end
 

--- a/apps/omg_watcher/lib/omg_watcher/release_tasks/set_child_chain.ex
+++ b/apps/omg_watcher/lib/omg_watcher/release_tasks/set_child_chain.ex
@@ -24,7 +24,7 @@ defmodule OMG.Watcher.ReleaseTasks.SetChildChain do
     :ok = Application.put_env(@app, :child_chain_url, get_app_env(), persistent: true)
   end
 
-  defp get_app_env do
+  defp get_app_env() do
     child_chain_url = validate_string(get_env("CHILD_CHAIN_URL"), Application.get_env(@app, :child_chain_url))
 
     _ = Logger.info("CONFIGURATION: App: #{@app} Key: CHILD_CHAIN_URL Value: #{inspect(child_chain_url)}.")

--- a/apps/omg_watcher/lib/omg_watcher/release_tasks/set_exit_processor_sla_margin.ex
+++ b/apps/omg_watcher/lib/omg_watcher/release_tasks/set_exit_processor_sla_margin.ex
@@ -28,7 +28,7 @@ defmodule OMG.Watcher.ReleaseTasks.SetExitProcessorSLAMargin do
     :ok = Application.put_env(@app, @app_env_name, get_exit_processor_sla_margin(), persistent: true)
   end
 
-  defp get_exit_processor_sla_margin do
+  defp get_exit_processor_sla_margin() do
     config_value = validate_int(get_env(@system_env_name), Application.get_env(@app, @app_env_name))
     _ = Logger.info("CONFIGURATION: App: #{@app} Key: #{@system_env_name} Value: #{inspect(config_value)}.")
     config_value

--- a/apps/omg_watcher/lib/omg_watcher/supervisor.ex
+++ b/apps/omg_watcher/lib/omg_watcher/supervisor.ex
@@ -24,7 +24,7 @@ defmodule OMG.Watcher.Supervisor do
   alias OMG.Watcher.Monitor
   alias OMG.Watcher.SyncSupervisor
 
-  def start_link do
+  def start_link() do
     Supervisor.start_link(__MODULE__, :ok, name: __MODULE__)
   end
 

--- a/apps/omg_watcher/lib/omg_watcher/sync_supervisor.ex
+++ b/apps/omg_watcher/lib/omg_watcher/sync_supervisor.ex
@@ -29,7 +29,7 @@ defmodule OMG.Watcher.SyncSupervisor do
   alias OMG.Watcher.ExitProcessor
   alias OMG.Watcher.Monitor
 
-  def start_link do
+  def start_link() do
     Supervisor.start_link(__MODULE__, :ok, name: __MODULE__)
   end
 

--- a/apps/omg_watcher/mix.exs
+++ b/apps/omg_watcher/mix.exs
@@ -1,7 +1,7 @@
 defmodule OMG.Watcher.MixProject do
   use Mix.Project
 
-  def project do
+  def project() do
     [
       app: :omg_watcher,
       version: "#{String.trim(File.read!("../../VERSION"))}",
@@ -18,7 +18,7 @@ defmodule OMG.Watcher.MixProject do
   end
 
   # Run "mix help compile.app" to learn about applications.
-  def application do
+  def application() do
     [
       mod: {OMG.Watcher.Application, []},
       start_phases: [{:attach_telemetry, []}],
@@ -31,7 +31,7 @@ defmodule OMG.Watcher.MixProject do
   defp elixirc_paths(:dev), do: ["lib"]
   defp elixirc_paths(:test), do: ["lib", "test/support"]
 
-  defp deps do
+  defp deps() do
     [
       {:telemetry, "~> 0.4.0"},
       # there's no apparent reason why libsecp256k1, spandex and distillery need to be included as dependencies

--- a/apps/omg_watcher/test/omg_watcher/integration/monitor_test.exs
+++ b/apps/omg_watcher/test/omg_watcher/integration/monitor_test.exs
@@ -119,7 +119,7 @@ defmodule OMG.Watcher.MonitorTest do
     use GenServer
 
     @spec prepare_child() :: %{id: atom(), start: tuple()}
-    def prepare_child do
+    def prepare_child() do
       %{id: __MODULE__, start: {__MODULE__, :start_link, [[]]}}
     end
 

--- a/apps/omg_watcher/test/support/exit_processor/test_helper.ex
+++ b/apps/omg_watcher/test/support/exit_processor/test_helper.ex
@@ -151,7 +151,7 @@ defmodule OMG.Watcher.ExitProcessor.TestHelper do
     {result, filtered_events}
   end
 
-  defp not_included_competitor_pos do
+  defp not_included_competitor_pos() do
     <<long::256>> =
       List.duplicate(<<255::8>>, 32)
       |> Enum.reduce(fn val, acc -> val <> acc end)

--- a/apps/omg_watcher_info/lib/omg_watcher_info/application.ex
+++ b/apps/omg_watcher_info/lib/omg_watcher_info/application.ex
@@ -23,7 +23,7 @@ defmodule OMG.WatcherInfo.Application do
     start_root_supervisor()
   end
 
-  def start_root_supervisor do
+  def start_root_supervisor() do
     # root supervisor must stop whenever any of its children supervisors goes down (children carry the load of restarts)
     children = [
       %{

--- a/apps/omg_watcher_info/lib/omg_watcher_info/db/block.ex
+++ b/apps/omg_watcher_info/lib/omg_watcher_info/db/block.ex
@@ -56,7 +56,7 @@ defmodule OMG.WatcherInfo.DB.Block do
   end
 
   @spec get_max_blknum() :: non_neg_integer()
-  def get_max_blknum do
+  def get_max_blknum() do
     DB.Repo.aggregate(__MODULE__, :max, :blknum)
   end
 
@@ -92,8 +92,8 @@ defmodule OMG.WatcherInfo.DB.Block do
     |> Paginator.set_data(paginator)
   end
 
-  @spec query_count :: Ecto.Query.t()
-  defp query_count do
+  @spec query_count() :: Ecto.Query.t()
+  defp query_count() do
     from(block in __MODULE__, select: count())
   end
 

--- a/apps/omg_watcher_info/lib/omg_watcher_info/db/transaction.ex
+++ b/apps/omg_watcher_info/lib/omg_watcher_info/db/transaction.ex
@@ -96,8 +96,8 @@ defmodule OMG.WatcherInfo.DB.Transaction do
     )
   end
 
-  @spec query_count :: Ecto.Query.t()
-  defp query_count do
+  @spec query_count() :: Ecto.Query.t()
+  defp query_count() do
     from(transaction in __MODULE__, select: count())
   end
 

--- a/apps/omg_watcher_info/lib/omg_watcher_info/db/types/atom_type.ex
+++ b/apps/omg_watcher_info/lib/omg_watcher_info/db/types/atom_type.ex
@@ -17,7 +17,7 @@ defmodule OMG.WatcherInfo.DB.Types.AtomType do
   Custom Ecto type that converts DB's string value into atom.
   """
   @behaviour Ecto.Type
-  def type, do: :string
+  def type(), do: :string
 
   def cast(value), do: {:ok, value}
 

--- a/apps/omg_watcher_info/lib/omg_watcher_info/db/types/integer_type.ex
+++ b/apps/omg_watcher_info/lib/omg_watcher_info/db/types/integer_type.ex
@@ -20,7 +20,7 @@ defmodule OMG.WatcherInfo.DB.Types.IntegerType do
   and we only work with whole numbers, we can safely convert to Elixir's primitive integer for easier operations.
   """
   @behaviour Ecto.Type
-  def type, do: :integer
+  def type(), do: :integer
 
   def cast(value) do
     {:ok, value}

--- a/apps/omg_watcher_info/lib/omg_watcher_info/release_tasks/init_postgresql_db.ex
+++ b/apps/omg_watcher_info/lib/omg_watcher_info/release_tasks/init_postgresql_db.ex
@@ -24,7 +24,7 @@ defmodule OMG.WatcherInfo.ReleaseTasks.InitPostgresqlDB do
   @start_apps [:crypto, :ssl, :postgrex, :phoenix_ecto, :ecto_sql, :telemetry]
   @apps [:omg_watcher_info]
 
-  def run do
+  def run() do
     Enum.each(@start_apps, &Application.ensure_all_started/1)
     Enum.each(@apps, &init_pg_db/1)
     :init.stop()

--- a/apps/omg_watcher_info/lib/omg_watcher_info/release_tasks/set_child_chain.ex
+++ b/apps/omg_watcher_info/lib/omg_watcher_info/release_tasks/set_child_chain.ex
@@ -24,7 +24,7 @@ defmodule OMG.WatcherInfo.ReleaseTasks.SetChildChain do
     :ok = Application.put_env(@app, :child_chain_url, get_app_env(), persistent: true)
   end
 
-  defp get_app_env do
+  defp get_app_env() do
     child_chain_url = validate_string(get_env("CHILD_CHAIN_URL"), Application.get_env(@app, :child_chain_url))
 
     _ = Logger.info("CONFIGURATION: App: #{@app} Key: CHILD_CHAIN_URL Value: #{inspect(child_chain_url)}.")

--- a/apps/omg_watcher_info/lib/omg_watcher_info/release_tasks/set_db.ex
+++ b/apps/omg_watcher_info/lib/omg_watcher_info/release_tasks/set_db.ex
@@ -26,7 +26,7 @@ defmodule OMG.WatcherInfo.ReleaseTasks.SetDB do
     :ok = Application.put_env(@app, OMG.WatcherInfo.DB.Repo, config, persistent: true)
   end
 
-  defp get_db_url do
+  defp get_db_url() do
     db_url = validate_string(get_env("DATABASE_URL"), Application.get_env(@app, OMG.WatcherInfo.DB.Repo)[:url])
 
     _ = Logger.info("CONFIGURATION: App: #{@app} Key: DATABASE_URL Value: #{inspect(db_url)}.")

--- a/apps/omg_watcher_info/lib/omg_watcher_info/supervisor.ex
+++ b/apps/omg_watcher_info/lib/omg_watcher_info/supervisor.ex
@@ -44,7 +44,7 @@ defmodule OMG.WatcherInfo.Supervisor do
 
   @children_run_after_repo if(Mix.env() == :test, do: [{__MODULE__.Sandbox, []}], else: [])
 
-  def start_link do
+  def start_link() do
     Supervisor.start_link(__MODULE__, :ok, name: __MODULE__)
   end
 

--- a/apps/omg_watcher_info/mix.exs
+++ b/apps/omg_watcher_info/mix.exs
@@ -1,7 +1,7 @@
 defmodule OMG.WatcherInfo.MixProject do
   use Mix.Project
 
-  def project do
+  def project() do
     [
       app: :omg_watcher_info,
       version: "#{String.trim(File.read!("../../VERSION"))}",
@@ -18,7 +18,7 @@ defmodule OMG.WatcherInfo.MixProject do
     ]
   end
 
-  def application do
+  def application() do
     [
       mod: {OMG.WatcherInfo.Application, []},
       extra_applications: [:logger, :runtime_tools, :telemetry]
@@ -30,7 +30,7 @@ defmodule OMG.WatcherInfo.MixProject do
   defp elixirc_paths(:dev), do: ["lib"]
   defp elixirc_paths(:test), do: ["lib", "test/support"]
 
-  defp deps do
+  defp deps() do
     [
       {:postgrex, "~> 0.14"},
       {:ecto_sql, "~> 3.1"},

--- a/apps/omg_watcher_info/priv/repo/migrations/20180813131000_create_block_table.exs
+++ b/apps/omg_watcher_info/priv/repo/migrations/20180813131000_create_block_table.exs
@@ -1,7 +1,7 @@
 defmodule OMG.WatcherInfo.Repo.Migrations.CreateBlockTable do
   use Ecto.Migration
 
-  def change do
+  def change() do
     create table(:blocks, primary_key: false) do
       add :blknum, :bigint, null: false, primary_key: true
       add :hash, :binary, null: false

--- a/apps/omg_watcher_info/priv/repo/migrations/20180813131706_create_transaction_table.exs
+++ b/apps/omg_watcher_info/priv/repo/migrations/20180813131706_create_transaction_table.exs
@@ -1,7 +1,7 @@
 defmodule OMG.WatcherInfo.Repo.Migrations.CreateTransactionTable do
   use Ecto.Migration
 
-  def change do
+  def change() do
     create table(:transactions, primary_key: false) do
       add :txhash, :binary, primary_key: true
       add :txindex, :integer, null: false

--- a/apps/omg_watcher_info/priv/repo/migrations/20180813133000_create_ethevent_table.exs
+++ b/apps/omg_watcher_info/priv/repo/migrations/20180813133000_create_ethevent_table.exs
@@ -1,7 +1,7 @@
 defmodule OMG.WatcherInfo.Repo.Migrations.CreateEtheventTable do
   use Ecto.Migration
 
-  def change do
+  def change() do
     create table(:ethevents, primary_key: false) do
       add :hash, :binary, primary_key: true
       add :blknum, :bigint

--- a/apps/omg_watcher_info/priv/repo/migrations/20180813143343_create_txoutput_table.exs
+++ b/apps/omg_watcher_info/priv/repo/migrations/20180813143343_create_txoutput_table.exs
@@ -1,7 +1,7 @@
 defmodule OMG.WatcherInfo.Repo.Migrations.CreateTxoutputTable do
   use Ecto.Migration
 
-  def change do
+  def change() do
     create table(:txoutputs, primary_key: false) do
       add :blknum, :bigint, null: false, primary_key: true
       add :txindex, :integer, null: false, primary_key: true

--- a/apps/omg_watcher_info/priv/repo/migrations/20190314105410_alter_transactions_table_add_metadata_field.exs
+++ b/apps/omg_watcher_info/priv/repo/migrations/20190314105410_alter_transactions_table_add_metadata_field.exs
@@ -1,7 +1,7 @@
 defmodule OMG.WatcherInfo.DB.Repo.Migrations.AlterTransactionsTableAddMetadataField do
   use Ecto.Migration
 
-  def change do
+  def change() do
     alter table(:transactions) do
       add(:metadata, :binary)
     end

--- a/apps/omg_watcher_info/priv/repo/migrations/20190315095855_alter_transactions_table_add_partitial_index.exs
+++ b/apps/omg_watcher_info/priv/repo/migrations/20190315095855_alter_transactions_table_add_partitial_index.exs
@@ -1,11 +1,11 @@
 defmodule OMG.WatcherInfo.DB.Repo.Migrations.AlterTransactionsTableAddPartialIndex do
   use Ecto.Migration
 
-  def up do
+  def up() do
     execute("CREATE INDEX transactions_metadata_index ON transactions(metadata) WHERE metadata IS NOT NULL")
   end
 
-  def down do
+  def down() do
     execute("DROP INDEX transactions_metadata_index")
   end
 end

--- a/apps/omg_watcher_info/priv/repo/migrations/20190408131000_add_missing_indices_to_txoutputs.exs
+++ b/apps/omg_watcher_info/priv/repo/migrations/20190408131000_add_missing_indices_to_txoutputs.exs
@@ -1,7 +1,7 @@
 defmodule OMG.WatcherInfo.Repo.Migrations.AddMissingIndicesToTxOuputs do
   use Ecto.Migration
 
-  def change do
+  def change() do
     create index(:txoutputs, [:creating_txhash, :spending_txhash])
     create index(:txoutputs, [:creating_deposit])
     create index(:txoutputs, [:spending_txhash])

--- a/apps/omg_watcher_info/priv/repo/migrations/20190806111817_alter_txoutputs_ethevents_make_many_to_many_relation.exs
+++ b/apps/omg_watcher_info/priv/repo/migrations/20190806111817_alter_txoutputs_ethevents_make_many_to_many_relation.exs
@@ -4,7 +4,7 @@ defmodule OMG.WatcherInfo.DB.Repo.Migrations.AlterTxOutputsTableAddRootchainTxnH
 
   # non-backward compatible migration, thus cannot use `change/0`
 
-  def up do
+  def up() do
     drop constraint(:txoutputs, "txoutputs_creating_deposit_fkey")
     drop constraint(:txoutputs, "txoutputs_spending_exit_fkey")
     drop constraint(:ethevents, "ethevents_pkey")
@@ -83,7 +83,7 @@ defmodule OMG.WatcherInfo.DB.Repo.Migrations.AlterTxOutputsTableAddRootchainTxnH
     create index(:ethevents_txoutputs, :child_chain_utxohash)
   end
 
-  def down do
+  def down() do
     # non-backward compatible migration, thus cannot use `change/0`
     # no-op
   end

--- a/apps/omg_watcher_info/priv/repo/migrations/20190917165912_set_inserted_at_updated_at_to_epoc.exs
+++ b/apps/omg_watcher_info/priv/repo/migrations/20190917165912_set_inserted_at_updated_at_to_epoc.exs
@@ -1,7 +1,7 @@
 defmodule OMG.WatcherInfo.Repo.Migrations.SetInsertedAtUpdatedAtToEpoch do
   use Ecto.Migration
 
-  def change do
+  def change() do
     execute("UPDATE txoutputs SET inserted_at = 'epoch' at time zone 'utc';")
     execute("UPDATE txoutputs SET updated_at = 'epoch' at time zone 'utc';")
     execute("ALTER TABLE txoutputs ALTER COLUMN inserted_at SET NOT NULL;")

--- a/apps/omg_watcher_info/priv/repo/migrations/20200129051756_index_block_timestamp.exs
+++ b/apps/omg_watcher_info/priv/repo/migrations/20200129051756_index_block_timestamp.exs
@@ -1,7 +1,7 @@
 defmodule OMG.WatcherInfo.DB.Repo.Migrations.IndexBlockTimestamp do
   use Ecto.Migration
 
-  def change do
+  def change() do
     create(index(:blocks, [:timestamp]))
   end
 end

--- a/apps/omg_watcher_rpc/lib/application.ex
+++ b/apps/omg_watcher_rpc/lib/application.ex
@@ -23,7 +23,7 @@ defmodule OMG.WatcherRPC.Application do
     start_root_supervisor()
   end
 
-  def start_root_supervisor do
+  def start_root_supervisor() do
     # root supervisor must stop whenever any of its children supervisors goes down (children carry the load of restarts)
     children = [
       %{

--- a/apps/omg_watcher_rpc/lib/release_tasks/set_endpoint.ex
+++ b/apps/omg_watcher_rpc/lib/release_tasks/set_endpoint.ex
@@ -46,7 +46,7 @@ defmodule OMG.WatcherRPC.ReleaseTasks.SetEndpoint do
     :ok = Application.put_env(@app, OMG.WatcherRPC.Web.Endpoint, Enum.sort(config), persistent: true)
   end
 
-  defp get_port do
+  defp get_port() do
     port =
       validate_integer(
         get_env("PORT"),
@@ -57,7 +57,7 @@ defmodule OMG.WatcherRPC.ReleaseTasks.SetEndpoint do
     {:port, port}
   end
 
-  defp get_hostname do
+  defp get_hostname() do
     hostname =
       validate_string(
         get_env("HOSTNAME"),

--- a/apps/omg_watcher_rpc/lib/release_tasks/set_tracer.ex
+++ b/apps/omg_watcher_rpc/lib/release_tasks/set_tracer.ex
@@ -28,7 +28,7 @@ defmodule OMG.WatcherRPC.ReleaseTasks.SetTracer do
     :ok = Application.put_env(:spandex_phoenix, :tracer, OMG.WatcherRPC.Tracer, persistent: true)
   end
 
-  defp get_dd_disabled do
+  defp get_dd_disabled() do
     dd_disabled? =
       validate_bool(
         get_env("DD_DISABLED"),
@@ -39,7 +39,7 @@ defmodule OMG.WatcherRPC.ReleaseTasks.SetTracer do
     dd_disabled?
   end
 
-  defp get_app_env do
+  defp get_app_env() do
     env = validate_string(get_env("APP_ENV"), Application.get_env(@app, OMG.WatcherRPC.Tracer)[:env])
     _ = Logger.info("CONFIGURATION: App: #{@app} Key: APP_ENV Value: #{inspect(env)}.")
     env

--- a/apps/omg_watcher_rpc/lib/web.ex
+++ b/apps/omg_watcher_rpc/lib/web.ex
@@ -31,7 +31,7 @@ defmodule OMG.WatcherRPC.Web do
   and import those modules here.
   """
 
-  def controller do
+  def controller() do
     quote do
       use Phoenix.Controller, namespace: OMG.WatcherRPC.Web, log: :debug
       import Plug.Conn
@@ -67,7 +67,7 @@ defmodule OMG.WatcherRPC.Web do
     end
   end
 
-  def view do
+  def view() do
     quote do
       use Phoenix.View,
         root: "lib/omg_watcher_rpc_web/templates",
@@ -81,7 +81,7 @@ defmodule OMG.WatcherRPC.Web do
     end
   end
 
-  def router do
+  def router() do
     quote do
       use Phoenix.Router
       import Plug.Conn
@@ -89,7 +89,7 @@ defmodule OMG.WatcherRPC.Web do
     end
   end
 
-  def channel do
+  def channel() do
     quote do
       use Phoenix.Channel
     end

--- a/apps/omg_watcher_rpc/mix.exs
+++ b/apps/omg_watcher_rpc/mix.exs
@@ -1,7 +1,7 @@
 defmodule OMG.WatcherRPC.Mixfile do
   use Mix.Project
 
-  def project do
+  def project() do
     [
       app: :omg_watcher_rpc,
       version: "#{String.trim(File.read!("../../VERSION"))}",
@@ -18,7 +18,7 @@ defmodule OMG.WatcherRPC.Mixfile do
     ]
   end
 
-  def application do
+  def application() do
     [
       mod: {OMG.WatcherRPC.Application, []},
       extra_applications: [:logger, :runtime_tools, :telemetry]
@@ -30,7 +30,7 @@ defmodule OMG.WatcherRPC.Mixfile do
   defp elixirc_paths(:dev), do: ["lib"]
   defp elixirc_paths(:test), do: ["lib", "test/support"]
 
-  defp deps do
+  defp deps() do
     [
       {:phoenix, "~> 1.3"},
       {:plug_cowboy, "~> 1.0"},

--- a/apps/omg_watcher_rpc/test/omg_watcher_rpc/web/validators/typed_data_signed_test.exs
+++ b/apps/omg_watcher_rpc/test/omg_watcher_rpc/web/validators/typed_data_signed_test.exs
@@ -38,7 +38,7 @@ defmodule OMG.WatcherRPC.Web.Validators.TypedDataSignedTest do
     verifyingContract: @ari_network_address
   }
 
-  defp get_message do
+  defp get_message() do
     alice_addr = Encoding.to_hex(@alice.addr)
     bob_addr = Encoding.to_hex(@bob.addr)
 

--- a/apps/xomg_tasks/lib/utils.ex
+++ b/apps/xomg_tasks/lib/utils.ex
@@ -40,7 +40,7 @@ defmodule XomgTasks.Utils do
     |> ensure_doesnt_contain("--no-halt")
   end
 
-  defp iex_running? do
+  defp iex_running?() do
     Code.ensure_loaded?(IEx) and IEx.started?()
   end
 

--- a/apps/xomg_tasks/mix.exs
+++ b/apps/xomg_tasks/mix.exs
@@ -6,7 +6,7 @@ defmodule OMG.XomgTasks.MixProject do
   """
   use Mix.Project
 
-  def project do
+  def project() do
     [
       app: :xomg_tasks,
       version: "#{String.trim(File.read!("../../VERSION"))}",
@@ -20,7 +20,7 @@ defmodule OMG.XomgTasks.MixProject do
     ]
   end
 
-  def application do
+  def application() do
     []
   end
 end

--- a/config/.credo.exs
+++ b/config/.credo.exs
@@ -28,7 +28,10 @@
       # If you create your own checks, you must specify the source files for
       # them here, so they can be loaded by Credo before running the analysis.
       #
-      requires: ["config/credo/license_header.ex"],
+      requires: [
+        "config/credo/license_header.ex",
+        "config/credo/require_parentheses_on_zero_arity_defs.ex"
+      ],
       #
       # If you want to enforce a style guide and need a more traditional linting
       # experience, you can change `strict` to `true` below:
@@ -50,6 +53,7 @@
       checks: [
         # custom checks
         {Credo.Check.Custom.LicenseHeader},
+        {Credo.Check.Custom.RequireParenthesesOnZeroArityDefs},
         #
         ## Consistency Checks
         #

--- a/config/credo/require_parentheses_on_zero_arity_defs.ex
+++ b/config/credo/require_parentheses_on_zero_arity_defs.ex
@@ -1,0 +1,89 @@
+defmodule Credo.Check.Custom.RequireParenthesesOnZeroArityDefs do
+  @moduledoc false
+
+  @checkdoc """
+  Use parentheses even when defining a function which has no arguments.
+
+  The code in this example ...
+
+      def summer? do
+        # ...
+      end
+
+  ... should be refactored to look like this:
+
+      def summer?() do
+        # ...
+      end
+
+  Like all `Readability` issues, this one is not a technical concern.
+  But you can improve the odds of others reading and liking your code by making
+  it easier to follow.
+
+  This conforms with the style guide at https://github.com/lexmag/elixir-style-guide/blob/master/README.md#parentheses
+  """
+  @explanation [check: @checkdoc]
+  @def_ops [:def, :defp, :defmacro, :defmacrop]
+
+  use Credo.Check, base_priority: :low
+
+  @doc false
+  def run(source_file, params \\ []) do
+    issue_meta = IssueMeta.for(source_file, params)
+
+    Credo.Code.prewalk(source_file, &traverse(&1, &2, issue_meta))
+  end
+
+  for op <- @def_ops do
+    # catch variables named e.g. `defp`
+    defp traverse({unquote(op), _, nil} = ast, issues, _issue_meta) do
+      {ast, issues}
+    end
+
+    defp traverse({unquote(op), _, body} = ast, issues, issue_meta) do
+      function_head = Enum.at(body, 0)
+
+      {ast, issues_for_definition(function_head, issues, issue_meta)}
+    end
+  end
+
+  defp traverse(ast, issues, _issue_meta) do
+    {ast, issues}
+  end
+
+  # skip the false positive for a metaprogrammed definition
+  defp issues_for_definition({{:unquote, _, _}, _, _}, issues, _) do
+    issues
+  end
+
+  defp issues_for_definition({_, _, args}, issues, _) when length(args) > 0 do
+    issues
+  end
+
+  defp issues_for_definition({name, meta, _}, issues, issue_meta) do
+    line_no = meta[:line]
+    text = remaining_line_after(issue_meta, line_no, name)
+
+    case String.match?(text, ~r/^\((\w*)\)(.)*/) do
+      true -> issues
+      false -> issues ++ [issue_for(issue_meta, line_no)]
+    end
+  end
+
+  defp remaining_line_after(issue_meta, line_no, text) do
+    source_file = IssueMeta.source_file(issue_meta)
+    line = SourceFile.line_at(source_file, line_no)
+    name_size = text |> to_string |> String.length()
+    skip = (SourceFile.column(source_file, line_no, text) || -1) + name_size - 1
+
+    String.slice(line, skip..-1)
+  end
+
+  defp issue_for(issue_meta, line_no) do
+    format_issue(
+      issue_meta,
+      message: "Use parentheses even when defining a function which has no arguments.",
+      line_no: line_no
+    )
+  end
+end


### PR DESCRIPTION
## Overview

Add an additional linting check to enforce parentheses on all functions to conform with the [Elixir style guide](https://github.com/lexmag/elixir-style-guide/blob/master/README.md#parentheses). 

Deprecates the same feature in Inobot.

## Changes

- Added a new `Credo.Check.Custom.RequireParenthesesOnZeroArityDefs` to credo
- Fix all existing parentheses warnings

## Testing

CI build passing should be sufficient.
