### PR TITLE
publish BlockSubmitted event

### DIFF
--- a/apps/omg/lib/omg/ethereum_event_listener.ex
+++ b/apps/omg/lib/omg/ethereum_event_listener.ex
@@ -189,7 +189,8 @@ defmodule OMG.EthereumEventListener do
   end
 
   defp publish_data([%{event_signature: event_signature} | _] = data) do
-    # String.split("DepositCreated(address,uint256,address,uint256)", "(")
+    # event signature is string with a method name with arguments,
+    # for example: BlockSubmitted(uint256)
     [event_signature, _] = String.split(event_signature, "(")
     OMG.Bus.direct_local_broadcast(event_signature, {:data, data})
   end

--- a/apps/omg_child_chain/lib/omg_child_chain/datadog_event/contract_event_consumer.ex
+++ b/apps/omg_child_chain/lib/omg_child_chain/datadog_event/contract_event_consumer.ex
@@ -14,11 +14,8 @@
 
 defmodule OMG.ChildChain.DatadogEvent.ContractEventConsumer do
   @moduledoc """
-  Subscribes to new events from EthereumEventListeners and pushes them to Datadog
+  Subscribes to new events from EthereumEventListeners and BlockGetter and pushes them to Datadog
   Integrated with the help of: https://docs.datadoghq.com/api/?lang=bash#post-an-event
-  Most things from the doc doesn't work. Either because Statix doesn't work or Datadog.
-  Date_happened, aggregation_key, source_type_name doesn't seem to appear in Events list.
-  Hence we transform everything into a tag.
   """
 
   require Logger
@@ -75,7 +72,10 @@ defmodule OMG.ChildChain.DatadogEvent.ContractEventConsumer do
     {:noreply, state}
   end
 
-  # Listens to events via OMG BUS and send them off
+  @doc """
+    Listens to events via OMG BUS and send them off
+    the assumption is all events are of the same type
+  """
   def handle_info({:internal_event_bus, :data, data}, state) do
     %{event_signature: event_signature} = hd(data)
     [event_name, _] = String.split(event_signature, "(")

--- a/apps/omg_child_chain/lib/omg_child_chain/datadog_event/contract_event_consumer.ex
+++ b/apps/omg_child_chain/lib/omg_child_chain/datadog_event/contract_event_consumer.ex
@@ -76,8 +76,8 @@ defmodule OMG.ChildChain.DatadogEvent.ContractEventConsumer do
   end
 
   # Listens to events via OMG BUS and send them off
-  def handle_info({:internal_event_bus, :data, [data]}, state) do
-    %{event_signature: event_signature} = data
+  def handle_info({:internal_event_bus, :data, data}, state) do
+    %{event_signature: event_signature} = hd(data)
     [event_name, _] = String.split(event_signature, "(")
     aggregation_key = :root_chain
     timestamp = DateTime.to_unix(DateTime.utc_now(), :millisecond)

--- a/apps/omg_child_chain/test/omg_child_chain/datadog_event/contract_event_consumer_test.exs
+++ b/apps/omg_child_chain/test/omg_child_chain/datadog_event/contract_event_consumer_test.exs
@@ -50,6 +50,15 @@ defmodule OMG.ChildChain.DatadogEvent.ContractEventConsumerTest do
     assert_receive {:event, _, _}
   end
 
+  test "if a list of event message are put on omg bus is consumed by the event consumer and published on the publisher interface" do
+    pid = :erlang.pid_to_list(self())
+    topic = "#{pid}"
+    data = [%{event_signature: "#{pid}(bytes32)"}, %{event_signature: "#{pid}(bytes32)"}]
+    OMG.Bus.direct_local_broadcast(topic, {:data, data})
+
+    assert_receive {:event, _, _}
+  end
+
   defmodule DatadogEventMock do
     def event(title, message, options) do
       pid =

--- a/apps/omg_child_chain/test/omg_child_chain/datadog_event/contract_event_consumer_test.exs
+++ b/apps/omg_child_chain/test/omg_child_chain/datadog_event/contract_event_consumer_test.exs
@@ -42,18 +42,18 @@ defmodule OMG.ChildChain.DatadogEvent.ContractEventConsumerTest do
   end
 
   test "if a event message put on omg bus is consumed by the event consumer and published on the publisher interface" do
-    pid = :erlang.pid_to_list(self())
-    topic = "#{pid}"
-    data = [%{event_signature: "#{pid}(bytes32)"}]
+    topic = self() |> :erlang.pid_to_list() |> to_string()
+    sig = "#{topic}(bytes32)"
+    data = [%{event_signature: sig}]
     OMG.Bus.direct_local_broadcast(topic, {:data, data})
 
     assert_receive {:event, _, _}
   end
 
   test "if a list of event message are put on omg bus is consumed by the event consumer and published on the publisher interface" do
-    pid = :erlang.pid_to_list(self())
-    topic = "#{pid}"
-    data = [%{event_signature: "#{pid}(bytes32)"}, %{event_signature: "#{pid}(bytes32)"}]
+    topic = self() |> :erlang.pid_to_list() |> to_string()
+    sig = "#{topic}(bytes32)"
+    data = [%{event_signature: sig}, %{event_signature: sig}]
     OMG.Bus.direct_local_broadcast(topic, {:data, data})
 
     assert_receive {:event, _, _}

--- a/apps/omg_watcher/lib/omg_watcher/block_getter.ex
+++ b/apps/omg_watcher/lib/omg_watcher/block_getter.ex
@@ -352,7 +352,8 @@ defmodule OMG.Watcher.BlockGetter do
   defp update_status(%Core{} = state), do: Status.update(Core.chain_ok(state))
 
   defp publish_data([%{event_signature: event_signature} | _] = data) do
-    # String.split("BlockSubmitted(uint256)", "(")
+    # event signature is string with a method name with arguments,
+    # for example: BlockSubmitted(uint256)
     [event_signature, _] = String.split(event_signature, "(")
     OMG.Bus.direct_local_broadcast(event_signature, {:data, data})
   end

--- a/apps/omg_watcher/lib/omg_watcher/block_getter.ex
+++ b/apps/omg_watcher/lib/omg_watcher/block_getter.ex
@@ -290,7 +290,7 @@ defmodule OMG.Watcher.BlockGetter do
       :ok = check_in_to_coordinator(synced_height)
       {:ok, _} = schedule_sync_height()
       :ok = update_status(state)
-
+      :ok = publish_data(submissions)
       {:noreply, state}
     else
       :nosync ->
@@ -350,4 +350,12 @@ defmodule OMG.Watcher.BlockGetter do
   defp check_in_to_coordinator(synced_height), do: RootChainCoordinator.check_in(synced_height, :block_getter)
 
   defp update_status(%Core{} = state), do: Status.update(Core.chain_ok(state))
+
+  defp publish_data([%{event_signature: event_signature} | _] = data) do
+    # String.split("BlockSubmitted(uint256)", "(")
+    [event_signature, _] = String.split(event_signature, "(")
+    OMG.Bus.direct_local_broadcast(event_signature, {:data, data})
+  end
+
+  defp publish_data([]), do: :ok
 end

--- a/apps/omg_watcher/lib/omg_watcher/datadog_event/contract_event_consumer.ex
+++ b/apps/omg_watcher/lib/omg_watcher/datadog_event/contract_event_consumer.ex
@@ -64,8 +64,10 @@ defmodule OMG.Watcher.DatadogEvent.ContractEventConsumer do
     {:noreply, state}
   end
 
-  # Listens to events via OMG BUS and send them off
-  # the assumption is all events are of the same type
+  @doc """
+    Listens to events via OMG BUS and send them off
+    the assumption is all events are of the same type
+  """
   def handle_info({:internal_event_bus, :data, data}, state) do
     %{event_signature: event_signature} = hd(data)
     [event_name, _] = String.split(event_signature, "(")

--- a/apps/omg_watcher/lib/omg_watcher/datadog_event/contract_event_consumer.ex
+++ b/apps/omg_watcher/lib/omg_watcher/datadog_event/contract_event_consumer.ex
@@ -65,8 +65,9 @@ defmodule OMG.Watcher.DatadogEvent.ContractEventConsumer do
   end
 
   # Listens to events via OMG BUS and send them off
-  def handle_info({:internal_event_bus, :data, [data]}, state) do
-    %{event_signature: event_signature} = data
+  # the assumption is all events are of the same type
+  def handle_info({:internal_event_bus, :data, data}, state) do
+    %{event_signature: event_signature} = hd(data)
     [event_name, _] = String.split(event_signature, "(")
     aggregation_key = :root_chain
     timestamp = DateTime.to_unix(DateTime.utc_now(), :millisecond)

--- a/apps/omg_watcher/test/omg_watcher/datadog_event/contract_event_consumer_test.exs
+++ b/apps/omg_watcher/test/omg_watcher/datadog_event/contract_event_consumer_test.exs
@@ -42,17 +42,17 @@ defmodule OMG.Watcher.DatadogEvent.ContractEventConsumerTest do
   end
 
   test "if a event message put on omg bus is consumed by the event consumer and published on the publisher interface" do
-    pid = :erlang.pid_to_list(self())
-    topic = "#{pid}"
-    data = [%{event_signature: "#{pid}(bytes32)"}]
+    topic = self() |> :erlang.pid_to_list() |> to_string()
+    sig = "#{topic}(bytes32)"
+    data = [%{event_signature: sig}]
     OMG.Bus.direct_local_broadcast(topic, {:data, data})
     assert_receive {:event, _, _}
   end
 
   test "if a list of event messages are put on omg bus is consumed by the event consumer and published on the publisher interface" do
-    pid = :erlang.pid_to_list(self())
-    topic = "#{pid}"
-    data = [%{event_signature: "#{pid}(bytes32)"}, %{event_signature: "#{pid}(bytes32)"}]
+    topic = self() |> :erlang.pid_to_list() |> to_string()
+    sig = "#{topic}(bytes32)"
+    data = [%{event_signature: sig}, %{event_signature: sig}]
     OMG.Bus.direct_local_broadcast(topic, {:data, data})
     assert_receive {:event, _, _}
   end

--- a/apps/omg_watcher/test/omg_watcher/datadog_event/contract_event_consumer_test.exs
+++ b/apps/omg_watcher/test/omg_watcher/datadog_event/contract_event_consumer_test.exs
@@ -49,6 +49,14 @@ defmodule OMG.Watcher.DatadogEvent.ContractEventConsumerTest do
     assert_receive {:event, _, _}
   end
 
+  test "if a list of event messages are put on omg bus is consumed by the event consumer and published on the publisher interface" do
+    pid = :erlang.pid_to_list(self())
+    topic = "#{pid}"
+    data = [%{event_signature: "#{pid}(bytes32)"}, %{event_signature: "#{pid}(bytes32)"}]
+    OMG.Bus.direct_local_broadcast(topic, {:data, data})
+    assert_receive {:event, _, _}
+  end
+
   defmodule DatadogEventMock do
     def event(title, message, options) do
       pid =

--- a/bin/variables
+++ b/bin/variables
@@ -2,8 +2,8 @@
 export REPLACE_OS_VARS=true
 export NODE_HOST=127.0.0.1
 export ERLANG_COOKIE=develop
-export APP_ENV=local_docker_development
-export HOSTNAME=yolo
+export APP_ENV=local-development
+export HOSTNAME=http://localhost/
 export DB_PATH=~/plasma-data/
 export ETHEREUM_RPC_URL=http://127.0.0.1:8545
 export ETH_NODE=geth


### PR DESCRIPTION

## Overview

When Watchers detect a block submitted event from Ethereum, publish it on omg bus so that consumers can do whatever they want with it.

## Changes

- find where it's detected and publish it

## Testing

