### PR TITLE
feat: properly skip CircleCI on gh-pages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,1 @@
+version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,12 @@
 version: 2
 
 jobs:
-  build:
+  print-skip-message:
     steps:
       - run: echo "Skipping CI on `gh-pages` branch."
+
+workflows:
+  version: 2
+  ignore-gh-pages:
+    jobs:
+      - print-skip-message

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,10 +1,10 @@
 version: 2
 
 jobs:
-  print-skipping-message:
+  skip-gh-pages-branch:
     docker:
       # This weird-looking docker image is CircleCI Base Image (https://circleci.com/docs/2.0/circleci-images/#circleci-base-image)
-      image: cimg/base:2020.01
+      - image: cimg/base:2020.01
     steps:
       - run: echo "Skipping CI on `gh-pages` branch."
 
@@ -14,6 +14,6 @@ workflows:
   # "No workflows to execute for this pipeline" which can be scary among other commits
   # that we expect CI to trigger. So we let a simple job run that would inform that
   # we are skipping the `gh-pages` branch.
-  ignore-gh-pages:
+  skip-gh-pages:
     jobs:
-      - print-skipping-message
+      - skip-gh-pages-branch

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,8 +11,9 @@ jobs:
 workflows:
   version: 2
   ignore-gh-pages:
-    branches:
-      ignore:
-        - gh-pages
     jobs:
-      - skip-build
+      - skip-build:
+          filters:
+            branches:
+              ignore:
+                - /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,1 +1,6 @@
 version: 2
+
+jobs:
+  build:
+    steps:
+      - run: echo "Skipping CI on `gh-pages` branch."

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,12 +1,18 @@
 version: 2
 
 jobs:
-  print-skip-message:
+  skip-build:
+    docker:
+      # This weird-looking docker image is CircleCI Base Image (https://circleci.com/docs/2.0/circleci-images/#circleci-base-image)
+      image: cimg/base:2020.01
     steps:
       - run: echo "Skipping CI on `gh-pages` branch."
+    branches:
+      ignore:
+        - gh-pages
 
 workflows:
   version: 2
   ignore-gh-pages:
     jobs:
-      - print-skip-message
+      - skip-build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,12 +7,12 @@ jobs:
       image: cimg/base:2020.01
     steps:
       - run: echo "Skipping CI on `gh-pages` branch."
-    branches:
-      ignore:
-        - gh-pages
 
 workflows:
   version: 2
   ignore-gh-pages:
+    branches:
+      ignore:
+        - gh-pages
     jobs:
       - skip-build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2
 
 jobs:
-  skip-build:
+  print-skipping-message:
     docker:
       # This weird-looking docker image is CircleCI Base Image (https://circleci.com/docs/2.0/circleci-images/#circleci-base-image)
       image: cimg/base:2020.01
@@ -10,10 +10,10 @@ jobs:
 
 workflows:
   version: 2
+  # We could have used workflow's branch filter but it shows up as undescriptive
+  # "No workflows to execute for this pipeline" which can be scary among other commits
+  # that we expect CI to trigger. So we let a simple job run that would inform that
+  # we are skipping the `gh-pages` branch.
   ignore-gh-pages:
     jobs:
-      - skip-build:
-          filters:
-            branches:
-              ignore:
-                - /.*/
+      - print-skipping-message


### PR DESCRIPTION
## Overview

Add a circleci config to `gh-pages` branch so it shows a proper message.

## Testing

**No good:**
![image](https://user-images.githubusercontent.com/921194/75988759-ae8a9300-5f24-11ea-96ed-899e1455a514.png)

**Too scary:**
![image](https://user-images.githubusercontent.com/921194/75988803-bba78200-5f24-11ea-84a6-89acbe72791b.png)

**Awyeah:**
![image](https://user-images.githubusercontent.com/921194/75988824-c530ea00-5f24-11ea-95b7-6e19d299b834.png)

The last screenshot is the one to be shown by this PR.