### PR TITLE
remove timestamps from api layer

### DIFF
--- a/apps/omg_utils/lib/omg_utils/http_rpc/response.ex
+++ b/apps/omg_utils/lib/omg_utils/http_rpc/response.ex
@@ -65,6 +65,7 @@ defmodule OMG.Utils.HttpRPC.Response do
     map_or_struct
     |> to_map()
     |> do_filter()
+    |> remove_timestamps()
     |> sanitize_map()
   end
 
@@ -93,6 +94,10 @@ defmodule OMG.Utils.HttpRPC.Response do
     else
       map_or_struct
     end
+  end
+
+  defp remove_timestamps(map) do
+    Map.drop(map, [:inserted_at, :updated_at])
   end
 
   # Allows to skip sanitize on specifies keys provided in list in key :skip_hex_encode

--- a/apps/omg_utils/test/omg_utils/http_rpc/response_test.exs
+++ b/apps/omg_utils/test/omg_utils/http_rpc/response_test.exs
@@ -24,9 +24,7 @@ defmodule OMG.Utils.HttpRPC.ResponseTest do
     txhash: nil,
     txindex: nil,
     txtype: nil,
-    metadata: nil,
-    inserted_at: nil,
-    updated_at: nil
+    metadata: nil
   }
 
   setup %{} do

--- a/apps/omg_watcher_rpc/lib/web/serializers/base.ex
+++ b/apps/omg_watcher_rpc/lib/web/serializers/base.ex
@@ -31,9 +31,7 @@ defmodule OMG.WatcherRPC.Web.Serializer.Base do
       :otype,
       :owner,
       :creating_txhash,
-      :spending_txhash,
-      :inserted_at,
-      :updated_at
+      :spending_txhash
     ])
     |> Map.put(:utxo_pos, Utxo.position(blknum, txindex, oindex) |> Utxo.Position.encode())
   end

--- a/apps/omg_watcher_rpc/lib/web/views/transaction.ex
+++ b/apps/omg_watcher_rpc/lib/web/views/transaction.ex
@@ -57,7 +57,7 @@ defmodule OMG.WatcherRPC.Web.View.Transaction do
 
   defp render_transaction(transaction) do
     transaction
-    |> Map.take([:txindex, :txhash, :txtype, :block, :inputs, :outputs, :txbytes, :metadata, :inserted_at, :updated_at])
+    |> Map.take([:txindex, :txhash, :txtype, :block, :inputs, :outputs, :txbytes, :metadata])
     |> Map.update!(:inputs, &render_txoutputs/1)
     |> Map.update!(:outputs, &render_txoutputs/1)
   end

--- a/apps/omg_watcher_rpc/priv/swagger/info_api_specs/account/response_schemas.yaml
+++ b/apps/omg_watcher_rpc/priv/swagger/info_api_specs/account/response_schemas.yaml
@@ -36,5 +36,4 @@ AccountUtxoResponseSchema:
         owner: '0xb3256026863eb6ae5b06fa396ab09069784ea8ea'
         currency: '0x0000000000000000000000000000000000000000'
         amount: 10
-        inserted_at: '2020-02-10T12:07:32Z'
-        updated_at: '2020-02-15T04:07:57Z'
+

--- a/apps/omg_watcher_rpc/priv/swagger/info_api_specs/account/schemas.yaml
+++ b/apps/omg_watcher_rpc/priv/swagger/info_api_specs/account/schemas.yaml
@@ -33,7 +33,3 @@ AccountUtxoSchema:
       type: integer
       format: int256
 
-      inserted_at:
-        type: string
-      updated_at:
-        type: string

--- a/apps/omg_watcher_rpc/priv/swagger/info_api_specs/block/response_schemas.yaml
+++ b/apps/omg_watcher_rpc/priv/swagger/info_api_specs/block/response_schemas.yaml
@@ -25,9 +25,7 @@ BlocksAllResponseSchema:
         hash: '0x0017372421f9a92bedb7163310918e623557ab5310befc14e67212b660c33bec'
         eth_height: 97424
         timestamp: 1540365586
-        tx_count: 2
-        inserted_at: '2020-02-10T12:07:32Z'
-        updated_at: '2020-02-15T04:07:57Z'      
+        tx_count: 2   
       data_paging:
         page: 1
         limit: 100
@@ -46,5 +44,3 @@ BlockResponseSchema:
         eth_height: 97424
         blknum: 68290000
         tx_count: 2
-        inserted_at: '2020-02-10T12:07:32Z'
-        updated_at: '2020-02-15T04:07:57Z' 

--- a/apps/omg_watcher_rpc/priv/swagger/info_api_specs/block/schemas.yaml
+++ b/apps/omg_watcher_rpc/priv/swagger/info_api_specs/block/schemas.yaml
@@ -17,8 +17,4 @@ BlockSchema:
       type: integer
       format: int64
 
-    inserted_at:
-      type: string
-    updated_at:
-      type: string
   

--- a/apps/omg_watcher_rpc/priv/swagger/info_api_specs/transaction/response_schemas.yaml
+++ b/apps/omg_watcher_rpc/priv/swagger/info_api_specs/transaction/response_schemas.yaml
@@ -26,15 +26,11 @@ GetAllTransactionsResponseSchema:
           hash: '0x0017372421f9a92bedb7163310918e623557ab5310befc14e67212b660c33bec'
           eth_height: 97424
           blknum: 68290000
-          inserted_at: '2020-02-10T12:07:32Z'
-          updated_at: '2020-02-15T04:07:57Z'
         txindex: 0
         txtype: 1
         txhash: '0x5df13a6bf96dbcf6e66d8babd6b55bd40d64d4320c3b115364c6588fc18c2a21'
         metadata: '0x00000000000000000000000000000000000000000000000000000048656c6c6f'
         txbytes: '0x5df13a6bee20000...'
-        inserted_at: '2020-02-10T12:07:32Z'
-        updated_at: '2020-02-15T04:07:57Z'
         inputs:
         -
           blknum: 1000
@@ -47,8 +43,6 @@ GetAllTransactionsResponseSchema:
           creating_txhash: '0x40d65df1c3b1156d813d6bf96d5bd3b5bcf6e6588fc18c2a2ba564c6a64d4320'
           spending_txhash: '0x5df13a6bf96dbcf6e66d8babd6b55bd40d64d4320c3b115364c6588fc18c2a21'
           amount: 20000000
-          inserted_at: '2020-02-10T12:07:32Z'
-          updated_at: '2020-02-15T04:07:57Z'
         outputs:
         -
           blknum: 68290000
@@ -61,8 +55,6 @@ GetAllTransactionsResponseSchema:
           amount: 15000000
           creating_txhash: '0x40d65df1c3b1156d813d6bf96d5bd3b5bcf6e6588fc18c2a2ba564c6a64d4320'
           spending_txhash: null
-          inserted_at: '2020-02-10T12:07:32Z'
-          updated_at: '2020-02-15T04:07:57Z'
         -
           blknum: 68290000
           txindex: 5113
@@ -74,8 +66,6 @@ GetAllTransactionsResponseSchema:
           amount: 5000000
           creating_txhash: '0x40d65df1c3b1156d813d6bf96d5bd3b5bcf6e6588fc18c2a2ba564c6a64d4320'
           spending_txhash: null
-          inserted_at: '2020-02-10T12:07:32Z'
-          updated_at: '2020-02-15T04:07:57Z'
       data_paging:
         page: 1
         limit: 200
@@ -232,15 +222,11 @@ GetTransactionResponseSchema:
         txhash: '0x5df13a6bf96dbcf6e66d8babd6b55bd40d64d4320c3b115364c6588fc18c2a21'
         metadata: '0x00000000000000000000000000000000000000000000000000000048656c6c6f'
         txbytes: '0x5df13a6bee20000...'
-        inserted_at: '2020-02-10T12:07:32Z'
-        updated_at: '2020-02-15T04:07:57Z'
         block:
           timestamp: 1540365586
           hash: '0x0017372421f9a92bedb7163310918e623557ab5310befc14e67212b660c33bec'
           eth_height: 97424
           blknum: 68290000
-          inserted_at: '2020-02-10T12:07:32Z'
-          updated_at: '2020-02-15T04:07:57Z'
         inputs:
         -
           blknum: 1000
@@ -253,8 +239,6 @@ GetTransactionResponseSchema:
           amount: 10
           creating_txhash: '0x40d65df1c3b1156d813d6bf96d5bd3b5bcf6e6588fc18c2a2ba564c6a64d4320'
           spending_txhash: '0x5df13a6bf96dbcf6e66d8babd6b55bd40d64d4320c3b115364c6588fc18c2a21'
-          inserted_at: '2020-02-10T12:07:32Z'
-          updated_at: '2020-02-15T04:07:57Z'
         outputs:
         -
           blknum: 68290000
@@ -267,8 +251,6 @@ GetTransactionResponseSchema:
           amount: 2
           creating_txhash: '0x40d65df1c3b1156d813d6bf96d5bd3b5bcf6e6588fc18c2a2ba564c6a64d4320'
           spending_txhash: null
-          inserted_at: '2020-02-10T12:07:32Z'
-          updated_at: '2020-02-15T04:07:57Z'
         -
           blknum: 68290000
           txindex: 5113
@@ -280,5 +262,3 @@ GetTransactionResponseSchema:
           amount: 7
           creating_txhash: '0x40d65df1c3b1156d813d6bf96d5bd3b5bcf6e6588fc18c2a2ba564c6a64d4320'
           spending_txhash: null
-          inserted_at: '2020-02-10T12:07:32Z'
-          updated_at: '2020-02-15T04:07:57Z'

--- a/apps/omg_watcher_rpc/priv/swagger/info_api_specs/transaction/schemas.yaml
+++ b/apps/omg_watcher_rpc/priv/swagger/info_api_specs/transaction/schemas.yaml
@@ -31,13 +31,6 @@ TransactionOutputSchema:
     spending_txhash:
       type: string
 
-    inserted_at:
-      type: string
-    updated_at:
-      type: string
-  
-       
-
 TransactionSchema:
   type: object
   properties:
@@ -54,11 +47,6 @@ TransactionSchema:
       type: string
        
     txbytes:
-      type: string
-
-    inserted_at:
-      type: string
-    updated_at:
       type: string
    
     block:

--- a/apps/omg_watcher_rpc/priv/swagger/security_critical_api_specs/account/response_schemas.yaml
+++ b/apps/omg_watcher_rpc/priv/swagger/security_critical_api_specs/account/response_schemas.yaml
@@ -18,6 +18,5 @@ AccountUtxoResponseSchema:
         owner: '0xb3256026863eb6ae5b06fa396ab09069784ea8ea'
         currency: '0x0000000000000000000000000000000000000000'
         amount: 10
-        inserted_at: '2020-02-10T12:07:32Z'
-        updated_at: '2020-02-15T04:07:57Z'
+
         

--- a/apps/omg_watcher_rpc/priv/swagger/security_critical_api_specs/account/schemas.yaml
+++ b/apps/omg_watcher_rpc/priv/swagger/security_critical_api_specs/account/schemas.yaml
@@ -25,9 +25,3 @@ AccountUtxoSchema:
     amount:
       type: integer
       format: int256
-
-    inserted_at:
-      type: string
-
-    updated_at:
-      type: string

--- a/apps/omg_watcher_rpc/test/omg_watcher_rpc/web/controllers/transaction_test.exs
+++ b/apps/omg_watcher_rpc/test/omg_watcher_rpc/web/controllers/transaction_test.exs
@@ -24,7 +24,6 @@ defmodule OMG.WatcherRPC.Web.Controller.TransactionTest do
   alias OMG.State.Transaction
   alias OMG.TestHelper, as: Test
   alias OMG.Utils.HttpRPC.Encoding
-  alias OMG.Utils.HttpRPC.Response
   alias OMG.Utxo
   alias OMG.WatcherInfo.DB
   alias OMG.WatcherInfo.TestServer

--- a/apps/omg_watcher_rpc/test/omg_watcher_rpc/web/controllers/transaction_test.exs
+++ b/apps/omg_watcher_rpc/test/omg_watcher_rpc/web/controllers/transaction_test.exs
@@ -79,9 +79,7 @@ defmodule OMG.WatcherRPC.Web.Controller.TransactionTest do
           "eth_height" => spending_transaction.block.eth_height,
           "hash" => Encoding.to_hex(spending_transaction.block.hash),
           "timestamp" => spending_transaction.block.timestamp,
-          "tx_count" => spending_transaction.block.tx_count,
-          "inserted_at" => Response.serialize(spending_transaction.block.inserted_at).data,
-          "updated_at" => Response.serialize(spending_transaction.block.updated_at).data
+          "tx_count" => spending_transaction.block.tx_count
         },
         "inputs" =>
           Enum.map(spending_transaction.inputs, fn input ->
@@ -95,9 +93,7 @@ defmodule OMG.WatcherRPC.Web.Controller.TransactionTest do
               "otype" => input.otype,
               "utxo_pos" => Utxo.Position.encode({:utxo_position, input.blknum, input.txindex, input.oindex}),
               "creating_txhash" => to_hex_or_nil(input.creating_txhash),
-              "spending_txhash" => to_hex_or_nil(input.spending_txhash),
-              "inserted_at" => Response.serialize(input.inserted_at).data,
-              "updated_at" => Response.serialize(input.updated_at).data
+              "spending_txhash" => to_hex_or_nil(input.spending_txhash)
             }
           end),
         "outputs" =>
@@ -112,18 +108,14 @@ defmodule OMG.WatcherRPC.Web.Controller.TransactionTest do
               "otype" => output.otype,
               "utxo_pos" => Utxo.Position.encode({:utxo_position, output.blknum, output.txindex, output.oindex}),
               "creating_txhash" => to_hex_or_nil(output.creating_txhash),
-              "spending_txhash" => to_hex_or_nil(output.spending_txhash),
-              "inserted_at" => Response.serialize(output.inserted_at).data,
-              "updated_at" => Response.serialize(output.updated_at).data
+              "spending_txhash" => to_hex_or_nil(output.spending_txhash)
             }
           end),
         "txhash" => Encoding.to_hex(spending_transaction.txhash),
         "txbytes" => Encoding.to_hex(spending_transaction.txbytes),
         "txindex" => spending_transaction.txindex,
         "txtype" => spending_transaction.txtype,
-        "metadata" => Encoding.to_hex(spending_transaction.metadata),
-        "inserted_at" => Response.serialize(spending_transaction.inserted_at).data,
-        "updated_at" => Response.serialize(spending_transaction.updated_at).data
+        "metadata" => Encoding.to_hex(spending_transaction.metadata)
       }
 
       response = WatcherHelper.success?("transaction.get", %{"id" => Encoding.to_hex(spending_transaction.txhash)})

--- a/docs/watcher_db_design.md
+++ b/docs/watcher_db_design.md
@@ -45,8 +45,8 @@ Stores inputs and outputs of transactions. Utxo is a record in `txoutputs` table
 |currency|bytea||
 |proof|bytea||
 |child_chain_utxohash|bytea|UI|
-|inserted_at|datetime|UTC (w/o TZ)|
-|updated_at|datetime|UTC (w/o TZ)|
+|inserted_at|datetime|UTC (w/ TZ)|
+|updated_at|datetime|UTC (w/ TZ)|
 
 ## The Ethereum events table
 Stores events logged in root contract, such as _deposits_ or _exits_.
@@ -57,8 +57,8 @@ Stores events logged in root contract, such as _deposits_ or _exits_.
 |event_type|integer|Pk^|
 |event_type|varchar(124)||
 |root_chain_txhash_event|bytea|UI|
-|inserted_at|datetime|UTC (w/o TZ)|
-|updated_at|datetime|UTC (w/o TZ)|
+|inserted_at|datetime|UTC (w/ TZ)|
+|updated_at|datetime|UTC (w/ TZ)|
 
 
 ## The ethevents_txoutputs table
@@ -68,8 +68,8 @@ A table for many-to-many relationships between Ethereum events and UTXOs.
 |:-:|:-|:-|
 |root_chain_txhash_event|bytea|Pk(root_chain_txhash_event, child_chain_utxohash), FK(ethevents, (root_chain_txhash_event))|
 |child_chain_utxohash|bytea|Pk^, FK(txoutputs, (child_chain_utxohash))|
-|inserted_at|datetime|UTC (w/o TZ)|
-|updated_at|datetime|UTC (w/o TZ)|
+|inserted_at|datetime|UTC (w/ TZ)|
+|updated_at|datetime|UTC (w/ TZ)|
 
 
 ## Examples of queries against the tables


### PR DESCRIPTION

introducing `inserted_at` and `updated_at` fields into the api change breaks `omg-js`, so removing them for now.

yolo