### PR TITLE
feat: add more config data to /configuration.get endpoint

### DIFF
--- a/apps/omg_child_chain/lib/omg_child_chain/api/configuration.ex
+++ b/apps/omg_child_chain/lib/omg_child_chain/api/configuration.ex
@@ -23,8 +23,10 @@ defmodule OMG.ChildChain.API.Configuration do
   def get_configuration() do
     configuration = %{
       deposit_finality_margin: Configuration.deposit_finality_margin(),
+
       contract_semver: OMG.Eth.Configuration.contract_semver(),
-      network: OMG.Eth.Configuration.network()
+      min_exit_period_seconds: OMG.Eth.Configuration.min_exit_period_seconds(),
+      network: OMG.Eth.Configuration.network(),
     }
 
     {:ok, configuration}

--- a/apps/omg_eth/lib/omg_eth/configuration.ex
+++ b/apps/omg_eth/lib/omg_eth/configuration.ex
@@ -14,14 +14,19 @@
 
 defmodule OMG.Eth.Configuration do
   @moduledoc """
-  Provides access to applications configuration
+  Provides access to plasma-contracts configuration
   """
   @app :omg_eth
+
   def contract_semver() do
     Application.get_env(@app, :contract_semver)
   end
 
   def network() do
     Application.get_env(@app, :network)
+  end
+
+  def min_exit_period_seconds() do
+    Application.get_env(@app, :min_exit_period_seconds)
   end
 end

--- a/apps/omg_watcher/lib/omg_watcher/api/configuration.ex
+++ b/apps/omg_watcher/lib/omg_watcher/api/configuration.ex
@@ -23,11 +23,15 @@ defmodule OMG.Watcher.API.Configuration do
   def get_configuration() do
     configuration = %{
       deposit_finality_margin: Configuration.deposit_finality_margin(),
+
       contract_semver: OMG.Eth.Configuration.contract_semver(),
+      min_exit_period_seconds: OMG.Eth.Configuration.min_exit_period_seconds(),
       network: OMG.Eth.Configuration.network(),
+
       exit_processor_sla_margin: OMG.Watcher.Configuration.exit_processor_sla_margin()
     }
 
     {:ok, configuration}
   end
 end
+


### PR DESCRIPTION

## Overview

Add more config data to the `/configuration.get` API endpoints for CC, Watcher and Watcher Info, to make it easier to get a full picture of a given server's configuration from a single source.

Putting this PR out as a quick draft to get a feel for people's thoughts on this. The initial commit exposes the `min_exit_period_seconds` config variable.

If the idea seems useful, I'd also like to add the following config data:
```
child_chain_url: <child_chain_url>
watcher_url: <watcher_url>
watcher_info_url: <watcher_info_url>
blockexplorer_url: <blockexplorer_url>
contract_transactions_url: <contract_transactions_url>
ethereum_network: <ethereum_network>
authority_address: <authority_address>
eth_vault: <eth_vault>
erc20_vault: <erc20_vault>
payment_exit_game: <payment_exit_game>
plasma_framework_tx_hash: <plasma_framework_tx_hash>
plasma_framework: <plasma_framework>
```
## Changes

Only added and exposed new configuration variable `min_exit_period_seconds` to `OMG.Eth.Configuration`, for the first commit to test the waters.

For simplicity I would like to add all the above variables to all 3 CC, Watcher and Watcher Info, but it's an open question. Should the config data be more tightly scoped to the service and the config variables the service actually uses? Eg: The CC's `/configuration.get` doesn't need to have the `child_chain_url: <child_chain_url>` key/value returned in its config, but it doesn't hurt. CC/Watcher/Watcher Info also don't use `blockexplorer_url: <blockexplorer_url>`, but still might be useful to have.

Regarding contract addresses, tx hashes and authority addresses, is there any config data that we would not want included?

## Testing
`curl http:/localhost/configuration.get` and verify that `min_exit_period_seconds` is in the output with a value of 120.
