### PR TITLE
docs: fix wrong indentation in API specs

### DIFF
--- a/docs-ui/0.4/info_api_specs.yaml
+++ b/docs-ui/0.4/info_api_specs.yaml
@@ -499,10 +499,10 @@ paths:
                             amount:
                               type: integer
                               format: int256
-                              inserted_at:
-                                type: string
-                              updated_at:
-                                type: string
+                            inserted_at:
+                              type: string
+                            updated_at:
+                              type: string
                     example:
                       data:
                         - blknum: 123000

--- a/docs-ui/master/info_api_specs.yaml
+++ b/docs-ui/master/info_api_specs.yaml
@@ -499,10 +499,10 @@ paths:
                             amount:
                               type: integer
                               format: int256
-                              inserted_at:
-                                type: string
-                              updated_at:
-                                type: string
+                            inserted_at:
+                              type: string
+                            updated_at:
+                              type: string
                     example:
                       data:
                         - blknum: 123000


### PR DESCRIPTION
Relates to #1362

## Overview

Mirrors the API specs fix from master branch's https://github.com/omisego/elixir-omg/pull/1362/commits/743d1bc63260b1f36224703b2dbed0419d0fefef 