### PR TITLE
double the max_header_value_length

### DIFF
--- a/apps/omg_child_chain_rpc/config/config.exs
+++ b/apps/omg_child_chain_rpc/config/config.exs
@@ -1,3 +1,6 @@
+use Mix.Config
+
+# Configures the endpoint
 # https://ninenines.eu/docs/en/cowboy/2.4/manual/cowboy_http/
 # defaults are:
 # protocol_options:[max_header_name_length: 64,
@@ -5,9 +8,6 @@
 # max_headers: 100,
 # max_request_line_length: 8096
 # ]
-use Mix.Config
-
-# Configures the endpoint
 config :omg_child_chain_rpc, OMG.ChildChainRPC.Web.Endpoint,
   render_errors: [view: OMG.ChildChainRPC.Web.Views.Error, accepts: ~w(json)],
   instrumenters: [SpandexPhoenix.Instrumenter],

--- a/apps/omg_child_chain_rpc/config/config.exs
+++ b/apps/omg_child_chain_rpc/config/config.exs
@@ -1,10 +1,10 @@
-# This file is responsible for configuring your application
-# and its dependencies with the aid of the Mix.Config module.
-#
-# This configuration file is loaded before any dependency and
-# is restricted to this project.
-
-# General application configuration
+# https://ninenines.eu/docs/en/cowboy/2.4/manual/cowboy_http/
+# defaults are:
+# protocol_options:[max_header_name_length: 64,
+# max_header_value_length: 4096,
+# max_headers: 100,
+# max_request_line_length: 8096
+# ]
 use Mix.Config
 
 # Configures the endpoint
@@ -12,7 +12,7 @@ config :omg_child_chain_rpc, OMG.ChildChainRPC.Web.Endpoint,
   render_errors: [view: OMG.ChildChainRPC.Web.Views.Error, accepts: ~w(json)],
   instrumenters: [SpandexPhoenix.Instrumenter],
   enable_cors: true,
-  http: [:inet6, port: 9656],
+  http: [:inet6, port: 9656, protocol_options: [max_request_line_length: 8192, max_header_value_length: 8192]],
   url: [host: "cc.example.com", port: 80],
   code_reloader: false
 

--- a/apps/omg_status/mix.exs
+++ b/apps/omg_status/mix.exs
@@ -35,7 +35,7 @@ defmodule OMG.Status.Mixfile do
     do: [
       {:telemetry, "~> 0.4.0"},
       {:sentry, "~> 7.0"},
-      {:statix, git: "https://github.com/bleacherreport/statix.git", branch: "otp-21.3.8.4-support"},
+      {:statix, git: "https://github.com/omisego/statix.git", branch: "otp-21.3.8.4-support-global-tag-patch"},
       {:spandex_datadog, "~> 0.4"},
       {:decorator, "~> 1.2"},
       {:vmstats, "~> 2.3", runtime: false},

--- a/apps/omg_watcher_rpc/config/config.exs
+++ b/apps/omg_watcher_rpc/config/config.exs
@@ -1,8 +1,10 @@
-# This file is responsible for configuring your application
-# and its dependencies with the aid of the Mix.Config module.
-#
-# This configuration file is loaded before any dependency and
-# is restricted to this project.
+# https://ninenines.eu/docs/en/cowboy/2.4/manual/cowboy_http/
+# defaults are:
+# protocol_options:[max_header_name_length: 64,
+# max_header_value_length: 4096,
+# max_headers: 100,
+# max_request_line_length: 8096
+# ]
 use Mix.Config
 
 # In mix environment, all modules are loaded, therefore it behaves like a watcher_info
@@ -15,7 +17,7 @@ config :omg_watcher_rpc, OMG.WatcherRPC.Web.Endpoint,
   pubsub: [name: OMG.WatcherRPC.PubSub, adapter: Phoenix.PubSub.PG2],
   instrumenters: [SpandexPhoenix.Instrumenter],
   enable_cors: true,
-  http: [:inet6, port: 7434],
+  http: [:inet6, port: 7434, protocol_options: [max_request_line_length: 8192, max_header_value_length: 8192]],
   url: [host: "w.example.com", port: 80],
   code_reloader: false
 

--- a/apps/omg_watcher_rpc/config/config.exs
+++ b/apps/omg_watcher_rpc/config/config.exs
@@ -1,10 +1,3 @@
-# https://ninenines.eu/docs/en/cowboy/2.4/manual/cowboy_http/
-# defaults are:
-# protocol_options:[max_header_name_length: 64,
-# max_header_value_length: 4096,
-# max_headers: 100,
-# max_request_line_length: 8096
-# ]
 use Mix.Config
 
 # In mix environment, all modules are loaded, therefore it behaves like a watcher_info
@@ -12,6 +5,13 @@ config :omg_watcher_rpc,
   api_mode: :watcher_info
 
 # Configures the endpoint
+# https://ninenines.eu/docs/en/cowboy/2.4/manual/cowboy_http/
+# defaults are:
+# protocol_options:[max_header_name_length: 64,
+# max_header_value_length: 4096,
+# max_headers: 100,
+# max_request_line_length: 8096
+# ]
 config :omg_watcher_rpc, OMG.WatcherRPC.Web.Endpoint,
   render_errors: [view: OMG.WatcherRPC.Web.Views.Error, accepts: ~w(json)],
   pubsub: [name: OMG.WatcherRPC.PubSub, adapter: Phoenix.PubSub.PG2],

--- a/mix.lock
+++ b/mix.lock
@@ -72,8 +72,8 @@
   "spandex_ecto": {:hex, :spandex_ecto, "0.6.0", "feedda8456deb37a87ee698f1f779304b68e7e42afc7c1fe5b9f801a732b89d6", [:mix], [{:spandex, "~> 2.2", [hex: :spandex, repo: "hexpm", optional: false]}], "hexpm", "67e1a6905efa77106b48405cc26d452e49473b5822c33eb2edc1544bcb378404"},
   "spandex_phoenix": {:hex, :spandex_phoenix, "0.4.1", "d52e12f801fce4efba658ac4e98be18ea9903ecf9f37682b401656ed8d9c7abe", [:mix], [{:plug, "~> 1.3", [hex: :plug, repo: "hexpm", optional: false]}, {:spandex, "~> 2.2", [hex: :spandex, repo: "hexpm", optional: false]}], "hexpm", "79bb8271e2db5e6113643a52a293504af75476946aa9c47517437f0e52830f01"},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.5", "6eaf7ad16cb568bb01753dbbd7a95ff8b91c7979482b95f38443fe2c8852a79b", [:make, :mix, :rebar3], [], "hexpm", "13104d7897e38ed7f044c4de953a6c28597d1c952075eb2e328bc6d6f2bfc496"},
-  "statix": {:git, "https://github.com/bleacherreport/statix.git", "f27c37bee69d1bbae89532049f6d3250b348f0ac", [branch: "otp-21.3.8.4-support"]},
+  "statix": {:git, "https://github.com/omisego/statix.git", "50745f14fd1d44297818a48336f041c228a0920f", [branch: "otp-21.3.8.4-support-global-tag-patch"]},
   "telemetry": {:hex, :telemetry, "0.4.0", "8339bee3fa8b91cb84d14c2935f8ecf399ccd87301ad6da6b71c09553834b2ab", [:rebar3], [], "hexpm", "e9e3cacfd37c1531c0ca70ca7c0c30ce2dbb02998a4f7719de180fe63f8d41e4"},
   "unicode_util_compat": {:hex, :unicode_util_compat, "0.4.1", "d869e4c68901dd9531385bb0c8c40444ebf624e60b6962d95952775cac5e90cd", [:rebar3], [], "hexpm", "1d1848c40487cdb0b30e8ed975e34e025860c02e419cb615d255849f3427439d"},
-  "vmstats": {:hex, :vmstats, "2.3.1", "fa719deb51c53672955cbf0e131cfe85be51732c700d2b58232157ac0478bf4a", [:rebar3], [], "hexpm", "8bf44615d8cca003d39e66eb2ec761eef37c0dd4f9a74e4dc98e125031c8df70"}
+  "vmstats": {:hex, :vmstats, "2.3.1", "fa719deb51c53672955cbf0e131cfe85be51732c700d2b58232157ac0478bf4a", [:rebar3], [], "hexpm", "8bf44615d8cca003d39e66eb2ec761eef37c0dd4f9a74e4dc98e125031c8df70"},
 }


### PR DESCRIPTION
We've seen occurrences of
```

error] module=Plug.Cowboy function=onresponse/4 ⋅Cowboy returned 400 because it was unable to parse the request headers.
--
  | Feb 20 04:00:17.860 | This may happen because there are no headers, or there are too many headers
  | Feb 20 04:00:17.860 | or the header name or value are too large (such as a large cookie).
  | Feb 20 04:00:17.860 | You can customize those values when configuring your http/https
  | Feb 20 04:00:17.860 | server. The configuration option and default values are shown below:
  | Feb 20 04:00:17.860 | protocol_options: [
  | Feb 20 04:00:17.860 | max_header_name_length: 64,
  | Feb 20 04:00:17.861 | max_header_value_length: 4096,
  | Feb 20 04:00:17.861 | max_headers: 100,
  | Feb 20 04:00:17.861 | max_request_line_length: 8096
  | Feb 20 04:00:17.861 | ]
  | Feb 20 04:00:17.861 | ⋅


```


added fixes for Statix on our fork https://github.com/bleacherreport/statix/pull/1