### PR TITLE
Fix "piggyback_available" popping back after challenge

### DIFF
--- a/apps/omg_watcher/lib/omg_watcher/exit_processor/core.ex
+++ b/apps/omg_watcher/lib/omg_watcher/exit_processor/core.ex
@@ -513,14 +513,14 @@ defmodule OMG.Watcher.ExitProcessor.Core do
 
     available_inputs =
       input_witnesses
-      |> Enum.filter(fn {index, _} -> not InFlightExitInfo.is_active?(ife, {:input, index}) end)
+      |> Enum.filter(fn {index, _} -> not InFlightExitInfo.is_piggybacked?(ife, {:input, index}) end)
       |> Enum.map(fn {index, owner} -> %{index: index, address: owner} end)
 
     available_outputs =
       outputs
       |> Enum.filter(fn %{owner: owner} -> zero_address?(owner) end)
       |> Enum.with_index()
-      |> Enum.filter(fn {_, index} -> not InFlightExitInfo.is_active?(ife, {:output, index}) end)
+      |> Enum.filter(fn {_, index} -> not InFlightExitInfo.is_piggybacked?(ife, {:output, index}) end)
       |> Enum.map(fn {%{owner: owner}, index} -> %{index: index, address: owner} end)
 
     if Enum.empty?(available_inputs) and Enum.empty?(available_outputs) do
@@ -553,8 +553,8 @@ defmodule OMG.Watcher.ExitProcessor.Core do
       txhash: txhash,
       txbytes: Transaction.raw_txbytes(tx),
       eth_height: eth_height,
-      piggybacked_inputs: InFlightExitInfo.piggybacked_inputs(ife_info),
-      piggybacked_outputs: InFlightExitInfo.piggybacked_outputs(ife_info)
+      piggybacked_inputs: InFlightExitInfo.actively_piggybacked_inputs(ife_info),
+      piggybacked_outputs: InFlightExitInfo.actively_piggybacked_outputs(ife_info)
     }
   end
 

--- a/apps/omg_watcher/lib/omg_watcher/exit_processor/core.ex
+++ b/apps/omg_watcher/lib/omg_watcher/exit_processor/core.ex
@@ -343,7 +343,7 @@ defmodule OMG.Watcher.ExitProcessor.Core do
       |> Enum.filter(&InFlightExitInfo.is_relevant?(&1, blknum_now))
 
     ife_inputs_pos = active_relevant_ifes |> Enum.flat_map(&Transaction.get_inputs(&1.tx))
-    ife_outputs_pos = active_relevant_ifes |> Enum.flat_map(&InFlightExitInfo.get_piggybacked_outputs_positions/1)
+    ife_outputs_pos = active_relevant_ifes |> Enum.flat_map(&InFlightExitInfo.get_active_output_piggybacks_positions/1)
 
     (ife_outputs_pos ++ ife_inputs_pos ++ standard_exits_pos)
     |> :lists.usort()
@@ -374,7 +374,7 @@ defmodule OMG.Watcher.ExitProcessor.Core do
       ifes
       |> Map.values()
       |> Enum.flat_map(fn %{tx: tx} = ife ->
-        InFlightExitInfo.get_piggybacked_outputs_positions(ife) ++ Transaction.get_inputs(tx)
+        InFlightExitInfo.get_active_output_piggybacks_positions(ife) ++ Transaction.get_inputs(tx)
       end)
       |> only_utxos_checked_and_missing(utxo_exists?)
       |> :lists.usort()

--- a/apps/omg_watcher/lib/omg_watcher/exit_processor/core.ex
+++ b/apps/omg_watcher/lib/omg_watcher/exit_processor/core.ex
@@ -513,14 +513,14 @@ defmodule OMG.Watcher.ExitProcessor.Core do
 
     available_inputs =
       input_witnesses
-      |> Enum.filter(fn {index, _} -> not InFlightExitInfo.is_input_piggybacked?(ife, index) end)
+      |> Enum.filter(fn {index, _} -> not InFlightExitInfo.is_active?(ife, {:input, index}) end)
       |> Enum.map(fn {index, owner} -> %{index: index, address: owner} end)
 
     available_outputs =
       outputs
       |> Enum.filter(fn %{owner: owner} -> zero_address?(owner) end)
       |> Enum.with_index()
-      |> Enum.filter(fn {_, index} -> not InFlightExitInfo.is_output_piggybacked?(ife, index) end)
+      |> Enum.filter(fn {_, index} -> not InFlightExitInfo.is_active?(ife, {:output, index}) end)
       |> Enum.map(fn {%{owner: owner}, index} -> %{index: index, address: owner} end)
 
     if Enum.empty?(available_inputs) and Enum.empty?(available_outputs) do

--- a/apps/omg_watcher/lib/omg_watcher/exit_processor/in_flight_exit_info.ex
+++ b/apps/omg_watcher/lib/omg_watcher/exit_processor/in_flight_exit_info.ex
@@ -69,7 +69,8 @@ defmodule OMG.Watcher.ExitProcessor.InFlightExitInfo do
   @type exit_map_t() :: %{
           {:input | :output, non_neg_integer()} => %{
             is_piggybacked: boolean(),
-            is_finalized: boolean()
+            is_finalized: boolean(),
+            is_challenged: boolean()
           }
         }
 
@@ -270,8 +271,8 @@ defmodule OMG.Watcher.ExitProcessor.InFlightExitInfo do
 
   def piggyback(%__MODULE__{}, _), do: {:error, :non_existent_exit}
 
-  defp piggyback_exit(%{is_piggybacked: false, is_finalized: false}),
-    do: {:ok, %{is_piggybacked: true, is_finalized: false}}
+  defp piggyback_exit(%{is_piggybacked: false, is_finalized: false, is_challenged: false} = exit_map_entry),
+    do: {:ok, %{exit_map_entry | is_piggybacked: true}}
 
   defp piggyback_exit(_), do: {:error, :cannot_piggyback}
 
@@ -292,8 +293,10 @@ defmodule OMG.Watcher.ExitProcessor.InFlightExitInfo do
 
   @spec challenge_piggyback(t(), combined_index_t()) :: t()
   def challenge_piggyback(%__MODULE__{exit_map: exit_map} = ife, combined_index) when is_tuple(combined_index) do
-    %{is_piggybacked: true, is_finalized: false} = exit_map_get(exit_map, combined_index)
-    %{ife | exit_map: Map.replace!(exit_map, combined_index, %{is_piggybacked: false, is_finalized: false})}
+    %{is_piggybacked: true, is_finalized: false, is_challenged: false} =
+      exit_map_entry = exit_map_get(exit_map, combined_index)
+
+    %{ife | exit_map: Map.replace!(exit_map, combined_index, %{exit_map_entry | is_challenged: true})}
   end
 
   @spec respond_to_challenge(t(), Utxo.Position.t()) ::
@@ -366,28 +369,21 @@ defmodule OMG.Watcher.ExitProcessor.InFlightExitInfo do
     {position, oindex}
   end
 
-  def piggybacked_inputs(ife) do
+  def actively_piggybacked_inputs(ife) do
     @inputs_index_range
-    |> Enum.filter(&is_piggybacked?(ife, {:input, &1}))
+    |> Enum.filter(&is_active?(ife, {:input, &1}))
   end
 
-  def piggybacked_outputs(ife) do
+  def actively_piggybacked_outputs(ife) do
     @outputs_index_range
-    |> Enum.filter(&is_piggybacked?(ife, {:output, &1}))
-  end
-
-  @spec is_finalized?(t(), combined_index_t()) :: boolean()
-  def is_finalized?(%__MODULE__{exit_map: map}, combined_index) do
-    if exit = exit_map_get(map, combined_index) do
-      Map.get(exit, :is_finalized, false)
-    else
-      false
-    end
+    |> Enum.filter(&is_active?(ife, {:output, &1}))
   end
 
   @spec is_active?(t(), combined_index_t()) :: boolean()
   def is_active?(%__MODULE__{} = ife, combined_index) do
-    is_piggybacked?(ife, combined_index) and !is_finalized?(ife, combined_index)
+    is_piggybacked?(ife, combined_index) and
+      !is_finalized?(ife, combined_index) and
+      !is_challenged?(ife, combined_index)
   end
 
   def activate(%__MODULE__{} = ife) do
@@ -434,9 +430,27 @@ defmodule OMG.Watcher.ExitProcessor.InFlightExitInfo do
     do: relevant_from_blknum < blknum_now
 
   @spec is_piggybacked?(t(), combined_index_t()) :: boolean()
-  defp is_piggybacked?(%__MODULE__{exit_map: map}, combined_index) when is_tuple(combined_index) do
+  def is_piggybacked?(%__MODULE__{exit_map: map}, combined_index) when is_tuple(combined_index) do
     if exit = exit_map_get(map, combined_index) do
       Map.get(exit, :is_piggybacked, false)
+    else
+      false
+    end
+  end
+
+  @spec is_finalized?(t(), combined_index_t()) :: boolean()
+  defp is_finalized?(%__MODULE__{exit_map: map}, combined_index) do
+    if exit = exit_map_get(map, combined_index) do
+      Map.get(exit, :is_finalized, false)
+    else
+      false
+    end
+  end
+
+  @spec is_challenged?(t(), combined_index_t()) :: boolean()
+  defp is_challenged?(%__MODULE__{exit_map: map}, combined_index) do
+    if exit = exit_map_get(map, combined_index) do
+      Map.get(exit, :is_challenged, false)
     else
       false
     end
@@ -472,8 +486,12 @@ defmodule OMG.Watcher.ExitProcessor.InFlightExitInfo do
     end
   end
 
-  @spec exit_map_get(exit_map_t(), combined_index_t()) :: %{is_piggybacked: boolean(), is_finalized: boolean()}
+  @spec exit_map_get(exit_map_t(), combined_index_t()) :: %{
+          is_piggybacked: boolean(),
+          is_finalized: boolean(),
+          is_challenged: boolean()
+        }
   defp exit_map_get(exit_map, {type, index} = combined_index)
        when (type == :input and index < @max_inputs) or (type == :output and index < @max_outputs),
-       do: Map.get(exit_map, combined_index, %{is_piggybacked: false, is_finalized: false})
+       do: Map.get(exit_map, combined_index, %{is_piggybacked: false, is_finalized: false, is_challenged: false})
 end

--- a/apps/omg_watcher/lib/omg_watcher/exit_processor/piggyback.ex
+++ b/apps/omg_watcher/lib/omg_watcher/exit_processor/piggyback.ex
@@ -131,7 +131,7 @@ defmodule OMG.Watcher.ExitProcessor.Piggyback do
           list({InFlightExitInfo.t(), piggyback_type_t(), %{non_neg_integer => DoubleSpend.t()}})
   defp invalid_piggybacks_by_ife(known_txs_by_input, pb_type, ifes) do
     ifes
-    |> Enum.map(&InFlightExitInfo.indexed_active_piggybacks_by_ife(&1, pb_type))
+    |> Enum.map(&InFlightExitInfo.unchallenged_piggybacks_by_ife(&1, pb_type))
     |> Enum.filter(&ife_has_something?/1)
     |> Enum.map(fn {ife, indexed_piggybacked_utxo_positions} ->
       proof_materials =

--- a/apps/omg_watcher/lib/omg_watcher/exit_processor/piggyback.ex
+++ b/apps/omg_watcher/lib/omg_watcher/exit_processor/piggyback.ex
@@ -130,9 +130,8 @@ defmodule OMG.Watcher.ExitProcessor.Piggyback do
   @spec invalid_piggybacks_by_ife(KnownTx.known_txs_by_input_t(), piggyback_type_t(), list(InFlightExitInfo.t())) ::
           list({InFlightExitInfo.t(), piggyback_type_t(), %{non_neg_integer => DoubleSpend.t()}})
   defp invalid_piggybacks_by_ife(known_txs_by_input, pb_type, ifes) do
-    # getting invalid piggybacks on inputs
     ifes
-    |> Enum.map(&InFlightExitInfo.indexed_piggybacks_by_ife(&1, pb_type))
+    |> Enum.map(&InFlightExitInfo.indexed_active_piggybacks_by_ife(&1, pb_type))
     |> Enum.filter(&ife_has_something?/1)
     |> Enum.map(fn {ife, indexed_piggybacked_utxo_positions} ->
       proof_materials =

--- a/apps/omg_watcher/test/omg_watcher/exit_processor/core/state_interaction_test.exs
+++ b/apps/omg_watcher/test/omg_watcher/exit_processor/core/state_interaction_test.exs
@@ -40,6 +40,9 @@ defmodule OMG.Watcher.ExitProcessor.Core.StateInteractionTest do
 
   @fee %{@eth => [1]}
 
+  # needs to match up with the default from `ExitProcessor.Case` :(
+  @exit_id 9876
+
   setup do
     {:ok, processor_empty} = Core.init([], [], [])
     {:ok, child_block_interval} = OMG.Eth.RootChain.get_child_block_interval()
@@ -121,7 +124,8 @@ defmodule OMG.Watcher.ExitProcessor.Core.StateInteractionTest do
              |> Core.check_validity(processor)
 
     # exit validly finalizes and continues to not emit any events
-    {:ok, {_, spends}, _} = [1] |> Enum.map(&Core.exit_key_by_exit_id(processor, &1)) |> State.Core.exit_utxos(state)
+    {:ok, {_, spends}, _} =
+      [@exit_id] |> Enum.map(&Core.exit_key_by_exit_id(processor, &1)) |> State.Core.exit_utxos(state)
 
     assert {processor, [{:put, :exit_info, {{2, 0, 0}, _}}]} = Core.finalize_exits(processor, spends)
 

--- a/apps/omg_watcher/test/omg_watcher/exit_processor/finalizations_test.exs
+++ b/apps/omg_watcher/test/omg_watcher/exit_processor/finalizations_test.exs
@@ -175,7 +175,7 @@ defmodule OMG.Watcher.ExitProcessor.FinalizationsTest do
         %{in_flight_exit_id: <<ife_id::192>>, output_index: 2, omg_data: %{piggyback_type: :input}}
       ]
 
-      {:unknown_piggybacks, ^expected_unknown_piggybacks} =
+      {:inactive_piggybacks_finalizing, ^expected_unknown_piggybacks} =
         Core.prepare_utxo_exits_for_in_flight_exit_finalizations(processor, [finalization1, finalization2])
     end
   end
@@ -259,7 +259,7 @@ defmodule OMG.Watcher.ExitProcessor.FinalizationsTest do
       assert [] == Core.get_active_in_flight_exits(processor)
     end
 
-    test "finalizing multiple times does not change state or produce database updates",
+    test "finalizing multiple times returns an error since it is not possible",
          %{processor_empty: processor, transactions: [tx | _]} do
       ife_id = 123
       tx_hash = Transaction.raw_txhash(tx)
@@ -271,7 +271,7 @@ defmodule OMG.Watcher.ExitProcessor.FinalizationsTest do
 
       finalization = %{in_flight_exit_id: ife_id, output_index: 1, omg_data: %{piggyback_type: :input}}
       {:ok, processor, _} = Core.finalize_in_flight_exits(processor, [finalization], %{})
-      {:ok, ^processor, []} = Core.finalize_in_flight_exits(processor, [finalization], %{})
+      {:inactive_piggybacks_finalizing, _} = Core.finalize_in_flight_exits(processor, [finalization], %{})
     end
 
     test "finalizing perserve in flights exits that are not being finalized",
@@ -316,7 +316,7 @@ defmodule OMG.Watcher.ExitProcessor.FinalizationsTest do
         %{in_flight_exit_id: <<ife_id::192>>, output_index: 2, omg_data: %{piggyback_type: :input}}
       ]
 
-      {:unknown_piggybacks, ^expected_unknown_piggybacks} =
+      {:inactive_piggybacks_finalizing, ^expected_unknown_piggybacks} =
         Core.finalize_in_flight_exits(processor, [finalization1, finalization2], %{})
     end
   end

--- a/apps/omg_watcher/test/omg_watcher/exit_processor/standard_exit_test.exs
+++ b/apps/omg_watcher/test/omg_watcher/exit_processor/standard_exit_test.exs
@@ -48,7 +48,8 @@ defmodule OMG.Watcher.ExitProcessor.StandardExitTest do
 
   @deposit_input2 {@deposit_blknum2, 0, 0}
 
-  @exit_id 1
+  # needs to match up with the default from `ExitProcessor.Case` :(
+  @exit_id 9876
 
   setup do
     {:ok, empty} = Core.init([], [], [])

--- a/apps/omg_watcher/test/support/exit_processor/test_helper.ex
+++ b/apps/omg_watcher/test/support/exit_processor/test_helper.ex
@@ -25,6 +25,7 @@ defmodule OMG.Watcher.ExitProcessor.TestHelper do
 
   require Utxo
 
+  # default exit_id used when starting exits using `start_se_from` and `start_ife_from`
   @exit_id 9876
 
   def start_se_from(%Core{} = processor, tx, exiting_pos, opts \\ []) do

--- a/apps/omg_watcher/test/support/exit_processor/test_helper.ex
+++ b/apps/omg_watcher/test/support/exit_processor/test_helper.ex
@@ -25,7 +25,7 @@ defmodule OMG.Watcher.ExitProcessor.TestHelper do
 
   require Utxo
 
-  @exit_id 1
+  @exit_id 9876
 
   def start_se_from(%Core{} = processor, tx, exiting_pos, opts \\ []) do
     {event, status} = se_event_status(tx, exiting_pos, opts)


### PR DESCRIPTION
Closes #1371 

## Overview

It is the "Quick fix" mentioned in #1371. The larger fix #1318 would do proper justice to the handling of piggyback state (description of that in #1318 still pending), which should not be modeled with a bunch of booleans. There should also be a revamp done to the overall "lifecycle" of the piggyback, to include invalidly processing ones.

## Changes

 - adds a simple test picking up the case in question, in `piggyback_test.exs`
 - refactors some other tests and inner working of `InFlightExitInfo`. We're interrested in the notions of 1/ "activity" of a piggyback, where it means it may finalize and we perhaps want to check if it is valid and 2/ "being piggybacked", where it means just this.
 - it finally adds an explicit notion of `is_challenged` to the IFE's piggyback model. Whenever a piggyback challenge happens it now turns that `true` instead of turning `is_piggybacked` to `false`, which led to the error

## Testing

the usual tests apply. Also I'll use this in the revamped IFE tests prepared as part of #1344, where we will challange invalid piggybacks and require that they do not show up as "`piggyback_available`" anymore