### PR TITLE
Cabbagize invalid exit tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -540,9 +540,9 @@ jobs:
           name: Run Child Chain, Watcher and Watcher Info
           command: |
             set -e
-            make start-child_chain OVERRIDING_START=start &&
-            make start-watcher OVERRIDING_START=start &&
-            make start-watcher_info OVERRIDING_START=foreground
+            make start-child_chain OVERRIDING_START=start OVERRIDING_VARIABLES=./bin/variables_test_barebone &&
+            make start-watcher OVERRIDING_START=start OVERRIDING_VARIABLES=./bin/variables_test_barebone &&
+            make start-watcher_info OVERRIDING_START=foreground OVERRIDING_VARIABLES=./bin/variables_test_barebone
           background: true
           no_output_timeout: 2400
       - run:

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 MAKEFLAGS += --silent
 OVERRIDING_START ?= foreground
+OVERRIDING_VARIABLES ?= ./bin/variables
 SNAPSHOT ?= SNAPSHOT_MIX_EXIT_PERIOD_SECONDS_20
 BAREBUILD_ENV ?= dev
 help:
@@ -373,7 +374,7 @@ start-services:
 	docker-compose up geth postgres
 
 start-child_chain:
-	set -e; . ./bin/variables; \
+	set -e; . ${OVERRIDING_VARIABLES}; \
 	echo "Building Child Chain" && \
 	make build-child_chain-${BAREBUILD_ENV} && \
 	rm -f ./_build/${BAREBUILD_ENV}/rel/child_chain/var/sys.config || true && \
@@ -383,7 +384,7 @@ start-child_chain:
 	_build/${BAREBUILD_ENV}/rel/child_chain/bin/child_chain $(OVERRIDING_START)
 
 start-watcher:
-	set -e; . ./bin/variables; \
+	set -e; . ${OVERRIDING_VARIABLES}; \
 	echo "Building Watcher" && \
 	make build-watcher-${BAREBUILD_ENV} && \
 	echo "Potential cleanup" && \
@@ -395,7 +396,7 @@ start-watcher:
 	PORT=${WATCHER_PORT} _build/${BAREBUILD_ENV}/rel/watcher/bin/watcher $(OVERRIDING_START)
 
 start-watcher_info:
-	set -e; . ./bin/variables; \
+	set -e; . ${OVERRIDING_VARIABLES}; \
 	echo "Building Watcher Info" && \
 	make build-watcher_info-${BAREBUILD_ENV} && \
 	echo "Potential cleanup" && \
@@ -410,19 +411,19 @@ start-watcher_info:
 update-child_chain:
 	_build/dev/rel/child_chain/bin/child_chain stop ; \
 	$(ENV_DEV) mix do compile, distillery.release dev --name child_chain --silent && \
-	set -e; . ./bin/variables && \
+	set -e; . ${OVERRIDING_VARIABLES} && \
 	exec _build/dev/rel/child_chain/bin/child_chain $(OVERRIDING_START) &
 
 update-watcher:
 	_build/dev/rel/watcher/bin/watcher stop ; \
 	$(ENV_DEV) mix do compile, distillery.release dev --name watcher --silent && \
-	set -e; . ./bin/variables && \
+	set -e; . ${OVERRIDING_VARIABLES} && \
 	exec PORT=${WATCHER_PORT} _build/dev/rel/watcher/bin/watcher $(OVERRIDING_START) &
 
 update-watcher_info:
 	_build/dev/rel/watcher_info/bin/watcher_info stop ; \
 	$(ENV_DEV) mix do compile, distillery.release dev --name watcher_info --silent && \
-	set -e; . ./bin/variables && \
+	set -e; . ${OVERRIDING_VARIABLES} && \
 	exec PORT=${WATCHER_INFO_PORT} _build/dev/rel/watcher_info/bin/watcher_info $(OVERRIDING_START) &
 
 stop-child_chain:
@@ -435,15 +436,15 @@ stop-watcher_info:
 	_build/dev/rel/watcher_info/bin/watcher_info stop
 
 remote-child_chain:
-	set -e; . ./bin/variables && \
+	set -e; . ${OVERRIDING_VARIABLES} && \
 	_build/dev/rel/child_chain/bin/child_chain remote_console
 
 remote-watcher:
-	set -e; . ./bin/variables && \
+	set -e; . ${OVERRIDING_VARIABLES} && \
 	_build/dev/rel/watcher/bin/watcher remote_console
 
 remote-watcher_info:
-	set -e; . ./bin/variables && \
+	set -e; . ${OVERRIDING_VARIABLES} && \
 	_build/dev/rel/watcher_info/bin/watcher_info remote_console
 
 get-alarms:

--- a/apps/omg_watcher/test/omg_watcher/integration/block_getter_test.exs
+++ b/apps/omg_watcher/test/omg_watcher/integration/block_getter_test.exs
@@ -38,6 +38,8 @@ defmodule OMG.Watcher.Integration.BlockGetterTest do
 
   require Utxo
 
+  import ExUnit.CaptureLog, only: [capture_log: 1]
+
   @timeout 40_000
   @eth OMG.Eth.RootChain.eth_pseudo_address()
 
@@ -169,6 +171,47 @@ defmodule OMG.Watcher.Integration.BlockGetterTest do
   end
 
   @tag fixtures: [:in_beam_watcher, :stable_alice, :mix_based_child_chain, :token, :stable_alice_deposits, :test_server]
+  test "transaction which is spending an exiting output before the `sla_margin` causes an invalid_exit event only",
+       %{stable_alice: alice, stable_alice_deposits: {deposit_blknum, _}, test_server: context} do
+    tx = OMG.TestHelper.create_encoded([{deposit_blknum, 0, 0, alice}], @eth, [{alice, 9}])
+    %{"blknum" => exit_blknum} = WatcherHelper.submit(tx)
+
+    # Here we're preparing invalid block
+    bad_block_number = 2_000
+    bad_tx = OMG.TestHelper.create_recovered([{exit_blknum, 0, 0, alice}], @eth, [{alice, 9}])
+
+    %{hash: bad_block_hash, number: _, transactions: _} =
+      bad_block = OMG.Block.hashed_txs_at([bad_tx], bad_block_number)
+
+    # from now on the child chain server is broken until end of test
+    BadChildChainServer.prepare_route_to_inject_bad_block(context, bad_block)
+
+    IntegrationTest.wait_for_block_fetch(exit_blknum, @timeout)
+
+    %{
+      "txbytes" => txbytes,
+      "proof" => proof,
+      "utxo_pos" => utxo_pos
+    } = WatcherHelper.get_exit_data(exit_blknum, 0, 0)
+
+    {:ok, %{"status" => "0x1", "blockNumber" => _eth_height}} =
+      RootChainHelper.start_exit(
+        utxo_pos,
+        txbytes,
+        proof,
+        alice.addr
+      )
+      |> DevHelper.transact_sync!()
+
+    # Here we're manually submitting invalid block to the root chain
+    # NOTE: this **must** come after `start_exit` is mined (see just above) but still not later than
+    #       `sla_margin` after exit start, hence the `config/test.exs` entry for the margin is rather high
+    {:ok, _} = Eth.submit_block(bad_block_hash, 2, 1)
+
+    IntegrationTest.wait_for_byzantine_events([%Event.InvalidExit{}.name], @timeout)
+  end
+
+  @tag fixtures: [:in_beam_watcher, :stable_alice, :mix_based_child_chain, :token, :stable_alice_deposits, :test_server]
   test "transaction which is spending an exiting output after the `sla_margin` causes an unchallenged_exit event",
        %{stable_alice: alice, stable_alice_deposits: {deposit_blknum, _}, test_server: context} do
     tx = OMG.TestHelper.create_encoded([{deposit_blknum, 0, 0, alice}], @eth, [{alice, 9}])
@@ -219,6 +262,46 @@ defmodule OMG.Watcher.Integration.BlockGetterTest do
     WatcherHelper.get_exit_challenge(exit_blknum, 0, 0)
   end
 
+  @tag fixtures: [:in_beam_watcher, :stable_alice, :mix_based_child_chain, :token, :stable_alice_deposits]
+  test "block getting halted by block withholding doesn't halt detection of new invalid exits", %{
+    stable_alice: alice,
+    stable_alice_deposits: {deposit_blknum, _}
+  } do
+    tx = OMG.TestHelper.create_encoded([{deposit_blknum, 0, 0, alice}], @eth, [{alice, 9}])
+    %{"blknum" => deposit_blknum} = WatcherHelper.submit(tx)
+
+    tx = OMG.TestHelper.create_encoded([{deposit_blknum, 0, 0, alice}], @eth, [{alice, 8}])
+    %{"blknum" => tx_blknum, "txhash" => _tx_hash} = WatcherHelper.submit(tx)
+
+    IntegrationTest.wait_for_block_fetch(tx_blknum, @timeout)
+
+    {_, nonce} = get_next_blknum_nonce(tx_blknum)
+
+    {:ok, _txhash} = Eth.submit_block(<<0::256>>, nonce, 20_000_000_000)
+
+    # checking if both machines and humans learn about the byzantine condition
+    assert capture_log(fn ->
+             IntegrationTest.wait_for_byzantine_events([%Event.BlockWithholding{}.name], @timeout)
+           end) =~ inspect(:withholding)
+
+    %{
+      "txbytes" => txbytes,
+      "proof" => proof,
+      "utxo_pos" => utxo_pos
+    } = WatcherHelper.get_exit_data(deposit_blknum, 0, 0)
+
+    {:ok, %{"status" => "0x1", "blockNumber" => _eth_height}} =
+      RootChainHelper.start_exit(
+        utxo_pos,
+        txbytes,
+        proof,
+        alice.addr
+      )
+      |> DevHelper.transact_sync!()
+
+    IntegrationTest.wait_for_byzantine_events([%Event.BlockWithholding{}.name, %Event.InvalidExit{}.name], @timeout)
+  end
+
   @tag fixtures: [:in_beam_watcher, :mix_based_child_chain, :test_server, :stable_alice, :stable_alice_deposits]
   test "operator claimed fees incorrectly (too much | little amount, not collected token)", %{
     stable_alice: alice,
@@ -247,5 +330,11 @@ defmodule OMG.Watcher.Integration.BlockGetterTest do
              {:ok, _txhash} = Eth.submit_block(block_overclaiming_fees.hash, 1, 20_000_000_000)
              IntegrationTest.wait_for_byzantine_events([%Event.InvalidBlock{}.name], @timeout)
            end) =~ inspect({:tx_execution, :claimed_and_collected_amounts_mismatch})
+  end
+
+  defp get_next_blknum_nonce(blknum) do
+    child_block_interval = Application.fetch_env!(:omg_eth, :child_block_interval)
+    next_blknum = blknum + child_block_interval
+    {next_blknum, trunc(next_blknum / child_block_interval)}
   end
 end

--- a/apps/omg_watcher/test/omg_watcher/integration/invalid_exit_test.exs
+++ b/apps/omg_watcher/test/omg_watcher/integration/invalid_exit_test.exs
@@ -100,7 +100,7 @@ defmodule OMG.Watcher.Integration.InvalidExitTest do
   end
 
   @tag fixtures: [:in_beam_watcher, :stable_alice, :mix_based_child_chain, :token, :stable_alice_deposits, :test_server]
-  test "transaction which is using already spent utxo from exit and happened before end of margin of slow validator (m_sv) causes to emit invalid_exit event",
+  test "transaction which is spending an exiting output before the `sla_margin` causes an invalid_exit event only",
        %{stable_alice: alice, stable_alice_deposits: {deposit_blknum, _}, test_server: context} do
     tx = OMG.TestHelper.create_encoded([{deposit_blknum, 0, 0, alice}], @eth, [{alice, 9}])
     %{"blknum" => exit_blknum} = WatcherHelper.submit(tx)
@@ -177,7 +177,7 @@ defmodule OMG.Watcher.Integration.InvalidExitTest do
       )
       |> DevHelper.transact_sync!()
 
-    IntegrationTest.wait_for_byzantine_events([%Event.InvalidExit{}.name], @timeout)
+    IntegrationTest.wait_for_byzantine_events([%Event.BlockWithholding{}.name, %Event.InvalidExit{}.name], @timeout)
   end
 
   defp get_next_blknum_nonce(blknum) do

--- a/apps/omg_watcher/test/omg_watcher/integration/invalid_exit_test.exs
+++ b/apps/omg_watcher/test/omg_watcher/integration/invalid_exit_test.exs
@@ -19,18 +19,14 @@ defmodule OMG.Watcher.Integration.InvalidExitTest do
   use OMG.ChildChain.Integration.Fixtures
   use Plug.Test
 
-  alias OMG.Eth
   alias OMG.Utxo
   alias OMG.Watcher.Event
-  alias OMG.Watcher.Integration.BadChildChainServer
   alias OMG.Watcher.Integration.TestHelper, as: IntegrationTest
   alias Support.DevHelper
   alias Support.RootChainHelper
   alias Support.WatcherHelper
 
   require Utxo
-
-  import ExUnit.CaptureLog
 
   @moduletag :integration
   @moduletag :watcher
@@ -99,90 +95,44 @@ defmodule OMG.Watcher.Integration.InvalidExitTest do
     IntegrationTest.wait_for_byzantine_events([], @timeout)
   end
 
-  @tag fixtures: [:in_beam_watcher, :stable_alice, :mix_based_child_chain, :token, :stable_alice_deposits, :test_server]
-  test "transaction which is spending an exiting output before the `sla_margin` causes an invalid_exit event only",
-       %{stable_alice: alice, stable_alice_deposits: {deposit_blknum, _}, test_server: context} do
-    tx = OMG.TestHelper.create_encoded([{deposit_blknum, 0, 0, alice}], @eth, [{alice, 9}])
-    %{"blknum" => exit_blknum} = WatcherHelper.submit(tx)
+  @tag fixtures: [:in_beam_watcher, :stable_alice, :mix_based_child_chain, :token, :stable_alice_deposits]
+  test "invalid_exit without a challenge raises unchallenged_exit after sla_margin had passed, can be challenged",
+       %{stable_alice: alice, stable_alice_deposits: {deposit_blknum, _}} do
+    %{"blknum" => first_tx_blknum} =
+      OMG.TestHelper.create_encoded([{deposit_blknum, 0, 0, alice}], @eth, [{alice, 9}]) |> WatcherHelper.submit()
 
-    # Here we're preparing invalid block
-    bad_block_number = 2_000
-    bad_tx = OMG.TestHelper.create_recovered([{exit_blknum, 0, 0, alice}], @eth, [{alice, 9}])
+    %{"blknum" => second_tx_blknum} =
+      OMG.TestHelper.create_encoded([{first_tx_blknum, 0, 0, alice}], @eth, [{alice, 8}]) |> WatcherHelper.submit()
 
-    %{hash: bad_block_hash, number: _, transactions: _} =
-      bad_block = OMG.Block.hashed_txs_at([bad_tx], bad_block_number)
+    IntegrationTest.wait_for_block_fetch(second_tx_blknum, @timeout)
 
-    # from now on the child chain server is broken until end of test
-    BadChildChainServer.prepare_route_to_inject_bad_block(context, bad_block)
+    %{"txbytes" => txbytes, "proof" => proof, "utxo_pos" => tx_utxo_pos} =
+      WatcherHelper.get_exit_data(first_tx_blknum, 0, 0)
 
-    IntegrationTest.wait_for_block_fetch(exit_blknum, @timeout)
-
-    %{
-      "txbytes" => txbytes,
-      "proof" => proof,
-      "utxo_pos" => utxo_pos
-    } = WatcherHelper.get_exit_data(exit_blknum, 0, 0)
-
-    {:ok, %{"status" => "0x1", "blockNumber" => _eth_height}} =
-      RootChainHelper.start_exit(
-        utxo_pos,
-        txbytes,
-        proof,
-        alice.addr
-      )
+    {:ok, %{"status" => "0x1", "blockNumber" => eth_height}} =
+      RootChainHelper.start_exit(tx_utxo_pos, txbytes, proof, alice.addr)
       |> DevHelper.transact_sync!()
-
-    # Here we're manually submitting invalid block to the root chain
-    # NOTE: this **must** come after `start_exit` is mined (see just above) but still not later than
-    #       `sla_margin` after exit start, hence the `config/test.exs` entry for the margin is rather high
-    {:ok, _} = Eth.submit_block(bad_block_hash, 2, 1)
 
     IntegrationTest.wait_for_byzantine_events([%Event.InvalidExit{}.name], @timeout)
-  end
 
-  @tag fixtures: [:in_beam_watcher, :stable_alice, :mix_based_child_chain, :token, :stable_alice_deposits]
-  test "invalid exit is detected after block withholding", %{
-    stable_alice: alice,
-    stable_alice_deposits: {deposit_blknum, _}
-  } do
-    tx = OMG.TestHelper.create_encoded([{deposit_blknum, 0, 0, alice}], @eth, [{alice, 9}])
-    %{"blknum" => deposit_blknum} = WatcherHelper.submit(tx)
+    exit_processor_sla_margin = Application.fetch_env!(:omg_watcher, :exit_processor_sla_margin)
+    DevHelper.wait_for_root_chain_block(eth_height + exit_processor_sla_margin, @timeout)
+    IntegrationTest.wait_for_byzantine_events([%Event.InvalidExit{}.name, %Event.UnchallengedExit{}.name], @timeout)
 
-    tx = OMG.TestHelper.create_encoded([{deposit_blknum, 0, 0, alice}], @eth, [{alice, 8}])
-    %{"blknum" => tx_blknum, "txhash" => _tx_hash} = WatcherHelper.submit(tx)
+    # after the notification has been received, a challenged is composed and sent, regardless of it being late
+    challenge = WatcherHelper.get_exit_challenge(first_tx_blknum, 0, 0)
 
-    IntegrationTest.wait_for_block_fetch(tx_blknum, @timeout)
+    assert {:ok, %{"status" => "0x1"}} =
+             RootChainHelper.challenge_exit(
+               challenge["exit_id"],
+               challenge["exiting_tx"],
+               challenge["txbytes"],
+               challenge["input_index"],
+               challenge["sig"],
+               alice.addr
+             )
+             |> DevHelper.transact_sync!()
 
-    {_, nonce} = get_next_blknum_nonce(tx_blknum)
-
-    {:ok, _txhash} = Eth.submit_block(<<0::256>>, nonce, 20_000_000_000)
-
-    # checking if both machines and humans learn about the byzantine condition
-    assert capture_log(fn ->
-             IntegrationTest.wait_for_byzantine_events([%Event.BlockWithholding{}.name], @timeout)
-           end) =~ inspect(:withholding)
-
-    %{
-      "txbytes" => txbytes,
-      "proof" => proof,
-      "utxo_pos" => utxo_pos
-    } = WatcherHelper.get_exit_data(deposit_blknum, 0, 0)
-
-    {:ok, %{"status" => "0x1", "blockNumber" => _eth_height}} =
-      RootChainHelper.start_exit(
-        utxo_pos,
-        txbytes,
-        proof,
-        alice.addr
-      )
-      |> DevHelper.transact_sync!()
-
-    IntegrationTest.wait_for_byzantine_events([%Event.BlockWithholding{}.name, %Event.InvalidExit{}.name], @timeout)
-  end
-
-  defp get_next_blknum_nonce(blknum) do
-    child_block_interval = Application.fetch_env!(:omg_eth, :child_block_interval)
-    next_blknum = blknum + child_block_interval
-    {next_blknum, trunc(next_blknum / child_block_interval)}
+    IntegrationTest.wait_for_byzantine_events([], @timeout)
   end
 end

--- a/apps/omg_watcher/test/support/integration/test_helper.ex
+++ b/apps/omg_watcher/test/support/integration/test_helper.ex
@@ -31,12 +31,7 @@ defmodule OMG.Watcher.Integration.TestHelper do
       %{"byzantine_events" => emitted_events} = WatcherHelper.success?("/status.get")
       emitted_event_names = Enum.map(emitted_events, &String.to_atom(&1["event"]))
 
-      all_events =
-        Enum.all?(event_names, fn x ->
-          x in emitted_event_names
-        end)
-
-      if all_events,
+      if Enum.sort(emitted_event_names) == Enum.sort(event_names),
         do: {:ok, emitted_event_names},
         else: :repeat
     end

--- a/bin/variables_test_barebone
+++ b/bin/variables_test_barebone
@@ -1,0 +1,33 @@
+#!/usr/bin/env sh
+
+# this is a version of the bin/variables script which enables cabbage integration tests to run against a test-friendly
+# setup of our services
+
+# test_barebone_release taylored values. Compare also with priv/cabbage/docker-compose-cabbage.yml
+export EXIT_PROCESSOR_SLA_MARGIN=30
+
+# the rest stays same as bin/variables
+export REPLACE_OS_VARS=true
+export NODE_HOST=127.0.0.1
+export ERLANG_COOKIE=develop
+export APP_ENV=local-development
+export HOSTNAME=http://localhost/
+export DB_PATH=~/plasma-data/
+export ETHEREUM_RPC_URL=http://127.0.0.1:8545
+export ETH_NODE=geth
+export ETHEREUM_NETWORK=LOCALCHAIN
+export DATABASE_URL=postgresql://omisego_dev:omisego_dev@127.0.0.1:5432/omisego_dev
+export CHILD_CHAIN_URL=http://127.0.0.1:9656
+export ETHEREUM_HEIGHT_CHECK_INTERVAL_MS=800
+export ETHEREUM_EVENTS_CHECK_INTERVAL_MS=800
+export ETHEREUM_STALLED_SYNC_THRESHOLD_MS=20000
+export FEE_CLAIMER_ADDRESS=0x3b9f4c1dd26e0be593373b1d36cee2008cbeb837
+export DD_HOSTNAME=localhost
+export DD_DISABLED=false
+export LOGGER_BACKEND=console
+# expects it's executed from the root of the project
+FILE='./localchain_contract_addresses.env'
+while IFS= read -r line; do
+    DATA_TO_EXPORT='export '$line
+    eval $DATA_TO_EXPORT
+done < ${FILE}

--- a/priv/cabbage/Makefile
+++ b/priv/cabbage/Makefile
@@ -12,7 +12,7 @@ start_daemon_services:
 	cd ../../ && \
 	SNAPSHOT=SNAPSHOT_MIX_EXIT_PERIOD_SECONDS_120 make init_test && \
 	cd priv/cabbage/ && \
-	docker-compose -f ../../docker-compose.yml up -d
+	docker-compose -f ../../docker-compose.yml -f docker-compose-cabbage.yml up -d
 
 generate-security_critical_api_specs:
 	priv/openapitools/openapi-generator-cli generate -i ../../apps/omg_watcher_rpc/priv/swagger/security_critical_api_specs.yaml -g elixir -o apps/watcher_security_critical_api

--- a/priv/cabbage/apps/itest/lib/account.ex
+++ b/priv/cabbage/apps/itest/lib/account.ex
@@ -3,34 +3,8 @@ defmodule Itest.Account do
     Maintaining used accounts state so that we're able to run tests multiple times.
   """
 
-  alias Itest.Transactions.Currency
   alias Itest.Transactions.Encoding
   import Itest.Poller, only: [wait_on_receipt_confirmed: 1]
-
-  def plasma_framework() do
-    contracts = parse_contracts()
-
-    contracts["CONTRACT_ADDRESS_PLASMA_FRAMEWORK"]
-    |> EIP55.encode()
-    |> elem(1)
-  end
-
-  @ether_vault_id 1
-  def vault_id(currency) do
-    ether = Currency.ether()
-
-    case currency do
-      ^ether -> @ether_vault_id
-    end
-  end
-
-  def vault(currency) do
-    ether = Currency.ether()
-
-    case currency do
-      ^ether -> get_vault(@ether_vault_id)
-    end
-  end
 
   @spec take_accounts(integer()) :: map()
   def take_accounts(number_of_accounts) do
@@ -92,42 +66,4 @@ defmodule Itest.Account do
   end
 
   defp hash(message), do: ExthCrypto.Hash.hash(message, ExthCrypto.Hash.kec())
-
-  defp get_vault(id) do
-    data = ABI.encode("vaults(uint256)", [id])
-    {:ok, result} = Ethereumex.HttpClient.eth_call(%{to: plasma_framework(), data: Encoding.to_hex(data)})
-
-    result
-    |> Encoding.to_binary()
-    |> ABI.TypeDecoder.decode([:address])
-    |> hd()
-    |> Encoding.to_hex()
-    |> EIP55.encode()
-    |> elem(1)
-  end
-
-  # taken from the plasma-contracts deployment snapshot
-  # this parsing occurs in several places around the codebase
-  defp parse_contracts() do
-    local_umbrella_path = Path.join([File.cwd!(), "../../../../", "localchain_contract_addresses.env"])
-
-    contract_addreses_path =
-      case File.exists?(local_umbrella_path) do
-        true ->
-          local_umbrella_path
-
-        _ ->
-          # CI/CD
-          Path.join([File.cwd!(), "localchain_contract_addresses.env"])
-      end
-
-    contract_addreses_path
-    |> File.read!()
-    |> String.split("\n", trim: true)
-    |> List.flatten()
-    |> Enum.reduce(%{}, fn line, acc ->
-      [key, value] = String.split(line, "=")
-      Map.put(acc, key, value)
-    end)
-  end
 end

--- a/priv/cabbage/apps/itest/lib/api_model/challenge_data.ex
+++ b/priv/cabbage/apps/itest/lib/api_model/challenge_data.ex
@@ -1,0 +1,38 @@
+defmodule Itest.ApiModel.ChallengeData do
+  @moduledoc """
+  The purpose of this module is to represent a specific API response as a struct and validates it's response and validates it's response
+  """
+
+  defstruct [:exit_id, :exiting_tx, :input_index, :sig, :txbytes]
+
+  @type t() :: %__MODULE__{
+          exit_id: pos_integer(),
+          exiting_tx: binary(),
+          input_index: non_neg_integer(),
+          sig: binary(),
+          txbytes: binary
+        }
+
+  def to_struct(attrs) do
+    struct = struct(__MODULE__)
+
+    result =
+      Enum.reduce(Map.to_list(struct), struct, fn {k, _}, acc ->
+        case Map.fetch(attrs, Atom.to_string(k)) do
+          {:ok, v} -> %{acc | k => v}
+          :error -> acc
+        end
+      end)
+
+    true = is_valid(result)
+    result
+  end
+
+  defp is_valid(struct) do
+    is_integer(struct.exit_id) &&
+      is_binary(struct.exiting_tx) &&
+      is_integer(struct.input_index) &&
+      is_binary(struct.sig) &&
+      is_binary(struct.txbytes)
+  end
+end

--- a/priv/cabbage/apps/itest/lib/plasma_framework.ex
+++ b/priv/cabbage/apps/itest/lib/plasma_framework.ex
@@ -1,0 +1,82 @@
+defmodule Itest.PlasmaFramework do
+  @moduledoc """
+  Used to pull information out of the main root chain contract PlasmaFramework.sol
+  """
+
+  alias Itest.Transactions.Currency
+  alias Itest.Transactions.Encoding
+
+  def address() do
+    contracts = parse_contracts()
+
+    contracts["CONTRACT_ADDRESS_PLASMA_FRAMEWORK"]
+    |> EIP55.encode()
+    |> elem(1)
+  end
+
+  @ether_vault_id 1
+  def vault_id(currency) do
+    ether = Currency.ether()
+
+    case currency do
+      ^ether -> @ether_vault_id
+    end
+  end
+
+  def vault(currency) do
+    ether = Currency.ether()
+
+    case currency do
+      ^ether -> get_vault(@ether_vault_id)
+    end
+  end
+
+  def exit_game_contract_address(tx_type) do
+    data = ABI.encode("exitGames(uint256)", [tx_type])
+    {:ok, result} = Ethereumex.HttpClient.eth_call(%{to: address(), data: Encoding.to_hex(data)})
+
+    result
+    |> Encoding.to_binary()
+    |> ABI.TypeDecoder.decode([:address])
+    |> hd()
+    |> Encoding.to_hex()
+  end
+
+  defp get_vault(id) do
+    data = ABI.encode("vaults(uint256)", [id])
+    {:ok, result} = Ethereumex.HttpClient.eth_call(%{to: address(), data: Encoding.to_hex(data)})
+
+    result
+    |> Encoding.to_binary()
+    |> ABI.TypeDecoder.decode([:address])
+    |> hd()
+    |> Encoding.to_hex()
+    |> EIP55.encode()
+    |> elem(1)
+  end
+
+  # taken from the plasma-contracts deployment snapshot
+  # this parsing occurs in several places around the codebase
+  defp parse_contracts() do
+    local_umbrella_path = Path.join([File.cwd!(), "../../../../", "localchain_contract_addresses.env"])
+
+    contract_addreses_path =
+      case File.exists?(local_umbrella_path) do
+        true ->
+          local_umbrella_path
+
+        _ ->
+          # CI/CD
+          Path.join([File.cwd!(), "localchain_contract_addresses.env"])
+      end
+
+    contract_addreses_path
+    |> File.read!()
+    |> String.split("\n", trim: true)
+    |> List.flatten()
+    |> Enum.reduce(%{}, fn line, acc ->
+      [key, value] = String.split(line, "=")
+      Map.put(acc, key, value)
+    end)
+  end
+end

--- a/priv/cabbage/apps/itest/lib/standard_exit_challenge_client.ex
+++ b/priv/cabbage/apps/itest/lib/standard_exit_challenge_client.ex
@@ -22,7 +22,7 @@ defmodule Itest.StandardExitChallengeClient do
 
   @gas 540_000
 
-  def challenge_standard_exit(address, utxo_pos) do
+  def challenge_standard_exit(utxo_pos, address) do
     _ = Logger.info("Address #{address} challenging standard exit for UTXO at #{utxo_pos}")
 
     %__MODULE__{address: address, utxo_pos: utxo_pos}

--- a/priv/cabbage/apps/itest/lib/standard_exit_challenge_client.ex
+++ b/priv/cabbage/apps/itest/lib/standard_exit_challenge_client.ex
@@ -40,19 +40,12 @@ defmodule Itest.StandardExitChallengeClient do
     %{challenge | challenge_data: Itest.ApiModel.ChallengeData.to_struct(response)}
   end
 
-  # FIXME: this will repeat, DRY?
   defp get_exit_game_contract_address(challenge) do
-    data = ABI.encode("exitGames(uint256)", [PaymentType.simple_payment_transaction()])
-    {:ok, result} = Ethereumex.HttpClient.eth_call(%{to: Itest.Account.plasma_framework(), data: Encoding.to_hex(data)})
-
-    exit_game_contract_address =
-      result
-      |> Encoding.to_binary()
-      |> ABI.TypeDecoder.decode([:address])
-      |> hd()
-      |> Encoding.to_hex()
-
-    %{challenge | exit_game_contract_address: exit_game_contract_address}
+    %{
+      challenge
+      | exit_game_contract_address:
+          Itest.PlasmaFramework.exit_game_contract_address(PaymentType.simple_payment_transaction())
+    }
   end
 
   defp do_challenge_standard_exit(

--- a/priv/cabbage/apps/itest/lib/standard_exit_challenge_client.ex
+++ b/priv/cabbage/apps/itest/lib/standard_exit_challenge_client.ex
@@ -1,0 +1,90 @@
+defmodule Itest.StandardExitChallengeClient do
+  @moduledoc """
+    An interface to Watcher API.
+  """
+  alias Itest.Transactions.Encoding
+  alias Itest.Transactions.PaymentType
+  alias WatcherSecurityCriticalAPI.Connection, as: Watcher
+  alias WatcherSecurityCriticalAPI.Model.UtxoPositionBodySchema1
+
+  import Itest.Poller, only: [wait_on_receipt_confirmed: 1, pull_api_until_successful: 4]
+
+  use Bitwise
+  require Logger
+
+  defstruct [
+    :address,
+    :utxo_pos,
+    :challenge_data,
+    :exit_game_contract_address,
+    :challenge_standard_exit_hash
+  ]
+
+  @gas 540_000
+
+  def challenge_standard_exit(address, utxo_pos) do
+    _ = Logger.info("Address #{address} challenging standard exit for UTXO at #{utxo_pos}")
+
+    %__MODULE__{address: address, utxo_pos: utxo_pos}
+    |> get_challenge_data()
+    |> get_exit_game_contract_address()
+    |> do_challenge_standard_exit()
+  end
+
+  defp get_challenge_data(%__MODULE__{utxo_pos: utxo_pos} = challenge) do
+    payload = %UtxoPositionBodySchema1{utxo_pos: utxo_pos}
+
+    response =
+      pull_api_until_successful(WatcherSecurityCriticalAPI.Api.UTXO, :utxo_get_challenge_data, Watcher.new(), payload)
+
+    %{challenge | challenge_data: Itest.ApiModel.ChallengeData.to_struct(response)}
+  end
+
+  # FIXME: this will repeat, DRY?
+  defp get_exit_game_contract_address(challenge) do
+    data = ABI.encode("exitGames(uint256)", [PaymentType.simple_payment_transaction()])
+    {:ok, result} = Ethereumex.HttpClient.eth_call(%{to: Itest.Account.plasma_framework(), data: Encoding.to_hex(data)})
+
+    exit_game_contract_address =
+      result
+      |> Encoding.to_binary()
+      |> ABI.TypeDecoder.decode([:address])
+      |> hd()
+      |> Encoding.to_hex()
+
+    %{challenge | exit_game_contract_address: exit_game_contract_address}
+  end
+
+  defp do_challenge_standard_exit(
+         %__MODULE__{
+           address: address,
+           exit_game_contract_address: exit_game_contract_address,
+           challenge_data: challenge_data
+         } = challenge
+       ) do
+    _ = Logger.info("Challenging standard exit.")
+
+    # FIXME: move somehow to challenge_data?
+    sender_data = address |> Encoding.to_binary() |> :keccakf1600.sha3_256()
+
+    data =
+      ABI.encode("challengeStandardExit((uint160,bytes,bytes,uint16,bytes,bytes32))", [
+        {challenge_data.exit_id, Encoding.to_binary(challenge_data.exiting_tx),
+         Encoding.to_binary(challenge_data.txbytes), challenge_data.input_index, Encoding.to_binary(challenge_data.sig),
+         sender_data}
+      ])
+
+    txmap = %{
+      from: address,
+      to: exit_game_contract_address,
+      value: Encoding.to_hex(0),
+      data: Encoding.to_hex(data),
+      gas: Encoding.to_hex(@gas)
+    }
+
+    {:ok, receipt_hash} = Ethereumex.HttpClient.eth_send_transaction(txmap)
+
+    wait_on_receipt_confirmed(receipt_hash)
+    %{challenge | challenge_standard_exit_hash: receipt_hash}
+  end
+end

--- a/priv/cabbage/apps/itest/lib/standard_exit_challenge_client.ex
+++ b/priv/cabbage/apps/itest/lib/standard_exit_challenge_client.ex
@@ -57,7 +57,6 @@ defmodule Itest.StandardExitChallengeClient do
        ) do
     _ = Logger.info("Challenging standard exit.")
 
-    # FIXME: move somehow to challenge_data?
     sender_data = address |> Encoding.to_binary() |> :keccakf1600.sha3_256()
 
     data =

--- a/priv/cabbage/apps/itest/lib/standard_exit_client.ex
+++ b/priv/cabbage/apps/itest/lib/standard_exit_client.ex
@@ -212,7 +212,7 @@ defmodule Itest.StandardExitClient do
        ) do
     data =
       ABI.encode("getStandardExitId(bool,bytes,uint256)", [
-        true,
+        from_deposit?(exit_data.utxo_pos),
         Encoding.to_binary(exit_data.txbytes),
         exit_data.utxo_pos
       ])
@@ -309,5 +309,10 @@ defmodule Itest.StandardExitClient do
     |> Encoding.to_binary()
     |> ABI.TypeDecoder.decode([:bool])
     |> hd()
+  end
+
+  defp from_deposit?(encoded_utxo_pos) do
+    {:ok, %ExPlasma.Utxo{blknum: blknum, txindex: 0, oindex: 0}} = ExPlasma.Utxo.new(encoded_utxo_pos)
+    rem(blknum, 1000) != 0
   end
 end

--- a/priv/cabbage/apps/itest/lib/standard_exit_client.ex
+++ b/priv/cabbage/apps/itest/lib/standard_exit_client.ex
@@ -77,7 +77,7 @@ defmodule Itest.StandardExitClient do
     se
     |> get_exit_game_contract_address()
     |> wait_for_exit_period()
-    |> process_exit(opts[:n_exits])
+    |> process_exit(Keyword.get(opts, :n_exits, 1))
     |> calculate_total_gas_used()
   end
 
@@ -235,14 +235,12 @@ defmodule Itest.StandardExitClient do
       |> hd()
 
     # double check correctness, our exit ID must be the first one in the priority queue
-    # FIXME: think how to have this sanity check
-    # ^standard_exit_id = next_exit_id &&& (1 <<< 160) - 1
+    ^standard_exit_id = next_exit_id &&& (1 <<< 160) - 1
 
     %{se | standard_exit_id: standard_exit_id}
   end
 
-  defp process_exit(%__MODULE__{address: address, standard_exit_id: standard_exit_id} = se, n_exits \\ nil) do
-    n_exits = n_exits || 1
+  defp process_exit(%__MODULE__{address: address, standard_exit_id: standard_exit_id} = se, n_exits) do
     _ = Logger.info("Process exit #{__MODULE__}")
 
     data =

--- a/priv/cabbage/apps/itest/lib/standard_exit_client.ex
+++ b/priv/cabbage/apps/itest/lib/standard_exit_client.ex
@@ -65,13 +65,19 @@ defmodule Itest.StandardExitClient do
     |> wait_and_process_standard_exit()
   end
 
-  def wait_and_process_standard_exit(%__MODULE__{address: address} = se) do
+  @doc """
+  Waits and processes standard exits
+
+  Options:
+    - :n_exits - provide how many exits should `processExits` attempt to process in the contract, defaults to 1
+  """
+  def wait_and_process_standard_exit(%__MODULE__{address: address} = se, opts \\ []) do
     _ = Logger.info("Waiting and processing a standard exit by #{address}")
 
     se
     |> get_exit_game_contract_address()
     |> wait_for_exit_period()
-    |> process_exit()
+    |> process_exit(opts[:n_exits])
     |> calculate_total_gas_used()
   end
 
@@ -235,13 +241,14 @@ defmodule Itest.StandardExitClient do
     %{se | standard_exit_id: standard_exit_id}
   end
 
-  defp process_exit(%__MODULE__{address: address, standard_exit_id: standard_exit_id} = se) do
+  defp process_exit(%__MODULE__{address: address, standard_exit_id: standard_exit_id} = se, n_exits \\ nil) do
+    n_exits = n_exits || 1
     _ = Logger.info("Process exit #{__MODULE__}")
 
     data =
       ABI.encode(
         "processExits(uint256,address,uint160,uint256)",
-        [Itest.Account.vault_id(Currency.ether()), Currency.ether(), standard_exit_id, 1]
+        [Itest.Account.vault_id(Currency.ether()), Currency.ether(), standard_exit_id, n_exits]
       )
 
     txmap = %{

--- a/priv/cabbage/apps/itest/test/features/in_flight_exits.feature
+++ b/priv/cabbage/apps/itest/test/features/in_flight_exits.feature
@@ -7,10 +7,10 @@ Feature: In Flight Exits
     Given Alice and Bob create a transaction for "5" ETH
     And Bob gets in flight exit data for "5" ETH from his most recent deposit
     And Alice sends the most recently created transaction
-    And Bob sends the most recently created transaction
+    And Bob spends an output from the most recently sent transaction
     And Alice starts an in flight exit from the most recently created transaction
     Then Alice verifies its in flight exit from the most recently created transaction
     Given Bob piggybacks inputs and outputs from Alices most recent in flight exit
-    And Bob starts an in flight exit from his most recently created transaction
+    And Bob starts an in flight exit using his most recently prepared in flight exit data
     And Alice fully challenges Bobs most recent invalid in flight exit
     Then Alice can processes her own most recent in flight exit

--- a/priv/cabbage/apps/itest/test/features/in_flight_exits.feature
+++ b/priv/cabbage/apps/itest/test/features/in_flight_exits.feature
@@ -11,6 +11,6 @@ Feature: In Flight Exits
     And Alice starts an in flight exit from the most recently created transaction
     Then Alice verifies its in flight exit from the most recently created transaction
     Given Bob piggybacks inputs and outputs from Alices most recent in flight exit
-    And Bob starts an in flight exit using his most recently prepared in flight exit data
+    And Bob starts a piggybacked in flight exit using his most recently prepared in flight exit data
     And Alice fully challenges Bobs most recent invalid in flight exit
     Then Alice can processes her own most recent in flight exit

--- a/priv/cabbage/apps/itest/test/features/invalid_standard_exits.feature
+++ b/priv/cabbage/apps/itest/test/features/invalid_standard_exits.feature
@@ -1,8 +1,8 @@
 Feature: Invalid Standard Exits
   Scenario: Alice starts an invalid Standard Exit
-    Given Alice has "12" ETH on the child chain
+    Given Alice deposited "12" ETH on the child chain
     And The child chain is secure
-    When Alice sends Bob "1" ETH on the child chain
+    When Alice sends Bob "11" ETH on the child chain
     And Alice starts a standard exit on the child chain from her recently spent input
     But Bob detects a new "invalid_exit"
     And Bob challenges an invalid exit
@@ -10,10 +10,21 @@ Feature: Invalid Standard Exits
     Then The child chain is secure
     And Alice should have "12" ETH less on the blockchain
 
-  Scenario: Alice almost succeeds with an invalid Standard Exit
-    Given Alice has "12" ETH on the child chain
+  Scenario: Alice starts an invalid Standard Exit from a non-deposit
+    Given Alice received "12" ETH on the child chain
     And The child chain is secure
-    When Alice sends Bob "1" ETH on the child chain
+    When Alice sends Bob "11" ETH on the child chain
+    And Alice starts a standard exit on the child chain from her recently spent input
+    But Bob detects a new "invalid_exit"
+    And Bob challenges an invalid exit
+    And Alice tries to process exits
+    Then The child chain is secure
+    And Alice should have "0" ETH less on the blockchain
+
+  Scenario: Alice almost succeeds with an invalid Standard Exit
+    Given Alice deposited "12" ETH on the child chain
+    And The child chain is secure
+    When Alice sends Bob "11" ETH on the child chain
     And Alice starts a standard exit on the child chain from her recently spent input
     Then Bob detects a new "invalid_exit"
     And Bob detects a new "unchallenged_exit"

--- a/priv/cabbage/apps/itest/test/features/invalid_standard_exits.feature
+++ b/priv/cabbage/apps/itest/test/features/invalid_standard_exits.feature
@@ -1,0 +1,12 @@
+Feature: Invalid Standard Exits
+  Scenario: Alice starts an invalid Standard Exit
+    When Alice deposits "12" ETH to the root chain
+    Then Alice should have "12" ETH on the child chain
+    When Alice sends Bob "1" ETH on the child chain
+    Given Some state of the chain
+    And Alice starts a standard exit on the child chain from her recently spent input
+    Then Bob detects the new "invalid_exit" and challenges all
+    And The child chain is secure
+    When Alice tries to process exits
+    And Alice should have no more than "11" ETH on the child chain
+    And Alice should have "12" ETH less on the blockchain

--- a/priv/cabbage/apps/itest/test/features/invalid_standard_exits.feature
+++ b/priv/cabbage/apps/itest/test/features/invalid_standard_exits.feature
@@ -3,9 +3,9 @@ Feature: Invalid Standard Exits
     When Alice deposits "12" ETH to the root chain
     Then Alice should have "12" ETH on the child chain
     When Alice sends Bob "1" ETH on the child chain
-    Given Some state of the chain
+    Given The child chain is secure
     And Alice starts a standard exit on the child chain from her recently spent input
-    Then Bob detects the new "invalid_exit" and challenges all
+    Then Bob detects a "invalid_exit" and challenges it
     And The child chain is secure
     When Alice tries to process exits
     And Alice should have no more than "11" ETH on the child chain

--- a/priv/cabbage/apps/itest/test/features/invalid_standard_exits.feature
+++ b/priv/cabbage/apps/itest/test/features/invalid_standard_exits.feature
@@ -1,12 +1,10 @@
 Feature: Invalid Standard Exits
   Scenario: Alice starts an invalid Standard Exit
-    When Alice deposits "12" ETH to the root chain
-    Then Alice should have "12" ETH on the child chain
-    When Alice sends Bob "1" ETH on the child chain
-    Given The child chain is secure
-    And Alice starts a standard exit on the child chain from her recently spent input
-    Then Bob detects a "invalid_exit" and challenges it
+    Given Alice has "12" ETH on the child chain
     And The child chain is secure
-    When Alice tries to process exits
-    And Alice should have no more than "11" ETH on the child chain
+    When Alice sends Bob "1" ETH on the child chain
+    And Alice starts a standard exit on the child chain from her recently spent input
+    But Bob detects an "invalid_exit" and challenges it
+    And Alice tries to process exits
+    Then The child chain is secure
     And Alice should have "12" ETH less on the blockchain

--- a/priv/cabbage/apps/itest/test/features/invalid_standard_exits.feature
+++ b/priv/cabbage/apps/itest/test/features/invalid_standard_exits.feature
@@ -4,7 +4,19 @@ Feature: Invalid Standard Exits
     And The child chain is secure
     When Alice sends Bob "1" ETH on the child chain
     And Alice starts a standard exit on the child chain from her recently spent input
-    But Bob detects an "invalid_exit" and challenges it
+    But Bob detects a new "invalid_exit"
+    And Bob challenges an invalid exit
     And Alice tries to process exits
     Then The child chain is secure
     And Alice should have "12" ETH less on the blockchain
+
+  Scenario: Alice almost succeeds with an invalid Standard Exit
+    Given Alice has "12" ETH on the child chain
+    And The child chain is secure
+    When Alice sends Bob "1" ETH on the child chain
+    And Alice starts a standard exit on the child chain from her recently spent input
+    Then Bob detects a new "invalid_exit"
+    And Bob detects a new "unchallenged_exit"
+    # these two are here only to not end up with a broken chain
+    And Bob challenges an invalid exit
+    And Alice tries to process exits

--- a/priv/cabbage/apps/itest/test/features/invalid_standard_exits.feature
+++ b/priv/cabbage/apps/itest/test/features/invalid_standard_exits.feature
@@ -6,9 +6,9 @@ Feature: Invalid Standard Exits
     And Alice starts a standard exit on the child chain from her recently spent input
     But Bob detects a new "invalid_exit"
     And Bob challenges an invalid exit
-    And Alice tries to process exits
+    And Exits are processed
     Then The child chain is secure
-    And Alice should have "12" ETH less on the blockchain
+    And Alice should have "12" ETH less on the root chain
 
   Scenario: Alice starts an invalid Standard Exit from a non-deposit
     Given Alice received "12" ETH on the child chain
@@ -17,9 +17,9 @@ Feature: Invalid Standard Exits
     And Alice starts a standard exit on the child chain from her recently spent input
     But Bob detects a new "invalid_exit"
     And Bob challenges an invalid exit
-    And Alice tries to process exits
+    And Exits are processed
     Then The child chain is secure
-    And Alice should have "0" ETH less on the blockchain
+    And Alice should have "0" ETH less on the root chain
 
   Scenario: Alice almost succeeds with an invalid Standard Exit
     Given Alice deposited "12" ETH on the child chain
@@ -30,4 +30,4 @@ Feature: Invalid Standard Exits
     And Bob detects a new "unchallenged_exit"
     # these two are here only to not end up with a broken chain
     And Bob challenges an invalid exit
-    And Alice tries to process exits
+    And Exits are processed

--- a/priv/cabbage/apps/itest/test/features/standard_exits.feature
+++ b/priv/cabbage/apps/itest/test/features/standard_exits.feature
@@ -4,4 +4,4 @@ Feature: Standard Exits
     Then Alice should have "1" ETH on the child chain
     When Alice completes a standard exit on the child chain
     Then Alice should have "0" ETH on the child chain after finality margin
-    And Alice should have "100" ETH on the blockchain
+    And Alice should have "100" ETH on the root chain

--- a/priv/cabbage/apps/itest/test/features/standard_exits.feature
+++ b/priv/cabbage/apps/itest/test/features/standard_exits.feature
@@ -2,6 +2,6 @@ Feature: Standard Exits
   Scenario: Alice starts a Standard Exit
     When Alice deposits "1" ETH to the root chain
     Then Alice should have "1" ETH on the child chain
-    When Alice starts a standard exit on the child chain
+    When Alice completes a standard exit on the child chain
     Then Alice should have "0" ETH on the child chain after finality margin
     And Alice should have "100" ETH on the blockchain

--- a/priv/cabbage/apps/itest/test/itest/configuration_api_test.exs
+++ b/priv/cabbage/apps/itest/test/itest/configuration_api_test.exs
@@ -7,7 +7,7 @@ defmodule ConfigurationRetrievalTests do
     data = ABI.encode("getVersion()", [])
 
     {:ok, response} =
-      Ethereumex.HttpClient.eth_call(%{to: Itest.Account.plasma_framework(), data: Encoding.to_hex(data)})
+      Ethereumex.HttpClient.eth_call(%{to: Itest.PlasmaFramework.address(), data: Encoding.to_hex(data)})
 
     [{contract_semver}] =
       response

--- a/priv/cabbage/apps/itest/test/itest/configuration_api_test.exs
+++ b/priv/cabbage/apps/itest/test/itest/configuration_api_test.exs
@@ -19,7 +19,7 @@ defmodule ConfigurationRetrievalTests do
         "contract_semver" => contract_semver,
         "deposit_finality_margin" => 10,
         "network" => "LOCALCHAIN",
-        "exit_processor_sla_margin" => 5520
+        "exit_processor_sla_margin" => 30
       },
       child_chain_assert_response: %{
         "contract_semver" => contract_semver,

--- a/priv/cabbage/apps/itest/test/itest/deposits_test.exs
+++ b/priv/cabbage/apps/itest/test/itest/deposits_test.exs
@@ -22,7 +22,7 @@ defmodule DepositsTests do
     {:ok, receipt_hash} =
       amount
       |> Currency.to_wei()
-      |> Client.deposit(alice_account, Itest.Account.vault(Currency.ether()))
+      |> Client.deposit(alice_account, Itest.PlasmaFramework.vault(Currency.ether()))
 
     gas_used = Client.get_gas_used(receipt_hash)
 

--- a/priv/cabbage/apps/itest/test/itest/fee_claiming_test.exs
+++ b/priv/cabbage/apps/itest/test/itest/fee_claiming_test.exs
@@ -43,7 +43,7 @@ defmodule FeeClaimingTests do
     {:ok, receipt_hash} =
       amount
       |> Currency.to_wei()
-      |> Client.deposit(entity_address, Itest.Account.vault(Currency.ether()))
+      |> Client.deposit(entity_address, Itest.PlasmaFramework.vault(Currency.ether()))
 
     gas_used = Client.get_gas_used(receipt_hash)
 

--- a/priv/cabbage/apps/itest/test/itest/in_flight_exits_test.exs
+++ b/priv/cabbage/apps/itest/test/itest/in_flight_exits_test.exs
@@ -560,13 +560,8 @@ defmodule InFlightExitsTests do
     assert in_flight_exit_ids_2.exit_map == 0
 
     # observe the byzantine events gone
-    # I’m waiting for this one, and only this one to remain
-    # NOTE: the piggyback pops back to being available after the challenge due to a bug in the Watcher
-    #       https://github.com/omisego/elixir-omg/issues/1371. Remove after this had been fixed
-    assert all_events_in_status?(["piggyback_available"])
-    # should be like this instead:
     # I’m waiting for clean state / secure chain to remain after all the challenges
-    # assert all_events_in_status?([])
+    assert all_events_in_status?([])
 
     alice_state =
       Map.put(

--- a/priv/cabbage/apps/itest/test/itest/in_flight_exits_test.exs
+++ b/priv/cabbage/apps/itest/test/itest/in_flight_exits_test.exs
@@ -329,7 +329,7 @@ defmodule InFlightExitsTests do
     {:ok, Map.put(state, entity, alice_state)}
   end
 
-  defand ~r/^Bob sends the most recently created transaction$/, _, state do
+  defand ~r/^Bob spends an output from the most recently sent transaction$/, _, state do
     %{address: alice_address, transaction_submit: alice_transaction_submit} = state["Alice"]
 
     %{address: bob_address, pkey: bob_pkey} = bob_state = state["Bob"]
@@ -447,7 +447,7 @@ defmodule InFlightExitsTests do
   end
 
   # ### start the competing IFE, to double-spend some inputs
-  defand ~r/^Bob starts an in flight exit from his most recently created transaction$/, _, state do
+  defand ~r/^Bob starts an in flight exit using his most recently prepared in flight exit data$/, _, state do
     exit_game_contract_address = state["exit_game_contract_address"]
     in_flight_exit_bond_size = state["in_flight_exit_bond_size"]
     %{address: address, exit_data: exit_data} = bob_state = state["Bob"]

--- a/priv/cabbage/apps/itest/test/itest/invalid_standard_exit_test.exs
+++ b/priv/cabbage/apps/itest/test/itest/invalid_standard_exit_test.exs
@@ -1,0 +1,196 @@
+defmodule InvalidStandardExitsTests do
+  use Cabbage.Feature, async: false, file: "invalid_standard_exits.feature"
+
+  require Logger
+
+  alias Itest.Account
+  alias Itest.ApiModel.Utxo
+  alias Itest.Client
+  alias Itest.StandardExitChallengeClient
+  alias Itest.StandardExitClient
+  alias Itest.Transactions.Currency
+  alias WatcherSecurityCriticalAPI.Api.Status
+
+  import Itest.Poller, only: [pull_api_until_successful: 3, pull_api_until_successful: 4]
+
+  @retry_count 60
+  @sleep_retry_sec 5_000
+
+  # FIXME: consider applying in other files
+  defp all?(expected_events), do: all?(expected_events, @retry_count)
+  defp all?(_, 0), do: false
+
+  defp all?(expected_events, counter) do
+    byzantine_events =
+      pull_api_until_successful(Status, :status_get, WatcherSecurityCriticalAPI.Connection.new())
+      |> Map.fetch!("byzantine_events")
+      |> Enum.map(& &1["event"])
+
+    if Enum.sort(byzantine_events) == Enum.sort(expected_events) do
+      true
+    else
+      Process.sleep(@sleep_retry_sec)
+      all?(expected_events, counter - 1)
+    end
+  end
+
+  setup do
+    [{alice_account, alice_pkey}, {bob_account, _bob_pkey}] = Account.take_accounts(2)
+
+    %{alice_account: alice_account, alice_pkey: alice_pkey, bob_account: bob_account, gas: 0}
+  end
+
+  defwhen ~r/^Alice deposits "(?<amount>[^"]+)" ETH to the root chain$/,
+          %{amount: amount},
+          %{alice_account: alice_account} = state do
+    initial_balance = Itest.Poller.eth_get_balance(alice_account)
+
+    {:ok, receipt_hash} =
+      amount
+      |> Currency.to_wei()
+      |> Client.deposit(alice_account, Itest.Account.vault(Currency.ether()))
+
+    gas_used = Client.get_gas_used(receipt_hash)
+
+    new_state =
+      state
+      |> Map.put_new(:alice_gas, gas_used)
+      |> Map.put_new(:alice_initial_balance, initial_balance)
+
+    {:ok, new_state}
+  end
+
+  defthen ~r/^Alice should have "(?<amount>[^"]+)" ETH on the child chain$/,
+          %{amount: amount},
+          %{alice_account: alice_account} = state do
+    expecting_amount = Currency.to_wei(amount)
+    %{"amount" => balance} = Client.get_balance(alice_account, expecting_amount)
+    assert expecting_amount == balance
+
+    {:ok, state}
+  end
+
+  defthen ~r/^Alice should have no more than "(?<amount>[^"]+)" ETH on the child chain$/,
+          %{amount: amount},
+          %{alice_account: alice_account} = state do
+    expecting_amount = Currency.to_wei(amount)
+    # FIXME: can this be that sometimes get_balance returns an array, sometimes not. Workaround:
+    [%{"amount" => balance}] =
+      case Client.get_balance(alice_account) do
+        [%{"amount" => balance}] -> [%{"amount" => balance}]
+        %{"amount" => balance} -> [%{"amount" => balance}]
+      end
+
+    assert expecting_amount >= balance
+
+    {:ok, state}
+  end
+
+  defwhen ~r/^Alice sends Bob "(?<amount>[^"]+)" ETH on the child chain$/,
+          %{amount: amount},
+          %{alice_account: alice_account, alice_pkey: alice_pkey, bob_account: bob_account} = state do
+    {:ok, [sign_hash, typed_data, _txbytes]} =
+      Client.create_transaction(
+        Currency.to_wei(amount),
+        alice_account,
+        bob_account
+      )
+
+    # get a public-API response that contains exactly the UTXO that alice just spent, for later exiting
+    %{"message" => %{"input0" => %{"blknum" => blknum, "oindex" => oindex, "txindex" => txindex}}} = typed_data
+    alice_recently_spent_utxo_pos = ExPlasma.Utxo.pos(%{blknum: blknum, oindex: oindex, txindex: txindex})
+    alice_recently_spent_utxo_pos = get_particular_utxo(alice_account, alice_recently_spent_utxo_pos)
+
+    _ = Client.submit_transaction(typed_data, sign_hash, [alice_pkey])
+
+    {:ok, Map.put_new(state, :alice_recently_spent_utxo_pos, alice_recently_spent_utxo_pos)}
+  end
+
+  # FIXME move
+  defp get_particular_utxo(address, utxo_pos) do
+    payload = %WatcherInfoAPI.Model.AddressBodySchema1{address: address}
+
+    response =
+      pull_api_until_successful(
+        WatcherInfoAPI.Api.Account,
+        :account_get_utxos,
+        WatcherInfoAPI.Connection.new(),
+        payload
+      )
+
+    response |> Enum.find(&(&1["utxo_pos"] == utxo_pos)) |> Utxo.to_struct()
+  end
+
+  defwhen ~r/^Some state of the chain$/,
+          _,
+          state do
+    status = pull_api_until_successful(Status, :status_get, WatcherSecurityCriticalAPI.Connection.new())
+    {:ok, Map.put(state, :prior_byzantine_events, status["byzantine_events"])}
+  end
+
+  defwhen ~r/^Alice starts a standard exit on the child chain from her recently spent input$/,
+          _,
+          %{alice_account: alice_account, alice_recently_spent_utxo_pos: alice_recently_spent_utxo_pos} = state do
+    se =
+      %StandardExitClient{address: alice_account, utxo: alice_recently_spent_utxo_pos}
+      |> StandardExitClient.start_standard_exit()
+
+    gas_used1 = Client.get_gas_used(se.start_standard_exit_hash)
+    gas_used2 = Client.get_gas_used(se.add_exit_queue_hash)
+
+    new_state =
+      state
+      |> Map.update!(:alice_gas, fn current_gas -> current_gas + gas_used1 + gas_used2 end)
+      |> Map.put_new(:alice_bond, se.standard_exit_bond_size)
+
+    {:ok, new_state}
+  end
+
+  # FIXME: change to "challenges it"
+  defwhen ~r/^Bob detects the new "(?<event>[^"]+)" and challenges all$/,
+          %{event: event},
+          %{bob_account: bob_account, prior_byzantine_events: prior_byzantine_events} = state do
+    prior_byzantine_events_names = Enum.map(prior_byzantine_events, & &1["event"])
+    assert all?([event | prior_byzantine_events_names])
+
+    pull_api_until_successful(Status, :status_get, WatcherSecurityCriticalAPI.Connection.new())
+    |> Map.fetch!("byzantine_events")
+    |> Enum.filter(&(&1["event"] == "invalid_exit"))
+    |> Enum.map(& &1["details"]["utxo_pos"])
+    |> Enum.map(&StandardExitChallengeClient.challenge_standard_exit(bob_account, &1))
+
+    {:ok, state}
+  end
+
+  defthen ~r/^The child chain is secure$/,
+          _,
+          %{} = state do
+    assert all?([])
+    {:ok, state}
+  end
+
+  defthen ~r/^Alice tries to process exits$/, _, %{alice_account: alice_account} = state do
+    se =
+      %StandardExitClient{address: alice_account, standard_exit_id: 0}
+      |> StandardExitClient.wait_and_process_standard_exit()
+
+    gas_used = Client.get_gas_used(se.process_exit_receipt_hash)
+    new_state = Map.update!(state, :alice_gas, fn current_gas -> current_gas + gas_used end)
+
+    {:ok, new_state}
+  end
+
+  defthen ~r/^Alice should have "(?<difference>[^"]+)" ETH less on the blockchain$/,
+          %{difference: difference},
+          %{
+            alice_initial_balance: alice_initial_balance,
+            alice_account: alice_account,
+            alice_gas: alice_gas,
+            alice_bond: alice_bond
+          } = state do
+    alice_ethereum_balance = Itest.Poller.eth_get_balance(alice_account)
+    assert alice_ethereum_balance == alice_initial_balance - Currency.to_wei(difference) - alice_gas - alice_bond
+
+    {:ok, state}
+  end
+end

--- a/priv/cabbage/apps/itest/test/itest/invalid_standard_exit_test.exs
+++ b/priv/cabbage/apps/itest/test/itest/invalid_standard_exit_test.exs
@@ -146,7 +146,7 @@ defmodule InvalidStandardExitsTests do
     {:ok, state}
   end
 
-  defthen ~r/^Alice tries to process exits$/, _, %{alice_account: alice_account} = state do
+  defthen ~r/^Exits are processed$/, _, %{alice_account: alice_account} = state do
     # need n_exits: <many>, because we're trying to prove that Alice's processing of the challenged exit fails
     # otherwise, you're risking not processing "enough" exits and it will seem like Alice's exit got challenged, while
     # it is not necessarily true
@@ -160,7 +160,7 @@ defmodule InvalidStandardExitsTests do
     {:ok, new_state}
   end
 
-  defthen ~r/^Alice should have "(?<difference>[^"]+)" ETH less on the blockchain$/,
+  defthen ~r/^Alice should have "(?<difference>[^"]+)" ETH less on the root chain$/,
           %{difference: difference},
           %{
             alice_initial_balance_on_root_chain: alice_initial_balance_on_root_chain,

--- a/priv/cabbage/apps/itest/test/itest/invalid_standard_exit_test.exs
+++ b/priv/cabbage/apps/itest/test/itest/invalid_standard_exit_test.exs
@@ -170,9 +170,10 @@ defmodule InvalidStandardExitsTests do
   end
 
   defthen ~r/^Alice tries to process exits$/, _, %{alice_account: alice_account} = state do
+    # need n_exits: 20, because we're trying to prove that Alice's processing of the challenged exit fails
     se =
       %StandardExitClient{address: alice_account, standard_exit_id: 0}
-      |> StandardExitClient.wait_and_process_standard_exit()
+      |> StandardExitClient.wait_and_process_standard_exit(n_exits: 20)
 
     gas_used = Client.get_gas_used(se.process_exit_receipt_hash)
     new_state = Map.update!(state, :alice_gas, fn current_gas -> current_gas + gas_used end)

--- a/priv/cabbage/apps/itest/test/itest/invalid_standard_exit_test.exs
+++ b/priv/cabbage/apps/itest/test/itest/invalid_standard_exit_test.exs
@@ -61,7 +61,7 @@ defmodule InvalidStandardExitsTests do
 
     expecting_amount = Currency.to_wei(amount)
 
-    {:ok, receipt_hash} = Client.deposit(expecting_amount, alice_account, Itest.Account.vault(Currency.ether()))
+    {:ok, receipt_hash} = Client.deposit(expecting_amount, alice_account, Itest.PlasmaFramework.vault(Currency.ether()))
     gas_used = Client.get_gas_used(receipt_hash)
 
     %{"amount" => ^expecting_amount} = Client.get_balance(alice_account, expecting_amount)
@@ -85,7 +85,7 @@ defmodule InvalidStandardExitsTests do
       # a little extra to cover fees etc and let Alice get amount
       |> Kernel.+(1_000_000_000_000_000_000)
 
-    {:ok, _receipt_hash} = Client.deposit(carol_amount, carol_account, Itest.Account.vault(Currency.ether()))
+    {:ok, _receipt_hash} = Client.deposit(carol_amount, carol_account, Itest.PlasmaFramework.vault(Currency.ether()))
 
     %{"amount" => ^carol_amount} = Client.get_balance(carol_account, carol_amount)
 

--- a/priv/cabbage/apps/itest/test/itest/standard_exit_test.exs
+++ b/priv/cabbage/apps/itest/test/itest/standard_exit_test.exs
@@ -74,7 +74,7 @@ defmodule StandardExitsTests do
     {:ok, Map.put(state, :alice_ethereum_balance, balance)}
   end
 
-  defthen ~r/^Alice should have "(?<amount>[^"]+)" ETH on the blockchain$/,
+  defthen ~r/^Alice should have "(?<amount>[^"]+)" ETH on the root chain$/,
           %{amount: amount},
           %{
             alice_account: _alice_account,

--- a/priv/cabbage/apps/itest/test/itest/standard_exit_test.exs
+++ b/priv/cabbage/apps/itest/test/itest/standard_exit_test.exs
@@ -22,7 +22,7 @@ defmodule StandardExitsTests do
     {:ok, receipt_hash} =
       amount
       |> Currency.to_wei()
-      |> Client.deposit(alice_account, Itest.Account.vault(Currency.ether()))
+      |> Client.deposit(alice_account, Itest.PlasmaFramework.vault(Currency.ether()))
 
     gas_used = Client.get_gas_used(receipt_hash)
 

--- a/priv/cabbage/apps/itest/test/itest/standard_exit_test.exs
+++ b/priv/cabbage/apps/itest/test/itest/standard_exit_test.exs
@@ -49,8 +49,8 @@ defmodule StandardExitsTests do
     {:ok, state}
   end
 
-  defwhen ~r/^Alice starts a standard exit on the child chain$/, _, %{alice_account: alice_account} = state do
-    se = StandardExitClient.start_standard_exit(alice_account)
+  defwhen ~r/^Alice completes a standard exit on the child chain$/, _, %{alice_account: alice_account} = state do
+    se = StandardExitClient.complete_standard_exit(alice_account)
     state = Map.put_new(state, :standard_exit_total_gas_used, se.total_gas_used)
 
     {:ok, state}

--- a/priv/cabbage/apps/itest/test/test_helper.exs
+++ b/priv/cabbage/apps/itest/test/test_helper.exs
@@ -6,7 +6,7 @@ import Itest.Poller, only: [wait_on_receipt_confirmed: 1]
 
 Application.ensure_all_started(:ethereumex)
 data = ABI.encode("minExitPeriod()", [])
-{:ok, result} = Ethereumex.HttpClient.eth_call(%{to: Itest.Account.plasma_framework(), data: Encoding.to_hex(data)})
+{:ok, result} = Ethereumex.HttpClient.eth_call(%{to: Itest.PlasmaFramework.address(), data: Encoding.to_hex(data)})
 
 miliseconds =
   result
@@ -57,11 +57,11 @@ has_exit_queue = fn ->
   data =
     ABI.encode(
       "hasExitQueue(uint256,address)",
-      [Itest.Account.vault_id(Currency.ether()), Currency.ether()]
+      [Itest.PlasmaFramework.vault_id(Currency.ether()), Currency.ether()]
     )
 
   {:ok, receipt_enc} =
-    Ethereumex.HttpClient.eth_call(%{to: Itest.Account.plasma_framework(), data: Encoding.to_hex(data)})
+    Ethereumex.HttpClient.eth_call(%{to: Itest.PlasmaFramework.address(), data: Encoding.to_hex(data)})
 
   receipt_enc
   |> Encoding.to_binary()
@@ -78,12 +78,12 @@ else
   data =
     ABI.encode(
       "addExitQueue(uint256,address)",
-      [Itest.Account.vault_id(Currency.ether()), Currency.ether()]
+      [Itest.PlasmaFramework.vault_id(Currency.ether()), Currency.ether()]
     )
 
   txmap = %{
     from: address,
-    to: Itest.Account.plasma_framework(),
+    to: Itest.PlasmaFramework.address(),
     value: Encoding.to_hex(0),
     data: Encoding.to_hex(data),
     gas: Encoding.to_hex(gas_add_exit_queue)

--- a/priv/cabbage/config/config.exs
+++ b/priv/cabbage/config/config.exs
@@ -5,3 +5,5 @@ config :ethereumex,
   http_options: [timeout: 68_000, recv_timeout: 60_000]
 
 config :tesla, adapter: Tesla.Adapter.Hackney
+
+config :logger, level: :info

--- a/priv/cabbage/docker-compose-cabbage.yml
+++ b/priv/cabbage/docker-compose-cabbage.yml
@@ -1,0 +1,10 @@
+# this is an override to our usual docker-compose.yml which enables cabbage integration tests to run against a
+# test-friendly setup of our services
+version: "2.3"
+services:
+  watcher:
+    environment:
+      - EXIT_PROCESSOR_SLA_MARGIN=30
+  watcher_info:
+    environment:
+      - EXIT_PROCESSOR_SLA_MARGIN=30


### PR DESCRIPTION
Fixes #1333 

## Overview

This is a still quite tentative take on how to turn invalid (standard) exit tests into cabbage tests.

I'm having many doubts about the approach and I'll probably experiment with alternative approaches (see below).

I'm keeping the tidied up "old" approach tests, as I'd like to first gain more confidence in the cabbage tests added.

## Changes

- does some necessary intro fixes to the "old" integration tests which were not strict enough
- separates those tests into two "kinds"
    - tests requiring an invalid block (not moving to cabbage yet)
    - tests not requiring an invalid block (this is moving)
- turns ~one~ three of those tests into cabbage tests
- tried to stick by conventions, but did some refactors: added `Itest.PlasmaFramework` to group related tools dispersed across modules, made `StandardExitClient` more flexible to allow invalid exits
- took the liberty to bump log level to `info`; I think the `debug` logs weren't very useful
- customized the tested services, to enable sla-margin-related tests to execute in reasonable time.
- ADDED: revamped the `in_flight_exits_test`, so that it leaves the state of the chain intact (no byzantine events)

## Testing

run tests as usual / CI

## TODOs

 - [ ] - ~standardize with the `in_flight_exits_test.exs` and `standard_exit_test.exs` somehow, but that's pending review of `invalid_standard_exit_test.exs` conventions~ would love to, but not in this PR, this is huge already

## Alternative approaches

Current gherkin wording is [this](https://github.com/omisego/elixir-omg/compare/pdobacz/1333_fix_cabbagize_invalid_exit_tests?expand=1#diff-ba1c55a4d50e4a09cea75b4a5c4199be)

It comes from the "happy path" `standard_exits.feature`.

However there's a couple of modifications I'm considering:
  - a very general concern - distinguish the `watcher-info`/`happy-path`-related scenarios like the `standard_exit.feature` from the `watcher-security`/`unhappy-path` ones, like `invalid_standard_exit.feature`. The latter should probably be much more detailed in the wording (e.g. named utxos and transactions, not unlike the alicebobbing-scenarios used in some of our docs). But this has drawbacks too
  - wrap up more of the setup under a single `Given Alice has ETH on a secure chain` or something, collapsing the first 3-4 lines into one (**EDIT**: in fact, I think I'll do it right away)