### PR TITLE
Fix: handle error when childchain is unreachable

### DIFF
--- a/apps/omg_watcher/test/support/watcher_helper.ex
+++ b/apps/omg_watcher/test/support/watcher_helper.ex
@@ -61,7 +61,11 @@ defmodule Support.WatcherHelper do
   end
 
   def rpc_call(path, body \\ nil, expected_resp_status \\ 200) do
-    response = post(put_req_header(build_conn(), "content-type", "application/json"), path, body)
+    response =
+      build_conn()
+      |> put_req_header("content-type", "application/json")
+      |> post(path, body)
+
     # CORS check
     assert ["*"] == get_resp_header(response, "access-control-allow-origin")
 

--- a/apps/omg_watcher_info/lib/omg_watcher_info/http_rpc/adapter.ex
+++ b/apps/omg_watcher_info/lib/omg_watcher_info/http_rpc/adapter.ex
@@ -53,7 +53,11 @@ defmodule OMG.WatcherInfo.HttpRPC.Adapter do
   def get_unparsed_response_body(%HTTPoison.Response{body: error}),
     do: {:error, {:server_error, error}}
 
-  def get_unparsed_response_body(error), do: {:error, {:client_error, error}}
+  def get_unparsed_response_body({:error, %HTTPoison.Error{reason: reason}}) do
+    {:error, reason}
+  end
+
+  def get_unparsed_response_body(error), do: error
 
   @doc """
   Retrieves body from response structure. When response is successful

--- a/apps/omg_watcher_info/lib/omg_watcher_info/http_rpc/adapter.ex
+++ b/apps/omg_watcher_info/lib/omg_watcher_info/http_rpc/adapter.ex
@@ -53,6 +53,10 @@ defmodule OMG.WatcherInfo.HttpRPC.Adapter do
   def get_unparsed_response_body(%HTTPoison.Response{body: error}),
     do: {:error, {:server_error, error}}
 
+  def get_unparsed_response_body({:error, %HTTPoison.Error{reason: :econnrefused}}) do
+    {:error, :childchain_unreachable}
+  end
+
   def get_unparsed_response_body({:error, %HTTPoison.Error{reason: reason}}) do
     {:error, reason}
   end

--- a/apps/omg_watcher_info/test/omg_watcher_info/http_rpc/adapter_test.exs
+++ b/apps/omg_watcher_info/test/omg_watcher_info/http_rpc/adapter_test.exs
@@ -37,7 +37,8 @@ defmodule OMG.WatcherInfo.HttpRPC.AdapterTest do
     end
 
     test "returns the HTTPoison error reason when present" do
-      assert {:error, :econnrefused} = Adapter.get_unparsed_response_body({:error, %HTTPoison.Error{id: nil, reason: :econnrefused}})
+      assert {:error, :econnrefused} =
+               Adapter.get_unparsed_response_body({:error, %HTTPoison.Error{id: nil, reason: :econnrefused}})
     end
   end
 

--- a/apps/omg_watcher_info/test/omg_watcher_info/http_rpc/adapter_test.exs
+++ b/apps/omg_watcher_info/test/omg_watcher_info/http_rpc/adapter_test.exs
@@ -35,6 +35,10 @@ defmodule OMG.WatcherInfo.HttpRPC.AdapterTest do
       assert {:error, response} = Adapter.get_unparsed_response_body(%HTTPoison.Response{status_code: 200, body: body})
       assert response == {:malformed_response, %{"malformed" => "body"}}
     end
+
+    test "returns the HTTPoison error reason when present" do
+      assert {:error, :econnrefused} = Adapter.get_unparsed_response_body({:error, %HTTPoison.Error{id: nil, reason: :econnrefused}})
+    end
   end
 
   describe "get_response_body/1" do

--- a/apps/omg_watcher_info/test/omg_watcher_info/http_rpc/adapter_test.exs
+++ b/apps/omg_watcher_info/test/omg_watcher_info/http_rpc/adapter_test.exs
@@ -36,9 +36,14 @@ defmodule OMG.WatcherInfo.HttpRPC.AdapterTest do
       assert response == {:malformed_response, %{"malformed" => "body"}}
     end
 
-    test "returns the HTTPoison error reason when present" do
-      assert {:error, :econnrefused} =
+    test "returns a `childchain_unreachable` error when `econnrefused` is returned" do
+      assert {:error, :childchain_unreachable} =
                Adapter.get_unparsed_response_body({:error, %HTTPoison.Error{id: nil, reason: :econnrefused}})
+    end
+
+    test "returns the HTTPoison error reason when present" do
+      assert {:error, :a_reason} =
+               Adapter.get_unparsed_response_body({:error, %HTTPoison.Error{id: nil, reason: :a_reason}})
     end
   end
 

--- a/apps/omg_watcher_rpc/lib/web/controllers/fallback.ex
+++ b/apps/omg_watcher_rpc/lib/web/controllers/fallback.ex
@@ -42,8 +42,12 @@ defmodule OMG.WatcherRPC.Web.Controller.Fallback do
       description: "No transaction that created input."
     },
     econnrefused: %{
-      code: "client:econnrefused",
-      description: "Cannot communicate with the server."
+      code: "connection:econnrefused",
+      description: "Cannot connect to the Ethereum node."
+    },
+    childchain_unreachable: %{
+      code: "connection:childchain_unreachable",
+      description: "Cannot communicate with the childchain."
     },
     insufficient_funds: %{
       code: "transaction.create:insufficient_funds",

--- a/apps/omg_watcher_rpc/lib/web/controllers/fallback.ex
+++ b/apps/omg_watcher_rpc/lib/web/controllers/fallback.ex
@@ -42,8 +42,8 @@ defmodule OMG.WatcherRPC.Web.Controller.Fallback do
       description: "No transaction that created input."
     },
     econnrefused: %{
-      code: "get_status:econnrefused",
-      description: "Cannot connect to the Ethereum node."
+      code: "client:econnrefused",
+      description: "Cannot communicate with the server."
     },
     insufficient_funds: %{
       code: "transaction.create:insufficient_funds",

--- a/apps/omg_watcher_rpc/lib/web/controllers/fee.ex
+++ b/apps/omg_watcher_rpc/lib/web/controllers/fee.ex
@@ -24,7 +24,7 @@ defmodule OMG.WatcherRPC.Web.Controller.Fee do
   def fees_all(conn, params) do
     with {:ok, _} <- expect(params, "currencies", list: &to_currency/1, optional: true),
          {:ok, _} <- expect(params, "tx_types", list: &to_tx_type/1, optional: true),
-         child_chain_url <- Application.get_env(:omg_watcher, :child_chain_url),
+         child_chain_url <- Application.get_env(:omg_watcher_info, :child_chain_url),
          {:ok, fees} <- Client.get_fees(params, child_chain_url) do
       api_response(fees, conn, :fees_all)
     end

--- a/apps/omg_watcher_rpc/test/omg_watcher_rpc/web/controllers/fee_test.exs
+++ b/apps/omg_watcher_rpc/test/omg_watcher_rpc/web/controllers/fee_test.exs
@@ -18,9 +18,53 @@ defmodule OMG.WatcherRPC.Web.Controller.FeeTest do
   use OMG.Fixtures
   use OMG.WatcherInfo.Fixtures
 
+  alias OMG.Eth
+  alias OMG.Utils.HttpRPC.Encoding
+  alias OMG.WatcherInfo.TestServer
+  alias OMG.WireFormatTypes
   alias Support.WatcherHelper
 
+  @eth Eth.zero_address()
+  @tx_type WireFormatTypes.tx_type_for(:tx_payment_v1)
+  @str_tx_type Integer.to_string(@tx_type)
+
+  setup do
+    context = TestServer.start()
+    on_exit(fn -> TestServer.stop(context) end)
+    context
+  end
+
   describe "fees_all/2" do
+    @tag fixtures: [:phoenix_ecto_sandbox]
+    test "forward a successful childchain response", context do
+      childchain_response = %{
+        @str_tx_type => [
+          %{
+            "currency" => Encoding.to_hex(@eth),
+            "amount" => 2,
+            "subunit_to_unit" => 1_000_000_000_000_000_000,
+            "pegged_amount" => 4,
+            "pegged_currency" => "USD",
+            "pegged_subunit_to_unit" => 100,
+            "updated_at" => "2019-01-01T10:10:00+00:00"
+          }
+        ]
+      }
+
+      prepare_test_server(context, childchain_response)
+
+      assert childchain_response = WatcherHelper.success?("/fees.all")
+    end
+
+    @tag fixtures: [:phoenix_ecto_sandbox]
+    test "raises an error gracefully when childchain is unreachable" do
+      assert %{
+               "code" => "client:econnrefused",
+               "description" => "Cannot communicate with the server.",
+               "object" => "error"
+             } = WatcherHelper.no_success?("/fees.all")
+    end
+
     @tag fixtures: [:phoenix_ecto_sandbox]
     test "fees.all endpoint rejects request with non list currencies" do
       assert %{
@@ -76,5 +120,11 @@ defmodule OMG.WatcherRPC.Web.Controller.FeeTest do
                }
              } = WatcherHelper.no_success?("/fees.all", %{tx_types: [-5]})
     end
+  end
+
+  defp prepare_test_server(context, response) do
+    response
+    |> TestServer.make_response()
+    |> TestServer.with_response(context, "/fees.all")
   end
 end

--- a/apps/omg_watcher_rpc/test/omg_watcher_rpc/web/controllers/fee_test.exs
+++ b/apps/omg_watcher_rpc/test/omg_watcher_rpc/web/controllers/fee_test.exs
@@ -59,8 +59,8 @@ defmodule OMG.WatcherRPC.Web.Controller.FeeTest do
     @tag fixtures: [:phoenix_ecto_sandbox]
     test "raises an error gracefully when childchain is unreachable" do
       assert %{
-               "code" => "client:econnrefused",
-               "description" => "Cannot communicate with the server.",
+               "code" => "connection:childchain_unreachable",
+               "description" => "Cannot communicate with the childchain.",
                "object" => "error"
              } = WatcherHelper.no_success?("/fees.all")
     end


### PR DESCRIPTION
Closes #1308 

## Overview

This PR adds the support for Poison connection error when the watcher queries the childchain in `fees.all`. 

## Testing

Run a watcher with a childchain that is unreachable and call `fees.all`