### PR TITLE
Add output types and transaction types to DB and API

### DIFF
--- a/apps/omg/lib/omg/fees.ex
+++ b/apps/omg/lib/omg/fees.ex
@@ -21,7 +21,6 @@ defmodule OMG.Fees do
   alias OMG.MergeTransactionValidator
   alias OMG.State.Transaction
   alias OMG.Utxo
-  alias OMG.WireFormatTypes
 
   require Utxo
 
@@ -176,8 +175,8 @@ defmodule OMG.Fees do
     end
   end
 
-  defp get_fee_for_type(%Transaction.Recovered{signed_tx: %Transaction.Signed{raw_tx: raw_tx}}, fee_map) do
-    case WireFormatTypes.tx_type_for_transaction(raw_tx) do
+  defp get_fee_for_type(%Transaction.Recovered{signed_tx: %Transaction.Signed{raw_tx: %{tx_type: type}}}, fee_map) do
+    case type do
       nil -> %{}
       type -> Map.get(fee_map, type, %{})
     end

--- a/apps/omg/lib/omg/state/core.ex
+++ b/apps/omg/lib/omg/state/core.ex
@@ -229,10 +229,11 @@ defmodule OMG.State.Core do
 
   # attempts to build a standard response data about a single UTXO, based on an abstract `output` structure
   # so that the data can be useful to discover exitable UTXOs
-  defp utxo_to_exitable_utxo_map(%Utxo{output: output}, Utxo.position(blknum, txindex, oindex)) do
+  defp utxo_to_exitable_utxo_map(%Utxo{output: %{output_type: otype} = output}, Utxo.position(blknum, txindex, oindex)) do
     output
     |> Map.from_struct()
     |> Map.take([:owner, :currency, :amount])
+    |> Map.put(:otype, otype)
     |> Map.put(:blknum, blknum)
     |> Map.put(:txindex, txindex)
     |> Map.put(:oindex, oindex)

--- a/apps/omg/lib/omg/wire_format_types.ex
+++ b/apps/omg/lib/omg/wire_format_types.ex
@@ -71,12 +71,6 @@ defmodule OMG.WireFormatTypes do
   def module_tx_types(), do: @module_tx_types
 
   @doc """
-  Returns the tx type corresponding to the given raw transaction
-  """
-  @spec tx_type_for_transaction(any()) :: non_neg_integer() | nil
-  def tx_type_for_transaction(%module{}), do: @module_tx_types[module]
-
-  @doc """
   Returns wire format type value of known input pointer type
   """
   @spec input_pointer_type_for(input_pointer_type :: atom()) :: non_neg_integer()

--- a/apps/omg/test/omg/state/core_test.exs
+++ b/apps/omg/test/omg/state/core_test.exs
@@ -889,17 +889,25 @@ defmodule OMG.State.CoreTest do
 
     assert MapSet.equal?(
              MapSet.new([
-               %{blknum: 1000, txindex: 0, oindex: 0, owner: alice.addr, currency: @eth, amount: 1},
-               %{blknum: 1000, txindex: 2, oindex: 0, owner: alice.addr, currency: @not_eth, amount: 3},
-               %{blknum: 1000, txindex: 3, oindex: 1, owner: alice.addr, currency: @eth, amount: 4}
+               %{blknum: 1000, txindex: 0, oindex: 0, otype: output_type, owner: alice.addr, currency: @eth, amount: 1},
+               %{
+                 blknum: 1000,
+                 txindex: 2,
+                 oindex: 0,
+                 otype: output_type,
+                 owner: alice.addr,
+                 currency: @not_eth,
+                 amount: 3
+               },
+               %{blknum: 1000, txindex: 3, oindex: 1, otype: output_type, owner: alice.addr, currency: @eth, amount: 4}
              ]),
              MapSet.new(Core.standard_exitable_utxos(utxos_query_result, alice.addr))
            )
 
     assert Map.equal?(
              MapSet.new([
-               %{blknum: 1000, txindex: 4, oindex: 0, owner: bob.addr, currency: @eth, amount: 5},
-               %{blknum: 2000, txindex: 1, oindex: 1, owner: bob.addr, currency: @eth, amount: 2}
+               %{blknum: 1000, txindex: 4, oindex: 0, otype: output_type, owner: bob.addr, currency: @eth, amount: 5},
+               %{blknum: 2000, txindex: 1, oindex: 1, otype: output_type, owner: bob.addr, currency: @eth, amount: 2}
              ]),
              MapSet.new(Core.standard_exitable_utxos(utxos_query_result, bob.addr))
            )

--- a/apps/omg/test/omg/wire_format_types_test.exs
+++ b/apps/omg/test/omg/wire_format_types_test.exs
@@ -24,13 +24,6 @@ defmodule OMG.WireFormatTypesTest do
     end
   end
 
-  describe "tx_type_for_transaction/1" do
-    test "returns the tx type for the given raw tx" do
-      tx = OMG.State.Transaction.Payment.new([], [])
-      assert WireFormatTypes.tx_type_for_transaction(tx) == 1
-    end
-  end
-
   describe "input_pointer_type_for/1" do
     test "returns the input type for the given input" do
       assert WireFormatTypes.input_pointer_type_for(:input_pointer_utxo_position) == 1

--- a/apps/omg_child_chain_rpc/priv/swagger/operator_api_specs.yaml
+++ b/apps/omg_child_chain_rpc/priv/swagger/operator_api_specs.yaml
@@ -76,7 +76,7 @@ paths:
                                         type: string
                               - type: object
                                 properties:
-                                  ethereum_connection_error:
+                                  invalid_fee_file:
                                     type: object
                                     properties:
                                       node:
@@ -107,6 +107,7 @@ paths:
                       data:
                         - disk_almost_full: /dev/null
                           ethereum_connection_error: {}
+                          ethereum_stalled_sync: {}
                           system_memory_high_watermark: []
         '500':
           description: Returns an internal server error

--- a/apps/omg_utils/lib/omg_utils/http_rpc/validators/base.ex
+++ b/apps/omg_utils/lib/omg_utils/http_rpc/validators/base.ex
@@ -132,6 +132,11 @@ defmodule OMG.Utils.HttpRPC.Validator.Base do
 
   def length({val, []}, len), do: {val, length: len}
 
+  @spec max_length({any(), list()}, non_neg_integer()) :: {any(), list()}
+  def max_length({_, [_ | _]} = err, _len), do: err
+  def max_length({list, []}, len) when is_list(list) and length(list) <= len, do: {list, []}
+  def max_length({val, []}, len), do: {val, max_length: len}
+
   @spec greater({any(), list()}, integer()) :: {any(), list()}
   def greater({_, [_ | _]} = err, _b), do: err
   def greater({val, []}, bound) when is_integer(val) and val > bound, do: {val, []}

--- a/apps/omg_utils/test/omg_utils/http_rpc/response_test.exs
+++ b/apps/omg_utils/test/omg_utils/http_rpc/response_test.exs
@@ -24,6 +24,7 @@ defmodule OMG.Utils.HttpRPC.ResponseTest do
     txbytes: nil,
     txhash: nil,
     txindex: nil,
+    txtype: nil,
     metadata: nil
   }
 

--- a/apps/omg_utils/test/omg_utils/http_rpc/validators/base_test.exs
+++ b/apps/omg_utils/test/omg_utils/http_rpc/validators/base_test.exs
@@ -31,7 +31,8 @@ defmodule OMG.Utils.HttpRPC.Validator.BaseTest do
     "hex_3" => "0xB3256026863EB6AE5B06FA396AB09069784EA8EA",
     "nhex_1" => "b3256026863eb6ae5b06fa396ab09069784ea8ea",
     "len_1" => "1",
-    "len_2" => <<1, 2, 3, 4, 5>>
+    "len_2" => <<1, 2, 3, 4, 5>>,
+    "max_len_1" => [1, 2, 3, 4, 5]
   }
 
   describe "Basic validation:" do
@@ -84,11 +85,23 @@ defmodule OMG.Utils.HttpRPC.Validator.BaseTest do
     test "length, positive" do
       assert {:ok, "1"} == expect(@params, "len_1", length: 1)
       assert {:ok, <<1, 2, 3, 4, 5>>} == expect(@params, "len_2", length: 5)
+      assert {:ok, [1, 2, 3, 4, 5]} == expect(@params, "max_len_1", max_length: 10)
+      assert {:ok, [1, 2, 3, 4, 5]} == expect(@params, "max_len_1", max_length: 5)
     end
 
     test "length, negative" do
       assert {:error, {:validation_error, "len_1", {:length, 5}}} == expect(@params, "len_1", length: 5)
       assert {:error, {:validation_error, "len_2", {:length, 1}}} == expect(@params, "len_2", length: 1)
+      assert {:error, {:validation_error, "max_len_1", {:max_length, 3}}} == expect(@params, "max_len_1", max_length: 3)
+    end
+
+    test "max_length, positive" do
+      assert {:ok, [1, 2, 3, 4, 5]} == expect(@params, "max_len_1", max_length: 10)
+      assert {:ok, [1, 2, 3, 4, 5]} == expect(@params, "max_len_1", max_length: 5)
+    end
+
+    test "max_length, negative" do
+      assert {:error, {:validation_error, "max_len_1", {:max_length, 3}}} == expect(@params, "max_len_1", max_length: 3)
     end
 
     test "list, positive" do

--- a/apps/omg_watcher_info/lib/omg_watcher_info/db/block.ex
+++ b/apps/omg_watcher_info/lib/omg_watcher_info/db/block.ex
@@ -242,7 +242,8 @@ defmodule OMG.WatcherInfo.DB.Block do
         ]
   defp prepare_db_transaction(recovered_tx, block_number, txindex) do
     tx = Map.fetch!(recovered_tx, :signed_tx)
-    %{tx_type: tx_type} = raw_tx = Map.fetch!(tx, :raw_tx)
+    raw_tx = Map.fetch!(tx, :raw_tx)
+    tx_type = Map.fetch!(raw_tx, :tx_type)
     metadata = Map.get(raw_tx, :metadata)
     signed_tx_bytes = Map.fetch!(recovered_tx, :signed_tx_bytes)
     tx_hash = State.Transaction.raw_txhash(tx)

--- a/apps/omg_watcher_info/lib/omg_watcher_info/db/eth_event.ex
+++ b/apps/omg_watcher_info/lib/omg_watcher_info/db/eth_event.ex
@@ -25,6 +25,7 @@ defmodule OMG.WatcherInfo.DB.EthEvent do
   alias OMG.Eth.Encoding
   alias OMG.Utxo
   alias OMG.WatcherInfo.DB
+  alias OMG.WireFormatTypes
 
   require Utxo
 
@@ -83,6 +84,7 @@ defmodule OMG.WatcherInfo.DB.EthEvent do
               blknum: blknum,
               txindex: 0,
               oindex: 0,
+              otype: WireFormatTypes.output_type_for(:output_payment_v1),
               owner: owner,
               currency: currency,
               amount: amount

--- a/apps/omg_watcher_info/lib/omg_watcher_info/db/transaction.ex
+++ b/apps/omg_watcher_info/lib/omg_watcher_info/db/transaction.ex
@@ -32,6 +32,7 @@ defmodule OMG.WatcherInfo.DB.Transaction do
   @derive {Jason.Encoder, except: [:__meta__]}
   schema "transactions" do
     field(:txindex, :integer)
+    field(:txtype, :integer)
     field(:txbytes, :binary)
     field(:sent_at, :utc_datetime)
     field(:metadata, :binary)
@@ -66,7 +67,7 @@ defmodule OMG.WatcherInfo.DB.Transaction do
   """
   @spec get_by_filters(Keyword.t(), Paginator.t()) :: Paginator.t()
   def get_by_filters(constraints, paginator) do
-    allowed_constraints = [:address, :blknum, :txindex, :metadata]
+    allowed_constraints = [:address, :blknum, :txindex, :txtype, :metadata]
 
     constraints = filter_constraints(constraints, allowed_constraints)
 

--- a/apps/omg_watcher_info/lib/omg_watcher_info/db/txoutput.ex
+++ b/apps/omg_watcher_info/lib/omg_watcher_info/db/txoutput.ex
@@ -47,6 +47,7 @@ defmodule OMG.WatcherInfo.DB.TxOutput do
     field(:txindex, :integer, primary_key: true)
     field(:oindex, :integer, primary_key: true)
     field(:owner, :binary)
+    field(:otype, :integer)
     field(:amount, OMG.WatcherInfo.DB.Types.IntegerType)
     field(:currency, :binary)
     field(:proof, :binary)
@@ -147,18 +148,19 @@ defmodule OMG.WatcherInfo.DB.TxOutput do
       tx
       |> Transaction.get_outputs()
       |> Enum.with_index()
-      |> Enum.flat_map(fn {%{currency: currency, owner: owner, amount: amount}, oindex} ->
-        create_output(blknum, txindex, oindex, txhash, owner, currency, amount)
+      |> Enum.flat_map(fn {%{currency: currency, owner: owner, amount: amount, output_type: otype}, oindex} ->
+        create_output(otype, blknum, txindex, oindex, txhash, owner, currency, amount)
       end)
 
     outputs
   end
 
-  defp create_output(_blknum, _txindex, _txhash, _oindex, _owner, _currency, 0), do: []
+  defp create_output(_otype, _blknum, _txindex, _txhash, _oindex, _owner, _currency, 0), do: []
 
-  defp create_output(blknum, txindex, oindex, txhash, owner, currency, amount) when amount > 0,
+  defp create_output(otype, blknum, txindex, oindex, txhash, owner, currency, amount) when amount > 0,
     do: [
       %{
+        otype: otype,
         blknum: blknum,
         txindex: txindex,
         oindex: oindex,

--- a/apps/omg_watcher_info/priv/repo/migrations/20200211064454_add_txtype_to_transaction_and_output.exs
+++ b/apps/omg_watcher_info/priv/repo/migrations/20200211064454_add_txtype_to_transaction_and_output.exs
@@ -1,0 +1,75 @@
+defmodule OMG.WatcherInfo.DB.Repo.Migrations.AddTxtypeToTransactionAndOutput do
+  use Ecto.Migration
+
+  import Ecto.Query, only: [from: 2]
+
+  alias Ecto.Adapters.SQL
+  alias OMG.State.Transaction
+  alias OMG.WatcherInfo.DB.Repo
+
+  def up() do
+    alter table(:transactions) do
+      add :txtype, :integer
+    end
+    alter table(:txoutputs) do
+      add :otype, :integer
+    end
+    create index(:transactions, :txtype)
+    create index(:txoutputs, :otype)
+    flush()
+
+    set_txtypes()
+
+    alter table(:transactions) do
+      modify(:txtype, :integer, null: false)
+    end
+    alter table(:txoutputs) do
+      modify(:otype, :integer, null: false)
+    end
+  end
+
+  def down() do
+    # This migration only supports outputs of type 1 and 2, we prevent rollback so we
+    # don't have problems if new types are introduced in the future.
+    raise "can't rollback this migration"
+  end
+
+  # Update existing transactions and output that don't have a type
+  defp set_txtypes() do
+    :ok =
+      Repo
+      |> SQL.query!("SELECT txhash, txbytes FROM transactions")
+      |> Map.get(:rows)
+      |> Enum.reduce(%{}, fn [txhash, txbytes], acc ->
+        %{raw_tx: %{tx_type: txtype}} = Transaction.Signed.decode!(txbytes)
+        hashes = [txhash | acc[txtype] || []]
+        Map.put(acc, txtype, hashes)
+      end)
+      |> Enum.each(fn {txtype, txhashes} ->
+        count = length(txhashes)
+
+        {^count, nil} = Repo.update_all(
+          from(t in "transactions", where: t.txhash in ^txhashes),
+          set: [txtype: txtype]
+        )
+      end)
+
+    # Fee outputs
+    {_, nil} = Repo.update_all(
+      from(
+        o in "txoutputs",
+        join: t in "transactions",
+        on: o.creating_txhash == t.txhash,
+        where: t.txtype == 3
+      ),
+      set: [otype: 2]
+    )
+
+    # Payment outputs
+    {_, nil} = Repo.update_all(
+      from(o in "txoutputs", where: is_nil(o.otype)),
+      set: [otype: 1]
+    )
+
+  end
+end

--- a/apps/omg_watcher_info/priv/repo/migrations/20200211064454_add_txtype_to_transaction_and_output.exs
+++ b/apps/omg_watcher_info/priv/repo/migrations/20200211064454_add_txtype_to_transaction_and_output.exs
@@ -31,13 +31,7 @@ defmodule OMG.WatcherInfo.DB.Repo.Migrations.AddTxtypeToTransactionAndOutput do
   def down() do
     # This migration only supports outputs of type 1 and 2, we prevent rollback so we
     # don't have problems if new types are introduced in the future.
-    # raise "can't rollback this migration"
-    alter table(:transactions) do
-      remove(:txtype)
-    end
-    alter table(:txoutputs) do
-      remove(:otype)
-    end
+    raise "can't rollback this migration"
   end
 
   # Update existing transactions and output that don't have a type

--- a/apps/omg_watcher_info/priv/repo/migrations/20200211064454_add_txtype_to_transaction_and_output.exs
+++ b/apps/omg_watcher_info/priv/repo/migrations/20200211064454_add_txtype_to_transaction_and_output.exs
@@ -6,6 +6,7 @@ defmodule OMG.WatcherInfo.DB.Repo.Migrations.AddTxtypeToTransactionAndOutput do
   alias Ecto.Adapters.SQL
   alias OMG.State.Transaction
   alias OMG.WatcherInfo.DB.Repo
+  alias OMG.WireFormatTypes
 
   def up() do
     alter table(:transactions) do
@@ -69,21 +70,22 @@ defmodule OMG.WatcherInfo.DB.Repo.Migrations.AddTxtypeToTransactionAndOutput do
   end
 
   defp update_fee_outputs() do
+    fee_tx_type = WireFormatTypes.tx_type_for(:tx_fee_token_claim)
     Repo.update_all(
       from(
         o in "txoutputs",
         join: t in "transactions",
         on: o.creating_txhash == t.txhash,
-        where: t.txtype == 3
+        where: t.txtype == ^fee_tx_type
       ),
-      set: [otype: 2]
+      set: [otype: WireFormatTypes.output_type_for(:output_fee_token_claim)]
     )
   end
 
   defp update_payment_outputs() do
      Repo.update_all(
       from(o in "txoutputs", where: is_nil(o.otype)),
-      set: [otype: 1]
+      set: [otype: WireFormatTypes.output_type_for(:output_payment_v1)]
     )
   end
 end

--- a/apps/omg_watcher_info/test/fixtures.exs
+++ b/apps/omg_watcher_info/test/fixtures.exs
@@ -122,6 +122,7 @@ defmodule OMG.WatcherInfo.Fixtures do
         owner: alice.addr,
         currency: @eth,
         amount: 333,
+        otype: 1,
         blknum: 1
       },
       %{
@@ -130,6 +131,7 @@ defmodule OMG.WatcherInfo.Fixtures do
         owner: bob.addr,
         currency: @eth,
         amount: 100,
+        otype: 1,
         blknum: 2
       }
     ]

--- a/apps/omg_watcher_info/test/omg_watcher_info/db/transaction_test.exs
+++ b/apps/omg_watcher_info/test/omg_watcher_info/db/transaction_test.exs
@@ -87,6 +87,21 @@ defmodule OMG.WatcherInfo.DB.TransactionTest do
     end
   end
 
+  describe "get/1" do
+    @tag fixtures: [:phoenix_ecto_sandbox]
+    test "returns the transaction from its hash with all data" do
+      block = insert(:block, blknum: 1000)
+      %{txhash: txhash} = insert(:transaction, block: block, txindex: 0, txtype: 1)
+      _ = insert(:transaction, block: block, txindex: 1, txtype: 3)
+
+      tx = DB.Transaction.get(txhash)
+
+      assert tx.txindex == 0
+      assert tx.txtype == 1
+      assert tx.txhash == txhash
+    end
+  end
+
   describe "count_all_between_timestamp/2" do
     @tag fixtures: [:phoenix_ecto_sandbox]
     test "returns correct count if transactions have been made between the given timestamps" do

--- a/apps/omg_watcher_info/test/omg_watcher_info/db/txoutput_test.exs
+++ b/apps/omg_watcher_info/test/omg_watcher_info/db/txoutput_test.exs
@@ -43,4 +43,37 @@ defmodule OMG.WatcherInfo.DB.TxOutputTest do
     assert not is_nil(utxo)
     assert utxo.amount == big_amount
   end
+
+  describe "create_outputs/4" do
+    @tag fixtures: [:phoenix_ecto_sandbox, :alice]
+    test "create outputs according to params", %{alice: alice} do
+      blknum = 11_000
+      amount_1 = 1000
+      amount_2 = 2000
+      tx = OMG.TestHelper.create_recovered([], @eth, [{alice, amount_1}, {alice, amount_2}])
+
+      assert [
+               %{
+                 amount: amount_1,
+                 blknum: blknum,
+                 creating_txhash: tx.tx_hash,
+                 currency: @eth,
+                 oindex: 0,
+                 otype: 1,
+                 owner: alice.addr,
+                 txindex: 0
+               },
+               %{
+                 amount: amount_2,
+                 blknum: blknum,
+                 creating_txhash: tx.tx_hash,
+                 currency: @eth,
+                 oindex: 1,
+                 otype: 1,
+                 owner: alice.addr,
+                 txindex: 0
+               }
+             ] == DB.TxOutput.create_outputs(blknum, 0, tx.tx_hash, tx)
+    end
+  end
 end

--- a/apps/omg_watcher_info/test/support/factory.ex
+++ b/apps/omg_watcher_info/test/support/factory.ex
@@ -89,6 +89,7 @@ defmodule OMG.WatcherInfo.Factory do
       txbytes: insecure_random_bytes(32),
       sent_at: DateTime.utc_now(),
       metadata: insecure_random_bytes(32),
+      txtype: 1,
       block: nil,
       inputs: [],
       outputs: []
@@ -113,6 +114,7 @@ defmodule OMG.WatcherInfo.Factory do
       blknum: block.blknum,
       txindex: 0,
       oindex: 0,
+      otype: 1,
       owner: insecure_random_bytes(20),
       amount: 100,
       currency: @eth,

--- a/apps/omg_watcher_rpc/lib/web/serializers/base.ex
+++ b/apps/omg_watcher_rpc/lib/web/serializers/base.ex
@@ -22,7 +22,7 @@ defmodule OMG.WatcherRPC.Web.Serializer.Base do
     require Utxo
 
     db_entry
-    |> Map.take([:amount, :currency, :blknum, :txindex, :oindex, :owner, :creating_txhash, :spending_txhash])
+    |> Map.take([:amount, :currency, :blknum, :txindex, :oindex, :otype, :owner, :creating_txhash, :spending_txhash])
     |> Map.put(:utxo_pos, Utxo.position(blknum, txindex, oindex) |> Utxo.Position.encode())
   end
 end

--- a/apps/omg_watcher_rpc/lib/web/validators/transaction_constraints.ex
+++ b/apps/omg_watcher_rpc/lib/web/validators/transaction_constraints.ex
@@ -28,6 +28,7 @@ defmodule OMG.WatcherRPC.Web.Validator.TransactionConstraints do
       {"address", [:address, :optional]},
       {"blknum", [:pos_integer, :optional]},
       {"metadata", [:hash, :optional]},
+      {"txtype", [:pos_integer, :optional]},
       {"limit", [:pos_integer, :optional]},
       {"page", [:pos_integer, :optional]}
     ]

--- a/apps/omg_watcher_rpc/lib/web/validators/transaction_constraints.ex
+++ b/apps/omg_watcher_rpc/lib/web/validators/transaction_constraints.ex
@@ -19,6 +19,8 @@ defmodule OMG.WatcherRPC.Web.Validator.TransactionConstraints do
 
   import OMG.Utils.HttpRPC.Validator.Base
 
+  @max_tx_types 16
+
   @doc """
   Validates possible query constraints, stops on first error.
   """
@@ -28,7 +30,7 @@ defmodule OMG.WatcherRPC.Web.Validator.TransactionConstraints do
       {"address", [:address, :optional], :address},
       {"blknum", [:pos_integer, :optional], :blknum},
       {"metadata", [:hash, :optional], :metadata},
-      {"txtypes", [list: &to_tx_type/1, optional: true], :txtypes},
+      {"txtypes", [list: &to_tx_type/1, max_length: @max_tx_types, optional: true], :txtypes},
       {"limit", [:pos_integer, :optional], :limit},
       {"page", [:pos_integer, :optional], :page}
     ]

--- a/apps/omg_watcher_rpc/lib/web/views/transaction.ex
+++ b/apps/omg_watcher_rpc/lib/web/views/transaction.ex
@@ -57,7 +57,7 @@ defmodule OMG.WatcherRPC.Web.View.Transaction do
 
   defp render_transaction(transaction) do
     transaction
-    |> Map.take([:txindex, :txhash, :block, :inputs, :outputs, :txbytes, :metadata])
+    |> Map.take([:txindex, :txhash, :txtype, :block, :inputs, :outputs, :txbytes, :metadata])
     |> Map.update!(:inputs, &render_txoutputs/1)
     |> Map.update!(:outputs, &render_txoutputs/1)
   end

--- a/apps/omg_watcher_rpc/priv/swagger/info_api_specs.yaml
+++ b/apps/omg_watcher_rpc/priv/swagger/info_api_specs.yaml
@@ -83,6 +83,17 @@ paths:
                                         type: string
                               - type: object
                                 properties:
+                                  ethereum_stalled_sync:
+                                    type: object
+                                    properties:
+                                      ethereum_height:
+                                        type: integer
+                                        minimum: 0
+                                      synced_at:
+                                        type: string
+                                        format: date-time
+                              - type: object
+                                properties:
                                   invalid_fee_file:
                                     type: object
                                     properties:
@@ -114,6 +125,7 @@ paths:
                       data:
                         - disk_almost_full: /dev/null
                           ethereum_connection_error: {}
+                          ethereum_stalled_sync: {}
                           system_memory_high_watermark: []
         '500':
           description: Returns an internal server error
@@ -492,6 +504,7 @@ paths:
                         - blknum: 123000
                           txindex: 111
                           oindex: 0
+                          otype: 1
                           utxo_pos: 123000001110000
                           owner: '0xb3256026863eb6ae5b06fa396ab09069784ea8ea'
                           currency: '0x0000000000000000000000000000000000000000'
@@ -573,6 +586,9 @@ paths:
                 blknum:
                   type: integer
                   format: int64
+                txtype:
+                  type: integer
+                  format: int64
                 metadata:
                   type: string
                 page:
@@ -631,6 +647,9 @@ paths:
                             txindex:
                               type: integer
                               format: int16
+                            txtype:
+                              type: integer
+                              format: int16
                             txhash:
                               type: string
                             metadata:
@@ -668,6 +687,9 @@ paths:
                                   oindex:
                                     type: integer
                                     format: int8
+                                  otype:
+                                    type: integer
+                                    format: int8
                                   utxo_pos:
                                     type: integer
                                     format: int256
@@ -694,6 +716,9 @@ paths:
                                     type: integer
                                     format: int16
                                   oindex:
+                                    type: integer
+                                    format: int8
+                                  otype:
                                     type: integer
                                     format: int8
                                   utxo_pos:
@@ -729,12 +754,14 @@ paths:
                             eth_height: 97424
                             blknum: 68290000
                           txindex: 0
+                          txtype: 1
                           txhash: '0x5df13a6bf96dbcf6e66d8babd6b55bd40d64d4320c3b115364c6588fc18c2a21'
                           metadata: '0x00000000000000000000000000000000000000000000000000000048656c6c6f'
                           txbytes: 0x5df13a6bee20000...
                           inputs:
                             - blknum: 1000
                               txindex: 111
+                              otype: 1
                               oindex: 0
                               utxo_pos: 1000001110000
                               owner: '0xb3256026863eb6ae5b06fa396ab09069784ea8ea'
@@ -745,6 +772,7 @@ paths:
                           outputs:
                             - blknum: 68290000
                               txindex: 5113
+                              otype: 1
                               oindex: 0
                               utxo_pos: 68290000051130000
                               owner: '0xae8ae48796090ba693af60b5ea6be3686206523b'
@@ -754,6 +782,7 @@ paths:
                               spending_txhash: null
                             - blknum: 68290000
                               txindex: 5113
+                              otype: 1
                               oindex: 1
                               utxo_pos: 68290000051130000
                               owner: '0xb3256026863eb6ae5b06fa396ab09069784ea8ea'
@@ -1134,6 +1163,9 @@ paths:
                 blknum:
                   type: integer
                   format: int64
+                txtype:
+                  type: integer
+                  format: int64
                 metadata:
                   type: string
                 page:
@@ -1192,6 +1224,9 @@ paths:
                             txindex:
                               type: integer
                               format: int16
+                            txtype:
+                              type: integer
+                              format: int16
                             txhash:
                               type: string
                             metadata:
@@ -1229,6 +1264,9 @@ paths:
                                   oindex:
                                     type: integer
                                     format: int8
+                                  otype:
+                                    type: integer
+                                    format: int8
                                   utxo_pos:
                                     type: integer
                                     format: int256
@@ -1255,6 +1293,9 @@ paths:
                                     type: integer
                                     format: int16
                                   oindex:
+                                    type: integer
+                                    format: int8
+                                  otype:
                                     type: integer
                                     format: int8
                                   utxo_pos:
@@ -1290,12 +1331,14 @@ paths:
                             eth_height: 97424
                             blknum: 68290000
                           txindex: 0
+                          txtype: 1
                           txhash: '0x5df13a6bf96dbcf6e66d8babd6b55bd40d64d4320c3b115364c6588fc18c2a21'
                           metadata: '0x00000000000000000000000000000000000000000000000000000048656c6c6f'
                           txbytes: 0x5df13a6bee20000...
                           inputs:
                             - blknum: 1000
                               txindex: 111
+                              otype: 1
                               oindex: 0
                               utxo_pos: 1000001110000
                               owner: '0xb3256026863eb6ae5b06fa396ab09069784ea8ea'
@@ -1306,6 +1349,7 @@ paths:
                           outputs:
                             - blknum: 68290000
                               txindex: 5113
+                              otype: 1
                               oindex: 0
                               utxo_pos: 68290000051130000
                               owner: '0xae8ae48796090ba693af60b5ea6be3686206523b'
@@ -1315,6 +1359,7 @@ paths:
                               spending_txhash: null
                             - blknum: 68290000
                               txindex: 5113
+                              otype: 1
                               oindex: 1
                               utxo_pos: 68290000051130000
                               owner: '0xb3256026863eb6ae5b06fa396ab09069784ea8ea'
@@ -1493,6 +1538,9 @@ paths:
                                         type: integer
                                         format: int16
                                       oindex:
+                                        type: integer
+                                        format: int8
+                                      otype:
                                         type: integer
                                         format: int8
                                       utxo_pos:
@@ -1692,6 +1740,7 @@ paths:
                                 txindex: 111
                                 oindex: 0
                                 utxo_pos: 123000001110000
+                                otype: 1
                                 owner: '0xb3256026863eb6ae5b06fa396ab09069784ea8ea'
                                 currency: '0x0000000000000000000000000000000000000000'
                                 amount: 50
@@ -1701,6 +1750,7 @@ paths:
                                 txindex: 2340
                                 oindex: 3
                                 utxo_pos: 277000023400003
+                                otype: 1
                                 owner: '0xb3256026863eb6ae5b06fa396ab09069784ea8ea'
                                 currency: '0x0000000000000000000000000000000000000000'
                                 amount: 75
@@ -1917,6 +1967,9 @@ paths:
                           txindex:
                             type: integer
                             format: int16
+                          txtype:
+                            type: integer
+                            format: int16
                           txhash:
                             type: string
                           metadata:
@@ -1954,6 +2007,9 @@ paths:
                                 oindex:
                                   type: integer
                                   format: int8
+                                otype:
+                                  type: integer
+                                  format: int8
                                 utxo_pos:
                                   type: integer
                                   format: int256
@@ -1982,6 +2038,9 @@ paths:
                                 oindex:
                                   type: integer
                                   format: int8
+                                otype:
+                                  type: integer
+                                  format: int8
                                 utxo_pos:
                                   type: integer
                                   format: int256
@@ -1999,6 +2058,7 @@ paths:
                     example:
                       data:
                         txindex: 5113
+                        txtype: 1
                         txhash: '0x5df13a6bf96dbcf6e66d8babd6b55bd40d64d4320c3b115364c6588fc18c2a21'
                         metadata: '0x00000000000000000000000000000000000000000000000000000048656c6c6f'
                         txbytes: 0x5df13a6bee20000...
@@ -2011,6 +2071,7 @@ paths:
                           - blknum: 1000
                             txindex: 111
                             oindex: 0
+                            otype: 1
                             utxo_pos: 1000001110000
                             owner: '0xb3256026863eb6ae5b06fa396ab09069784ea8ea'
                             currency: '0x0000000000000000000000000000000000000000'
@@ -2021,6 +2082,7 @@ paths:
                           - blknum: 68290000
                             txindex: 5113
                             oindex: 0
+                            otype: 1
                             utxo_pos: 68290000051130000
                             owner: '0xae8ae48796090ba693af60b5ea6be3686206523b'
                             currency: '0x0000000000000000000000000000000000000000'
@@ -2030,6 +2092,7 @@ paths:
                           - blknum: 68290000
                             txindex: 5113
                             oindex: 1
+                            otype: 1
                             utxo_pos: 68290000051130000
                             owner: '0xb3256026863eb6ae5b06fa396ab09069784ea8ea'
                             currency: '0x0000000000000000000000000000000000000000'

--- a/apps/omg_watcher_rpc/priv/swagger/info_api_specs.yaml
+++ b/apps/omg_watcher_rpc/priv/swagger/info_api_specs.yaml
@@ -586,9 +586,10 @@ paths:
                 blknum:
                   type: integer
                   format: int64
-                txtype:
-                  type: integer
-                  format: int64
+                txtypes:
+                  type: array
+                  items:
+                    type: integer
                 metadata:
                   type: string
                 page:
@@ -604,6 +605,8 @@ paths:
               example:
                 address: '0xb3256026863eb6ae5b06fa396ab09069784ea8ea'
                 metadata: '0x5df13a6bf96dbcf6e66d8babd6b55bd40d64d4320c3b115364c6588fc18c2a21'
+                txtypes:
+                  - 1
                 blknum: 68290000
                 limit: 100
                 page: 2
@@ -1163,9 +1166,10 @@ paths:
                 blknum:
                   type: integer
                   format: int64
-                txtype:
-                  type: integer
-                  format: int64
+                txtypes:
+                  type: array
+                  items:
+                    type: integer
                 metadata:
                   type: string
                 page:
@@ -1181,6 +1185,8 @@ paths:
               example:
                 address: '0xb3256026863eb6ae5b06fa396ab09069784ea8ea'
                 metadata: '0x5df13a6bf96dbcf6e66d8babd6b55bd40d64d4320c3b115364c6588fc18c2a21'
+                txtypes:
+                  - 1
                 blknum: 68290000
                 limit: 100
                 page: 2

--- a/apps/omg_watcher_rpc/priv/swagger/info_api_specs/account/response_schemas.yaml
+++ b/apps/omg_watcher_rpc/priv/swagger/info_api_specs/account/response_schemas.yaml
@@ -31,6 +31,7 @@ AccountUtxoResponseSchema:
         blknum: 123000
         txindex: 111
         oindex: 0
+        otype: 1
         utxo_pos: 123000001110000
         owner: '0xb3256026863eb6ae5b06fa396ab09069784ea8ea'
         currency: '0x0000000000000000000000000000000000000000'

--- a/apps/omg_watcher_rpc/priv/swagger/info_api_specs/transaction/request_bodies.yaml
+++ b/apps/omg_watcher_rpc/priv/swagger/info_api_specs/transaction/request_bodies.yaml
@@ -12,6 +12,9 @@ GetAllTransactionsBodySchema:
           blknum:
             type: integer
             format: int64
+          txtype:
+            type: integer
+            format: int64
           metadata:
             type: string    
           page:

--- a/apps/omg_watcher_rpc/priv/swagger/info_api_specs/transaction/request_bodies.yaml
+++ b/apps/omg_watcher_rpc/priv/swagger/info_api_specs/transaction/request_bodies.yaml
@@ -12,9 +12,10 @@ GetAllTransactionsBodySchema:
           blknum:
             type: integer
             format: int64
-          txtype:
-            type: integer
-            format: int64
+          txtypes:
+            type: array
+            items: 
+              type: integer
           metadata:
             type: string    
           page:
@@ -30,6 +31,7 @@ GetAllTransactionsBodySchema:
         example:
           address: '0xb3256026863eb6ae5b06fa396ab09069784ea8ea'
           metadata: '0x5df13a6bf96dbcf6e66d8babd6b55bd40d64d4320c3b115364c6588fc18c2a21'
+          txtypes: [1]
           blknum: 68290000
           limit: 100
           page: 2

--- a/apps/omg_watcher_rpc/priv/swagger/info_api_specs/transaction/response_schemas.yaml
+++ b/apps/omg_watcher_rpc/priv/swagger/info_api_specs/transaction/response_schemas.yaml
@@ -27,6 +27,7 @@ GetAllTransactionsResponseSchema:
           eth_height: 97424
           blknum: 68290000
         txindex: 0
+        txtype: 1
         txhash: '0x5df13a6bf96dbcf6e66d8babd6b55bd40d64d4320c3b115364c6588fc18c2a21'
         metadata: '0x00000000000000000000000000000000000000000000000000000048656c6c6f'
         txbytes: '0x5df13a6bee20000...'
@@ -34,6 +35,7 @@ GetAllTransactionsResponseSchema:
         -
           blknum: 1000
           txindex: 111
+          otype: 1
           oindex: 0
           utxo_pos: 1000001110000
           owner: '0xb3256026863eb6ae5b06fa396ab09069784ea8ea'
@@ -45,6 +47,7 @@ GetAllTransactionsResponseSchema:
         -
           blknum: 68290000
           txindex: 5113
+          otype: 1
           oindex: 0
           utxo_pos: 68290000051130000
           owner: '0xae8ae48796090ba693af60b5ea6be3686206523b'
@@ -55,6 +58,7 @@ GetAllTransactionsResponseSchema:
         -
           blknum: 68290000
           txindex: 5113
+          otype: 1
           oindex: 1
           utxo_pos: 68290000051130001
           owner: '0xb3256026863eb6ae5b06fa396ab09069784ea8ea'
@@ -85,6 +89,7 @@ CreateTransactionResponseSchema:
                 txindex: 111
                 oindex: 0
                 utxo_pos: 123000001110000
+                otype: 1
                 owner: '0xb3256026863eb6ae5b06fa396ab09069784ea8ea'
                 currency: '0x0000000000000000000000000000000000000000'
                 amount: 50
@@ -95,6 +100,7 @@ CreateTransactionResponseSchema:
                 txindex: 2340
                 oindex: 3
                 utxo_pos: 277000023400003
+                otype: 1
                 owner: '0xb3256026863eb6ae5b06fa396ab09069784ea8ea'
                 currency: '0x0000000000000000000000000000000000000000'
                 amount: 75
@@ -212,6 +218,7 @@ GetTransactionResponseSchema:
     example:
       data:
         txindex: 5113
+        txtype: 1
         txhash: '0x5df13a6bf96dbcf6e66d8babd6b55bd40d64d4320c3b115364c6588fc18c2a21'
         metadata: '0x00000000000000000000000000000000000000000000000000000048656c6c6f'
         txbytes: '0x5df13a6bee20000...'
@@ -225,6 +232,7 @@ GetTransactionResponseSchema:
           blknum: 1000
           txindex: 111
           oindex: 0
+          otype: 1
           utxo_pos: 1000001110000
           owner: '0xb3256026863eb6ae5b06fa396ab09069784ea8ea'
           currency: '0x0000000000000000000000000000000000000000'
@@ -236,6 +244,7 @@ GetTransactionResponseSchema:
           blknum: 68290000
           txindex: 5113
           oindex: 0
+          otype: 1
           utxo_pos: 68290000051130000
           owner: '0xae8ae48796090ba693af60b5ea6be3686206523b'
           currency: '0x0000000000000000000000000000000000000000'
@@ -246,6 +255,7 @@ GetTransactionResponseSchema:
           blknum: 68290000
           txindex: 5113
           oindex: 1
+          otype: 1
           utxo_pos: 68290000051130001
           owner: '0xb3256026863eb6ae5b06fa396ab09069784ea8ea'
           currency: '0x0000000000000000000000000000000000000000'

--- a/apps/omg_watcher_rpc/priv/swagger/info_api_specs/transaction/schemas.yaml
+++ b/apps/omg_watcher_rpc/priv/swagger/info_api_specs/transaction/schemas.yaml
@@ -10,6 +10,9 @@ TransactionOutputSchema:
     oindex:
       type: integer
       format: int8
+    otype:
+      type: integer
+      format: int8
     utxo_pos:
       type: integer
       format: int256
@@ -33,6 +36,9 @@ TransactionSchema:
   type: object
   properties:
     txindex:
+      type: integer
+      format: int16
+    txtype:
       type: integer
       format: int16
     txhash:

--- a/apps/omg_watcher_rpc/priv/swagger/security_critical_api_specs.yaml
+++ b/apps/omg_watcher_rpc/priv/swagger/security_critical_api_specs.yaml
@@ -83,6 +83,17 @@ paths:
                                         type: string
                               - type: object
                                 properties:
+                                  ethereum_stalled_sync:
+                                    type: object
+                                    properties:
+                                      ethereum_height:
+                                        type: integer
+                                        minimum: 0
+                                      synced_at:
+                                        type: string
+                                        format: date-time
+                              - type: object
+                                properties:
                                   invalid_fee_file:
                                     type: object
                                     properties:
@@ -114,6 +125,7 @@ paths:
                       data:
                         - disk_almost_full: /dev/null
                           ethereum_connection_error: {}
+                          ethereum_stalled_sync: {}
                           system_memory_high_watermark: []
         '500':
           description: Returns an internal server error
@@ -498,6 +510,17 @@ paths:
                                           type: array
                                           items:
                                             type: integer
+                                - type: object
+                                  properties:
+                                    ethereum_stalled_sync:
+                                      type: object
+                                      properties:
+                                        ethereum_height:
+                                          type: integer
+                                          minimum: 0
+                                        synced_at:
+                                          type: string
+                                          format: date-time
                           in_flight_txs:
                             type: array
                             items:
@@ -615,6 +638,10 @@ paths:
                                 - 1
                               outputs:
                                 - 0
+                          - event: ethereum_stalled_sync
+                            details:
+                              eth_height: 615440
+                              synced_at: '2020-02-07T10:10:10+00:00'
                         in_flight_txs:
                           - txhash: '0xbdf562c24ace032176e27621073df58ce1c6f65de3b5932343b70ba03c72132d'
                             txbytes: 0x3eb6ae5b06f3...
@@ -778,6 +805,9 @@ paths:
                             txindex:
                               type: integer
                               format: int16
+                            otype:
+                              type: integer
+                              format: int16
                             oindex:
                               type: integer
                               format: int8
@@ -796,6 +826,7 @@ paths:
                         - blknum: 123000
                           txindex: 111
                           oindex: 0
+                          otype: 1
                           utxo_pos: 123000001110000
                           owner: '0xb3256026863eb6ae5b06fa396ab09069784ea8ea'
                           currency: '0x0000000000000000000000000000000000000000'

--- a/apps/omg_watcher_rpc/priv/swagger/security_critical_api_specs/account/response_schemas.yaml
+++ b/apps/omg_watcher_rpc/priv/swagger/security_critical_api_specs/account/response_schemas.yaml
@@ -13,6 +13,7 @@ AccountUtxoResponseSchema:
         blknum: 123000
         txindex: 111
         oindex: 0
+        otype: 1
         utxo_pos: 123000001110000
         owner: '0xb3256026863eb6ae5b06fa396ab09069784ea8ea'
         currency: '0x0000000000000000000000000000000000000000'

--- a/apps/omg_watcher_rpc/priv/swagger/security_critical_api_specs/account/schemas.yaml
+++ b/apps/omg_watcher_rpc/priv/swagger/security_critical_api_specs/account/schemas.yaml
@@ -7,6 +7,9 @@ AccountUtxoSchema:
     txindex:
       type: integer
       format: int16
+    otype:
+      type: integer
+      format: int16
     oindex:
       type: integer
       format: int8

--- a/apps/omg_watcher_rpc/test/omg_watcher_rpc/web/controllers/transaction_test.exs
+++ b/apps/omg_watcher_rpc/test/omg_watcher_rpc/web/controllers/transaction_test.exs
@@ -401,7 +401,7 @@ defmodule OMG.WatcherRPC.Web.Controller.TransactionTest do
     @tag fixtures: [:blocks_inserter, :initial_deposits, :alice]
     test "returns transactions with matching txtype", %{
       blocks_inserter: blocks_inserter,
-      alice: alice,
+      alice: alice
     } do
       blocks_inserter.([
         {1000,

--- a/apps/omg_watcher_rpc/test/omg_watcher_rpc/web/controllers/transaction_test.exs
+++ b/apps/omg_watcher_rpc/test/omg_watcher_rpc/web/controllers/transaction_test.exs
@@ -78,6 +78,7 @@ defmodule OMG.WatcherRPC.Web.Controller.TransactionTest do
                    "oindex" => input_2.oindex,
                    "owner" => Encoding.to_hex(input_2.owner),
                    "txindex" => input_2.txindex,
+                   "otype" => input_2.otype,
                    "utxo_pos" =>
                      Utxo.Position.encode({:utxo_position, input_2.blknum, input_2.txindex, input_2.oindex}),
                    "creating_txhash" => Encoding.to_hex(input_2.creating_txhash),
@@ -90,6 +91,7 @@ defmodule OMG.WatcherRPC.Web.Controller.TransactionTest do
                    "oindex" => input_1.oindex,
                    "owner" => Encoding.to_hex(input_1.owner),
                    "txindex" => input_1.txindex,
+                   "otype" => input_1.otype,
                    "utxo_pos" =>
                      Utxo.Position.encode({:utxo_position, input_1.blknum, input_1.txindex, input_1.oindex}),
                    "creating_txhash" => Encoding.to_hex(input_1.creating_txhash),
@@ -104,6 +106,7 @@ defmodule OMG.WatcherRPC.Web.Controller.TransactionTest do
                    "oindex" => output_2.oindex,
                    "owner" => Encoding.to_hex(output_2.owner),
                    "txindex" => output_2.txindex,
+                   "otype" => output_2.otype,
                    "utxo_pos" =>
                      Utxo.Position.encode({:utxo_position, output_2.blknum, output_2.txindex, output_2.oindex}),
                    "creating_txhash" => Encoding.to_hex(transaction.txhash),
@@ -116,6 +119,7 @@ defmodule OMG.WatcherRPC.Web.Controller.TransactionTest do
                    "oindex" => output_1.oindex,
                    "owner" => Encoding.to_hex(output_1.owner),
                    "txindex" => output_1.txindex,
+                   "otype" => output_1.otype,
                    "utxo_pos" =>
                      Utxo.Position.encode({:utxo_position, output_1.blknum, output_1.txindex, output_1.oindex}),
                    "creating_txhash" => Encoding.to_hex(transaction.txhash),
@@ -125,6 +129,7 @@ defmodule OMG.WatcherRPC.Web.Controller.TransactionTest do
                "txhash" => Encoding.to_hex(transaction.txhash),
                "txbytes" => Encoding.to_hex(transaction.txbytes),
                "txindex" => transaction.txindex,
+               "txtype" => transaction.txtype,
                "metadata" => Encoding.to_hex(transaction.metadata)
              }
     end

--- a/apps/omg_watcher_rpc/test/omg_watcher_rpc/web/validators/transaction_constraints_test.exs
+++ b/apps/omg_watcher_rpc/test/omg_watcher_rpc/web/validators/transaction_constraints_test.exs
@@ -58,6 +58,13 @@ defmodule OMG.WatcherRPC.Web.Validator.TransactionConstraintsTest do
       assert constraints == []
     end
 
+    test "returns validation errors when given invalid tx_types" do
+      assert TransactionConstraints.parse(%{"txtypes" => 1}) == {:error, {:validation_error, "txtypes", :list}}
+
+      assert TransactionConstraints.parse(%{"txtypes" => ["1"]}) ==
+               {:error, {:validation_error, "txtypes.txtype", :integer}}
+    end
+
     test "returns a :validation_error when the given page == 0" do
       assert TransactionConstraints.parse(%{"page" => 0}) == {:error, {:validation_error, "page", {:greater, 0}}}
     end

--- a/apps/omg_watcher_rpc/test/omg_watcher_rpc/web/validators/transaction_constraints_test.exs
+++ b/apps/omg_watcher_rpc/test/omg_watcher_rpc/web/validators/transaction_constraints_test.exs
@@ -61,6 +61,9 @@ defmodule OMG.WatcherRPC.Web.Validator.TransactionConstraintsTest do
     test "returns validation errors when given invalid tx_types" do
       assert TransactionConstraints.parse(%{"txtypes" => 1}) == {:error, {:validation_error, "txtypes", :list}}
 
+      assert TransactionConstraints.parse(%{"txtypes" => Enum.to_list(1..17)}) ==
+               {:error, {:validation_error, "txtypes", {:max_length, 16}}}
+
       assert TransactionConstraints.parse(%{"txtypes" => ["1"]}) ==
                {:error, {:validation_error, "txtypes.txtype", :integer}}
     end

--- a/apps/omg_watcher_rpc/test/omg_watcher_rpc/web/validators/transaction_constraints_test.exs
+++ b/apps/omg_watcher_rpc/test/omg_watcher_rpc/web/validators/transaction_constraints_test.exs
@@ -1,0 +1,87 @@
+# Copyright 2019-2020 OmiseGO Pte Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defmodule OMG.WatcherRPC.Web.Validator.TransactionConstraintsTest do
+  use ExUnit.Case, async: true
+
+  alias OMG.Eth.Encoding
+  alias OMG.Eth.RootChain
+  alias OMG.WatcherRPC.Web.Validator.TransactionConstraints
+
+  @eth RootChain.eth_pseudo_address()
+  @zero_metadata <<0::256>>
+
+  describe "parse/1" do
+    test "returns page and limit constraints when given page and limit params" do
+      request_data = %{"page" => 1, "limit" => 100}
+
+      {:ok, constraints} = TransactionConstraints.parse(request_data)
+      assert constraints == [page: 1, limit: 100]
+    end
+
+    test "returns supported constraints when given" do
+      request_data = %{
+        "address" => Encoding.to_hex(@eth),
+        "blknum" => 1000,
+        "metadata" => Encoding.to_hex(@zero_metadata),
+        "txtypes" => [1, 3]
+      }
+
+      {:ok, constraints} = TransactionConstraints.parse(request_data)
+      assert constraints == [txtypes: [1, 3], metadata: @zero_metadata, blknum: 1000, address: @eth]
+    end
+
+    test "filters unsupported constraints" do
+      request_data = %{
+        "something" => "123"
+      }
+
+      {:ok, constraints} = TransactionConstraints.parse(request_data)
+      assert constraints == []
+    end
+
+    test "returns empty constraints when given no params" do
+      request_data = %{}
+
+      {:ok, constraints} = TransactionConstraints.parse(request_data)
+      assert constraints == []
+    end
+
+    test "returns a :validation_error when the given page == 0" do
+      assert TransactionConstraints.parse(%{"page" => 0}) == {:error, {:validation_error, "page", {:greater, 0}}}
+    end
+
+    test "returns a :validation_error when the given page < 0" do
+      assert TransactionConstraints.parse(%{"page" => -1}) == {:error, {:validation_error, "page", {:greater, 0}}}
+    end
+
+    test "returns a :validation_error when the given page is not an integer" do
+      assert TransactionConstraints.parse(%{"page" => 3.14}) == {:error, {:validation_error, "page", :integer}}
+      assert TransactionConstraints.parse(%{"page" => "abcd"}) == {:error, {:validation_error, "page", :integer}}
+    end
+
+    test "returns a :validation_error when the given limit == 0" do
+      assert TransactionConstraints.parse(%{"page" => 0}) == {:error, {:validation_error, "page", {:greater, 0}}}
+    end
+
+    test "returns a :validation_error when the given limit < 0" do
+      assert TransactionConstraints.parse(%{"page" => -1}) == {:error, {:validation_error, "page", {:greater, 0}}}
+    end
+
+    test "returns a :validation_error when the given limit is not an integer" do
+      assert TransactionConstraints.parse(%{"page" => 3.14}) == {:error, {:validation_error, "page", :integer}}
+      assert TransactionConstraints.parse(%{"page" => "abcd"}) == {:error, {:validation_error, "page", :integer}}
+    end
+  end
+end


### PR DESCRIPTION
## Overview

This PR adds more txtype to transactions and otype to outputs in API responses.

[https://github.com/omisego/elixir-omg/pull/1244](#1244) introduced fee transactions. These transactions are stored in the DB in each block similarly to payment transactions. 
There was no "visual" way to differentiate these transactions when querying API and no way to filter these transactions out if we only wanted to see payment transactions or fee transactions.

## Changes

Describe your changes and implementation choices. More details make PRs easier to review.

- Store the type of outputs and transactions in the sql db
- Return theses types in the API jsons
- Add a txtypes array params when querying a list of transactions to filter specific types

## Deployement

This PR requires to run migrations when deploying