### PR TITLE
fix: internal server error when making requests to unsupported endpoints

### DIFF
--- a/apps/omg_watcher_rpc/lib/web/plugs/supported_watcher_modes.ex
+++ b/apps/omg_watcher_rpc/lib/web/plugs/supported_watcher_modes.ex
@@ -27,8 +27,13 @@ defmodule OMG.WatcherRPC.Web.Plugs.SupportedWatcherModes do
   @spec call(Plug.Conn.t(), [atom()]) :: Plug.Conn.t()
   def call(conn, supported_modes) do
     case Application.get_env(@app, :api_mode) in supported_modes do
-      true -> conn
-      false -> Controller.Fallback.call(conn, {:error, :operation_not_found})
+      true ->
+        conn
+
+      false ->
+        conn
+        |> Controller.Fallback.call({:error, :operation_not_found})
+        |> Plug.Conn.halt()
     end
   end
 end

--- a/apps/omg_watcher_rpc/lib/web/router.ex
+++ b/apps/omg_watcher_rpc/lib/web/router.ex
@@ -21,13 +21,13 @@ defmodule OMG.WatcherRPC.Web.Router do
   end
 
   pipeline :security_api do
-    plug(SupportedWatcherModes, [:watcher, :watcher_info])
     plug(:accepts, ["json"])
+    plug(SupportedWatcherModes, [:watcher, :watcher_info])
   end
 
   pipeline :info_api do
-    plug(SupportedWatcherModes, [:watcher_info])
     plug(:accepts, ["json"])
+    plug(SupportedWatcherModes, [:watcher_info])
   end
 
   # A note on scope ordering.

--- a/apps/omg_watcher_rpc/test/omg_watcher_rpc/web/router_test.exs
+++ b/apps/omg_watcher_rpc/test/omg_watcher_rpc/web/router_test.exs
@@ -1,0 +1,46 @@
+# Copyright 2019-2020 OmiseGO Pte Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defmodule OMG.WatcherRPC.Web.RouterTest do
+  # async: false as we need to change :api_mode application env.
+  use ExUnitFixtures
+  use ExUnit.Case, async: false
+  use OMG.WatcherInfo.Fixtures
+
+  alias Support.WatcherHelper
+
+  setup do
+    original_mode = Application.get_env(:omg_watcher_rpc, :api_mode)
+    _ = on_exit(fn -> Application.put_env(:omg_watcher_rpc, :api_mode, original_mode) end)
+
+    :ok
+  end
+
+  @tag fixtures: [:phoenix_ecto_sandbox]
+  test "returns a successful response when calling an :info_api endpoint from :watcher_info mode" do
+    :ok = Application.put_env(:omg_watcher_rpc, :api_mode, :watcher_info)
+    assert WatcherHelper.success?("transaction.all", %{})
+  end
+
+  @tag fixtures: [:phoenix_ecto_sandbox]
+  test "returns an error response when calling an :info_api endpoint from :watcher mode" do
+    :ok = Application.put_env(:omg_watcher_rpc, :api_mode, :watcher)
+
+    assert %{
+             "object" => "error",
+             "code" => "operation:not_found",
+             "description" => "Operation cannot be found. Check request URL."
+           } == WatcherHelper.no_success?("transaction.all", %{})
+  end
+end


### PR DESCRIPTION
Closes #1292 

## Overview

This PR fixes the internal server error returned when requests are made to the unsupported watcher mode.

## Changes

- `Plugs.SupportedWatcherModes` halts the pipeline on error so no further processing is done
- `plug(:accepts, ["json"])` is moved above `Plugs.SupportedWatcherModes` so Phoenix knows to render the error template as json.

## Testing

An informational API call to watcher should render proper error:

```
curl -X POST http://watcher-not-watcher-info/transaction.all \
-H "Content-Type: application/json" \
-d '{}' \
-v -w "\n" | jq

{
  "data": {
    "code": "operation:not_found",
    "description": "Operation cannot be found. Check request URL.",
    "object": "error"
  },
  "service_name": "watcher",
  "success": false,
  "version": "0.3.0+dc971b2"
}
```