### PR TITLE
fix: run CircleCI builds on tags

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -665,7 +665,12 @@ workflows:
           requires: [build]
   build-test-deploy:
     jobs:
-      - build
+      - build:
+          filters:
+            branches:
+              only: /.+/
+            tags:
+              only: /.+/
       - test_barebone_release:
           requires: [build]
       - notify_services:


### PR DESCRIPTION
## Overview

Fix CircleCI not running CI on git tags

## Changes

By default, tags do not trigger CI jobs and the only way to enable it is through `only:` config. And so because we add `only:` config we need to add one for branches too.

Sources:
- https://discuss.circleci.com/t/builds-for-tags-not-triggering/17681
- https://discuss.circleci.com/t/build-workflow-not-triggered-when-tag-is-pushed/19577

## Testing

Merge this PR. Push a new tag. CircleCI should run on tags now.
