### PR TITLE
fix: formatter using * without wildcard

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -8,7 +8,7 @@
     "priv/*/config/config.exs",
     "priv/*/mix.exs",
   ]
-  ++ (Path.wildcard("priv/*/apps/*/mix.exs") -- ["priv/*/apps/watcher_info_api/mix.exs", "priv/*/apps/watcher_security_critical_api/mix.exs", "priv/*/apps/child_chain_api/mix.exs"])
+  ++ (Path.wildcard("priv/*/apps/*/mix.exs") -- (Path.wildcard("priv/*/apps/watcher_info_api/mix.exs") ++ Path.wildcard("priv/*/apps/watcher_security_critical_api/mix.exs") ++ Path.wildcard("priv/*/apps/child_chain_api/mix.exs")))
   ++ (Path.wildcard("priv/*/apps/*/{lib,test,config}/**/*.{ex,exs}") -- (Path.wildcard("priv/*/apps/watcher_info_api/{lib,test,config}/**/*.{ex,exs}") ++ Path.wildcard("priv/*/apps/watcher_security_critical_api/{lib,test,config}/**/*.{ex,exs}") ++ Path.wildcard("priv/*/apps/child_chain_api/{lib,test,config}/**/*.{ex,exs}"))),
   line_length: 120
 ]

--- a/.formatter.exs
+++ b/.formatter.exs
@@ -8,7 +8,10 @@
     "priv/*/config/config.exs",
     "priv/*/mix.exs",
   ]
-  ++ (Path.wildcard("priv/*/apps/*/mix.exs") -- (Path.wildcard("priv/*/apps/watcher_info_api/mix.exs") ++ Path.wildcard("priv/*/apps/watcher_security_critical_api/mix.exs") ++ Path.wildcard("priv/*/apps/child_chain_api/mix.exs")))
+  ++ (Path.wildcard("priv/*/apps/*/mix.exs") -- Enum.flat_map(
+    ["priv/*/apps/watcher_info_api/mix.exs", "priv/*/apps/watcher_security_critical_api/mix.exs", "priv/*/apps/child_chain_api/mix.exs"],
+    &Path.wildcard/1
+  ))
   ++ (Path.wildcard("priv/*/apps/*/{lib,test,config}/**/*.{ex,exs}") -- (Path.wildcard("priv/*/apps/watcher_info_api/{lib,test,config}/**/*.{ex,exs}") ++ Path.wildcard("priv/*/apps/watcher_security_critical_api/{lib,test,config}/**/*.{ex,exs}") ++ Path.wildcard("priv/*/apps/child_chain_api/{lib,test,config}/**/*.{ex,exs}"))),
   line_length: 120
 ]


### PR DESCRIPTION
## Overview

Previous PR: https://github.com/omisego/elixir-omg/pull/1323 forgot to use `wildcard` when using `*` on path, causing format failure once you have swagger client generated.

## Changes
- use `Path.wildcard`

## Testing

`mix format --check-formatted` with swagger client generated
