### PR TITLE
feat: Enforce consistent fee_specs.json between releases

### DIFF
--- a/apps/omg_child_chain/lib/omg_child_chain/fees/file_adapter.ex
+++ b/apps/omg_child_chain/lib/omg_child_chain/fees/file_adapter.ex
@@ -70,6 +70,6 @@ defmodule OMG.ChildChain.Fees.FileAdapter do
   end
 
   defp get_path() do
-    "#{:code.priv_dir(:omg_child_chain)}/#{Application.get_env(:omg_child_chain, :fee_specs_file_name)}"
+    "#{:code.priv_dir(:omg_child_chain)}/#{Application.get_env(:fee_specs_file_name)}"
   end
 end


### PR DESCRIPTION
## Overview

Fixes the `fee_specs.json` mountpath at the same location, irrespective of release number.

https://github.com/omisego/elixir-omg/issues/1353

## Changes

Removed child chain version from `get_path()`

## Testing

CI
