### PR TITLE
fix: add tags filter to CircleCI workflow jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -666,13 +666,14 @@ workflows:
   build-test-deploy:
     jobs:
       - build:
-          filters:
+          filters: &all_branches_and_tags
             branches:
               only: /.+/
             tags:
               only: /.+/
       - test_barebone_release:
           requires: [build]
+          filters: *all_branches_and_tags
       - notify_services:
           requires: [deploy_watcher, deploy_watcher_info, deploy_child_chain]
           filters:
@@ -688,26 +689,37 @@ workflows:
             - test
       - child_chain_coveralls_and_integration_tests:
           requires: [build]
+          filters: *all_branches_and_tags
       - watcher_coveralls_and_integration_tests:
           requires: [build]
+          filters: *all_branches_and_tags
       - watcher_info_coveralls_and_integration_tests:
           requires: [build]
+          filters: *all_branches_and_tags
       - common_coveralls_and_integration_tests:
           requires: [build]
+          filters: *all_branches_and_tags
       - test_docker_compose_release:
           requires: [build]
+          filters: *all_branches_and_tags
       - lint:
           requires: [build]
+          filters: *all_branches_and_tags
       - lint_version:
           requires: [build]
+          filters: *all_branches_and_tags
       - sobelow:
           requires: [build]
+          filters: *all_branches_and_tags
       - dialyzer:
           requires: [build]
+          filters: *all_branches_and_tags
       - test:
           requires: [build]
+          filters: *all_branches_and_tags
       - property_tests:
           requires: [build]
+          filters: *all_branches_and_tags
       # Publish in case of master branch, version branches and version tags.
       - publish_child_chain:
           requires:
@@ -722,7 +734,7 @@ workflows:
               lint,
               lint_version,
             ]
-          filters:
+          filters: &master_and_version_branches_and_all_tags
             branches:
               only:
                 - master
@@ -744,15 +756,7 @@ workflows:
               lint,
               lint_version,
             ]
-          filters:
-            branches:
-              only:
-                - master
-                # vMAJOR.MINOR (e.g. v0.1, v0.2, v1.0, v2.1, etc.)
-                - /^v[0-9]+\.[0-9]+/
-            tags:
-              only:
-                - /.+/
+          filters: *master_and_version_branches_and_all_tags
       - publish_watcher_info:
           requires:
             [
@@ -766,15 +770,7 @@ workflows:
               lint,
               lint_version,
             ]
-          filters:
-            branches:
-              only:
-                - master
-                # vMAJOR.MINOR (e.g. v0.1, v0.2, v1.0, v2.1, etc.)
-                - /^v[0-9]+\.[0-9]+/
-            tags:
-              only:
-                - /.+/
+          filters: *master_and_version_branches_and_all_tags
       # Release deploy to development in case of master branch.
       - deploy_child_chain:
           requires: [publish_child_chain, publish_watcher, publish_watcher_info]


### PR DESCRIPTION
Relates to #1366 

## Overview

Another attempt to make CircleCI build docker images for version tags.

The previous PR #1366 made some progress by having the [`build` job executed on tags](https://app.circleci.com/github/omisego/elixir-omg/pipelines/376f16be-e2c4-4d09-bfd2-846a19286c0d/workflows/3145a22b-835b-4bc8-9a92-00d1f9e2be84). Now we need to bring up the rest of the workflow.

## Changes

Enable the rest of build, test and publish jobs enabled on tags. This aligns with the [ewallet's CircleCI](https://github.com/omisego/ewallet/blob/master/.circleci/config.yml#L235-L255) where docker images are being published on tags correctly.

## Testing

Merge this PR and tag a new release.