### PR TITLE
feat: credo should complain of custom lintings and better make clean/nuke commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ help:
 	@echo "  - \`make start-pre-lumphini-watcher\` \c"
 	@echo ""
 	@echo
-	@echo "DOCKER DEVELOPMENT"
+	@echo "DOCKER CLUSTER USAGE"
 	@echo "------------------"
 	@echo ""
 	@echo "  - \`make docker-start-cluster\`: start everything for you, but if there are no local images \c"
@@ -23,8 +23,11 @@ help:
 	@echo "instead of your own local geth network. Note: you will need to configure the environment \c"
 	@echo "variables defined in docker-compose-infura.yml"
 	@echo ""
-	@echo "  - \`make docker-watcher && make docker-watcher_info && make docker-child_chain\`: \c"
-	@echo "use your own image containers for Watcher, Watcher Info and Child Chain"
+	@echo "DOCKER DEVELOPMENT"
+	@echo "------------------"
+	@echo ""
+	@echo "  - \`make docker-build-cluster\`: build child_chain, watcher and watcher_info images \c"
+	@echo "from your current code base, then start a cluster with these freshly built images."
 	@echo ""
 	@echo "  - \`make docker-update-watcher\`, \`make docker-update-watcher_info\` or \c"
 	@echo "\`make docker-update-child_chain\`: replaces containers with your code changes\c"
@@ -54,7 +57,6 @@ help:
 	@echo ""
 	@echo "3. In the third terminal window, run:"
 	@echo "    make start-watcher"
-	@echo ""
 	@echo ""
 	@echo "4. In the fourth terminal window, run:"
 	@echo "    make start-watcher_info"
@@ -285,6 +287,10 @@ docker-push: docker
 
 ###OTHER
 docker-start-cluster:
+	SNAPSHOT=SNAPSHOT_MIX_EXIT_PERIOD_SECONDS_120 make init_test && \
+	docker-compose build --no-cache && docker-compose up
+
+docker-build-cluster: docker-child_chain docker-watcher docker-watcher_info
 	SNAPSHOT=SNAPSHOT_MIX_EXIT_PERIOD_SECONDS_120 make init_test && \
 	docker-compose build --no-cache && docker-compose up
 

--- a/apps/omg/lib/omg/state/transaction/payment.ex
+++ b/apps/omg/lib/omg/state/transaction/payment.ex
@@ -46,13 +46,13 @@ defmodule OMG.State.Transaction.Payment do
   @max_inputs 4
   @max_outputs 4
 
-  defmacro max_inputs do
+  defmacro max_inputs() do
     quote do
       unquote(@max_inputs)
     end
   end
 
-  defmacro max_outputs do
+  defmacro max_outputs() do
     quote do
       unquote(@max_outputs)
     end

--- a/config/.credo.exs
+++ b/config/.credo.exs
@@ -52,8 +52,8 @@
       #
       checks: [
         # custom checks
-        {Credo.Check.Custom.LicenseHeader},
-        {Credo.Check.Custom.RequireParenthesesOnZeroArityDefs},
+        {Credo.Check.Warning.LicenseHeader},
+        {Credo.Check.Readability.RequireParenthesesOnZeroArityDefs},
         #
         ## Consistency Checks
         #

--- a/config/credo/license_header.ex
+++ b/config/credo/license_header.ex
@@ -1,4 +1,4 @@
-defmodule Credo.Check.Custom.LicenseHeader do
+defmodule Credo.Check.Warning.LicenseHeader do
   @moduledoc """
   Checks whether license header has been included in every file, except those where it shouldn't be
 

--- a/config/credo/require_parentheses_on_zero_arity_defs.ex
+++ b/config/credo/require_parentheses_on_zero_arity_defs.ex
@@ -64,7 +64,7 @@ defmodule Credo.Check.Readability.RequireParenthesesOnZeroArityDefs do
     line_no = meta[:line]
     text = remaining_line_after(issue_meta, line_no, name)
 
-    case String.match?(text, ~r/^\((\w*)\)(.)*/) do
+    case String.match?(text, ~r/^\(([\w\?]*)\)(.)*/) do
       true -> issues
       false -> issues ++ [issue_for(issue_meta, line_no)]
     end

--- a/config/credo/require_parentheses_on_zero_arity_defs.ex
+++ b/config/credo/require_parentheses_on_zero_arity_defs.ex
@@ -1,4 +1,4 @@
-defmodule Credo.Check.Custom.RequireParenthesesOnZeroArityDefs do
+defmodule Credo.Check.Readability.RequireParenthesesOnZeroArityDefs do
   @moduledoc false
 
   @checkdoc """
@@ -25,7 +25,7 @@ defmodule Credo.Check.Custom.RequireParenthesesOnZeroArityDefs do
   @explanation [check: @checkdoc]
   @def_ops [:def, :defp, :defmacro, :defmacrop]
 
-  use Credo.Check, base_priority: :low
+  use Credo.Check, base_priority: :normal
 
   @doc false
   def run(source_file, params \\ []) do

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule OMG.Umbrella.MixProject do
   use Mix.Project
 
-  def project do
+  def project() do
     [
       # name the ap for the sake of `mix coveralls --umbrella`
       # see https://github.com/parroty/excoveralls/issues/23#issuecomment-339379061
@@ -28,11 +28,11 @@ defmodule OMG.Umbrella.MixProject do
     ]
   end
 
-  defp test_paths do
+  defp test_paths() do
     "apps/*/test" |> Path.wildcard() |> Enum.sort()
   end
 
-  defp deps do
+  defp deps() do
     [
       {:distillery, "~> 2.1", runtime: false},
       {:dialyxir, "~> 1.0.0-rc.7", only: [:dev, :test], runtime: false},
@@ -56,7 +56,7 @@ defmodule OMG.Umbrella.MixProject do
     ]
   end
 
-  defp aliases do
+  defp aliases() do
     [
       test: ["test --no-start"],
       coveralls: ["coveralls --no-start"],
@@ -79,8 +79,8 @@ defmodule OMG.Umbrella.MixProject do
     ]
   end
 
-  defp plt_apps,
-    do: [
+  defp plt_apps() do
+    [
       :briefly,
       :cowboy,
       :distillery,
@@ -96,6 +96,7 @@ defmodule OMG.Umbrella.MixProject do
       :sentry,
       :vmstats
     ]
+  end
 
   defp docker(), do: if(System.get_env("DOCKER"), do: "_docker", else: "")
 end


### PR DESCRIPTION
## Overview

Forces credo to exit with bad status when it found custom lint errors. Also piggybacking geth snapshot cleanups.

## Changes

- Moved custom linting into `Credo.Check.Warning` and `Credo.Check.Readability` namespace so it derives the exit status from https://github.com/rrrene/credo/blob/master/lib/credo/check.ex#L48-L54
- Moved geth snapshot to `make init-contracts` since now it's used a lot to setup docker-compose for multiple use cases.
- Alias `make init_test` to `make init-contracts`
- `make docker-nuke` and `make clean` also cleans up geth data folder, since the geth data will no longer be compatible with new containers

## Testing

Linting should exit with error like this: https://app.circleci.com/jobs/github/omisego/elixir-omg/40258/parallel-runs/0/steps/0-103