### PR TITLE
chore: add more Tesla middleware overriding for a more stable client on load tests

### DIFF
--- a/priv/perf/README.md
+++ b/priv/perf/README.md
@@ -3,14 +3,13 @@
 Umbrella app for performance/load/stress tests
 
 ## How to run the test
-1. Override the urls for the services by environment variables if needed. Otherwise would be set to the default localhost with port defined in docker-compose file (No need to override if running against local services). for example:
-    ```
-    CHILD_CHAIN_URL=http://localhost:7534
-    WATCHER_SECURITY_URL=http://localhost:7434
-    WATCHER_INFO_URL=http://localhost:7534
-    ```
+1. Change the urls inside the [config files](config/) for the environment you are targeting.
+1. To generate the open-api client (only need once): `make init`
+1. To run the test: `MIX_ENV=<your_env> mix test`. Or `mix test` if you want to run against local services.
 
+### Spin up local services for development
 1. To test with local services (by docker-compose): `make start-services`
-1. To generate the open-api client: `make init`
-1. To run the test: `make test`
 1. To turn the local services down: `make stop-services`
+
+### Increase connection pool size and connection
+One can override the setup in config to increase the `pool_size` and `max_connection`. If you found the latency on the api calls are high but the data dog latency shows way smaller, it might be latency from setting up the connection instead of real api latency.

--- a/priv/perf/apps/load_test/.formatter.exs
+++ b/priv/perf/apps/load_test/.formatter.exs
@@ -1,4 +1,5 @@
 # Used by "mix format"
 [
-  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
+  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"],
+  line_length: 120
 ]

--- a/priv/perf/apps/load_test/lib/application.ex
+++ b/priv/perf/apps/load_test/lib/application.ex
@@ -3,7 +3,6 @@ defmodule LoadTest.Application do
   Application for the load test
   """
 
-  @impl true
   def start(_type, _args) do
     pool_size = Application.get_env(:load_test, :pool_size)
     max_connections = Application.get_env(:load_test, :max_connection)
@@ -19,7 +18,6 @@ defmodule LoadTest.Application do
     {:ok, self()}
   end
 
-  @impl true
   def stop(_app) do
     :hackney_pool.stop_pool(:perf_pool)
   end

--- a/priv/perf/apps/load_test/lib/application.ex
+++ b/priv/perf/apps/load_test/lib/application.ex
@@ -1,0 +1,26 @@
+defmodule LoadTest.Application do
+  @moduledoc """
+  Application for the load test
+  """
+
+  @impl true
+  def start(_type, _args) do
+    pool_size = Application.get_env(:load_test, :pool_size)
+    max_connections = Application.get_env(:load_test, :max_connection)
+
+    :ok =
+      :hackney_pool.start_pool(
+        :perf_pool,
+        timeout: 180_000,
+        pool_size: pool_size,
+        max_connections: max_connections
+      )
+
+    {:ok, self()}
+  end
+
+  @impl true
+  def stop(_app) do
+    :hackney_pool.stop_pool(:perf_pool)
+  end
+end

--- a/priv/perf/apps/load_test/lib/connection/child_chain.ex
+++ b/priv/perf/apps/load_test/lib/connection/child_chain.ex
@@ -13,7 +13,9 @@ defmodule LoadTest.Connection.ChildChain do
       {Tesla.Middleware.BaseUrl, base_url},
       {Tesla.Middleware.EncodeJson, engine: Jason},
       {Tesla.Middleware.Headers, [{"user-agent", "Perf"}]},
-      {Tesla.Middleware.Retry, delay: 500, max_retries: 10, max_delay: 45_000, should_retry: Utils.retry?()}
+      {Tesla.Middleware.Retry, delay: 500, max_retries: 10, max_delay: 45_000, should_retry: Utils.retry?()},
+      {Tesla.Middleware.Timeout, timeout: 30_000},
+      {Tesla.Middleware.Opts, [adapter: [recv_timeout: 30_000, pool: :perf_pool]]}
     ]
 
     Tesla.client(middleware)

--- a/priv/perf/apps/load_test/lib/connection/child_chain.ex
+++ b/priv/perf/apps/load_test/lib/connection/child_chain.ex
@@ -9,6 +9,7 @@ defmodule LoadTest.Connection.ChildChain do
     base_url = Application.get_env(:load_test, :child_chain_url)
 
     middleware = [
+      Tesla.Middleware.Logger,
       {Tesla.Middleware.BaseUrl, base_url},
       {Tesla.Middleware.EncodeJson, engine: Jason},
       {Tesla.Middleware.Headers, [{"user-agent", "Elixir"}]},

--- a/priv/perf/apps/load_test/lib/connection/child_chain.ex
+++ b/priv/perf/apps/load_test/lib/connection/child_chain.ex
@@ -3,13 +3,16 @@ defmodule LoadTest.Connection.ChildChain do
   Module that overrides the Tesla middleware with the url in config.
   """
 
+  alias LoadTest.Connection.Utils
+
   def client() do
     base_url = Application.get_env(:load_test, :child_chain_url)
 
     middleware = [
       {Tesla.Middleware.BaseUrl, base_url},
       {Tesla.Middleware.EncodeJson, engine: Jason},
-      {Tesla.Middleware.Headers, [{"user-agent", "Elixir"}]}
+      {Tesla.Middleware.Headers, [{"user-agent", "Elixir"}]},
+      {Tesla.Middleware.Retry, delay: 500, max_retries: 10, max_delay: 45_000, should_retry: Utils.retry?()}
     ]
 
     Tesla.client(middleware)

--- a/priv/perf/apps/load_test/lib/connection/child_chain.ex
+++ b/priv/perf/apps/load_test/lib/connection/child_chain.ex
@@ -8,7 +8,7 @@ defmodule LoadTest.Connection.ChildChain do
 
     middleware = [
       {Tesla.Middleware.BaseUrl, base_url},
-      {Tesla.Middleware.EncodeJson, engine: Poison},
+      {Tesla.Middleware.EncodeJson, engine: Jason},
       {Tesla.Middleware.Headers, [{"user-agent", "Elixir"}]}
     ]
 

--- a/priv/perf/apps/load_test/lib/connection/child_chain.ex
+++ b/priv/perf/apps/load_test/lib/connection/child_chain.ex
@@ -12,7 +12,7 @@ defmodule LoadTest.Connection.ChildChain do
       Tesla.Middleware.Logger,
       {Tesla.Middleware.BaseUrl, base_url},
       {Tesla.Middleware.EncodeJson, engine: Jason},
-      {Tesla.Middleware.Headers, [{"user-agent", "Elixir"}]},
+      {Tesla.Middleware.Headers, [{"user-agent", "Perf"}]},
       {Tesla.Middleware.Retry, delay: 500, max_retries: 10, max_delay: 45_000, should_retry: Utils.retry?()}
     ]
 

--- a/priv/perf/apps/load_test/lib/connection/utils.ex
+++ b/priv/perf/apps/load_test/lib/connection/utils.ex
@@ -1,0 +1,13 @@
+defmodule LoadTest.Connection.Utils do
+  @moduledoc """
+  Utils functions that can be shared to all connection modules for Tesla clients
+  """
+
+  def retry?() do
+    fn
+      {:ok, %{status: status}} when status in 400..599 -> true
+      {:ok, _} -> false
+      {:error, _} -> true
+    end
+  end
+end

--- a/priv/perf/apps/load_test/lib/connection/watcher_info.ex
+++ b/priv/perf/apps/load_test/lib/connection/watcher_info.ex
@@ -12,7 +12,7 @@ defmodule LoadTest.Connection.WatcherInfo do
       Tesla.Middleware.Logger,
       {Tesla.Middleware.BaseUrl, base_url},
       {Tesla.Middleware.EncodeJson, engine: Jason},
-      {Tesla.Middleware.Headers, [{"user-agent", "Elixir"}]},
+      {Tesla.Middleware.Headers, [{"user-agent", "Perf"}]},
       {Tesla.Middleware.Retry, delay: 500, max_retries: 10, max_delay: 45_000, should_retry: Utils.retry?()}
     ]
 

--- a/priv/perf/apps/load_test/lib/connection/watcher_info.ex
+++ b/priv/perf/apps/load_test/lib/connection/watcher_info.ex
@@ -13,7 +13,9 @@ defmodule LoadTest.Connection.WatcherInfo do
       {Tesla.Middleware.BaseUrl, base_url},
       {Tesla.Middleware.EncodeJson, engine: Jason},
       {Tesla.Middleware.Headers, [{"user-agent", "Perf"}]},
-      {Tesla.Middleware.Retry, delay: 500, max_retries: 10, max_delay: 45_000, should_retry: Utils.retry?()}
+      {Tesla.Middleware.Retry, delay: 500, max_retries: 10, max_delay: 45_000, should_retry: Utils.retry?()},
+      {Tesla.Middleware.Timeout, timeout: 30_000},
+      {Tesla.Middleware.Opts, [adapter: [recv_timeout: 30_000, pool: :perf_pool]]}
     ]
 
     Tesla.client(middleware)

--- a/priv/perf/apps/load_test/lib/connection/watcher_info.ex
+++ b/priv/perf/apps/load_test/lib/connection/watcher_info.ex
@@ -8,7 +8,7 @@ defmodule LoadTest.Connection.WatcherInfo do
 
     middleware = [
       {Tesla.Middleware.BaseUrl, base_url},
-      {Tesla.Middleware.EncodeJson, engine: Poison},
+      {Tesla.Middleware.EncodeJson, engine: Jason},
       {Tesla.Middleware.Headers, [{"user-agent", "Elixir"}]}
     ]
 

--- a/priv/perf/apps/load_test/lib/connection/watcher_info.ex
+++ b/priv/perf/apps/load_test/lib/connection/watcher_info.ex
@@ -3,13 +3,16 @@ defmodule LoadTest.Connection.WatcherInfo do
   Module that overrides the Tesla middleware with the url in config.
   """
 
+  alias LoadTest.Connection.Utils
+
   def client() do
     base_url = Application.get_env(:load_test, :watcher_info_url)
 
     middleware = [
       {Tesla.Middleware.BaseUrl, base_url},
       {Tesla.Middleware.EncodeJson, engine: Jason},
-      {Tesla.Middleware.Headers, [{"user-agent", "Elixir"}]}
+      {Tesla.Middleware.Headers, [{"user-agent", "Elixir"}]},
+      {Tesla.Middleware.Retry, delay: 500, max_retries: 10, max_delay: 45_000, should_retry: Utils.retry?()}
     ]
 
     Tesla.client(middleware)

--- a/priv/perf/apps/load_test/lib/connection/watcher_info.ex
+++ b/priv/perf/apps/load_test/lib/connection/watcher_info.ex
@@ -9,6 +9,7 @@ defmodule LoadTest.Connection.WatcherInfo do
     base_url = Application.get_env(:load_test, :watcher_info_url)
 
     middleware = [
+      Tesla.Middleware.Logger,
       {Tesla.Middleware.BaseUrl, base_url},
       {Tesla.Middleware.EncodeJson, engine: Jason},
       {Tesla.Middleware.Headers, [{"user-agent", "Elixir"}]},

--- a/priv/perf/apps/load_test/lib/connection/watcher_security.ex
+++ b/priv/perf/apps/load_test/lib/connection/watcher_security.ex
@@ -12,7 +12,7 @@ defmodule LoadTest.Connection.WatcherSecurity do
       Tesla.Middleware.Logger,
       {Tesla.Middleware.BaseUrl, base_url},
       {Tesla.Middleware.EncodeJson, engine: Jason},
-      {Tesla.Middleware.Headers, [{"user-agent", "Elixir"}]},
+      {Tesla.Middleware.Headers, [{"user-agent", "Perf"}]},
       {Tesla.Middleware.Retry, delay: 500, max_retries: 10, max_delay: 45_000, should_retry: Utils.retry?()}
     ]
 

--- a/priv/perf/apps/load_test/lib/connection/watcher_security.ex
+++ b/priv/perf/apps/load_test/lib/connection/watcher_security.ex
@@ -3,13 +3,16 @@ defmodule LoadTest.Connection.WatcherSecurity do
   Module that overrides the Tesla middleware with the url in config.
   """
 
+  alias LoadTest.Connection.Utils
+
   def client() do
     base_url = Application.get_env(:load_test, :watcher_security_url)
 
     middleware = [
       {Tesla.Middleware.BaseUrl, base_url},
       {Tesla.Middleware.EncodeJson, engine: Jason},
-      {Tesla.Middleware.Headers, [{"user-agent", "Elixir"}]}
+      {Tesla.Middleware.Headers, [{"user-agent", "Elixir"}]},
+      {Tesla.Middleware.Retry, delay: 500, max_retries: 10, max_delay: 45_000, should_retry: Utils.retry?()}
     ]
 
     Tesla.client(middleware)

--- a/priv/perf/apps/load_test/lib/connection/watcher_security.ex
+++ b/priv/perf/apps/load_test/lib/connection/watcher_security.ex
@@ -13,7 +13,9 @@ defmodule LoadTest.Connection.WatcherSecurity do
       {Tesla.Middleware.BaseUrl, base_url},
       {Tesla.Middleware.EncodeJson, engine: Jason},
       {Tesla.Middleware.Headers, [{"user-agent", "Perf"}]},
-      {Tesla.Middleware.Retry, delay: 500, max_retries: 10, max_delay: 45_000, should_retry: Utils.retry?()}
+      {Tesla.Middleware.Retry, delay: 500, max_retries: 10, max_delay: 45_000, should_retry: Utils.retry?()},
+      {Tesla.Middleware.Timeout, timeout: 30_000},
+      {Tesla.Middleware.Opts, [adapter: [recv_timeout: 30_000, pool: :perf_pool]]}
     ]
 
     Tesla.client(middleware)

--- a/priv/perf/apps/load_test/lib/connection/watcher_security.ex
+++ b/priv/perf/apps/load_test/lib/connection/watcher_security.ex
@@ -8,7 +8,7 @@ defmodule LoadTest.Connection.WatcherSecurity do
 
     middleware = [
       {Tesla.Middleware.BaseUrl, base_url},
-      {Tesla.Middleware.EncodeJson, engine: Poison},
+      {Tesla.Middleware.EncodeJson, engine: Jason},
       {Tesla.Middleware.Headers, [{"user-agent", "Elixir"}]}
     ]
 

--- a/priv/perf/apps/load_test/lib/connection/watcher_security.ex
+++ b/priv/perf/apps/load_test/lib/connection/watcher_security.ex
@@ -9,6 +9,7 @@ defmodule LoadTest.Connection.WatcherSecurity do
     base_url = Application.get_env(:load_test, :watcher_security_url)
 
     middleware = [
+      Tesla.Middleware.Logger,
       {Tesla.Middleware.BaseUrl, base_url},
       {Tesla.Middleware.EncodeJson, engine: Jason},
       {Tesla.Middleware.Headers, [{"user-agent", "Elixir"}]},

--- a/priv/perf/apps/load_test/mix.exs
+++ b/priv/perf/apps/load_test/mix.exs
@@ -18,7 +18,8 @@ defmodule LoadTest.MixProject do
   # Run "mix help compile.app" to learn about applications.
   def application do
     [
-      extra_applications: [:logger]
+      extra_applications: [:logger],
+      mod: {LoadTest.Application, []}
     ]
   end
 

--- a/priv/perf/config/config.exs
+++ b/priv/perf/config/config.exs
@@ -5,4 +5,8 @@ use Mix.Config
 # https://github.com/googleapis/elixir-google-api/issues/26#issuecomment-360209019
 config :tesla, adapter: Tesla.Adapter.Hackney
 
+config :load_test,
+  pool_size: 5000,
+  max_connection: 5000
+
 import_config "#{Mix.env()}.exs"

--- a/priv/perf/config/stress.exs
+++ b/priv/perf/config/stress.exs
@@ -1,6 +1,8 @@
 use Mix.Config
 
 config :load_test,
+  pool_size: 20_000,
+  max_connection: 20_000,
   child_chain_url: "https://stress-e043a92-childchain-ropsten-01.omg.network/",
   watcher_security_url: "https://stress-e043a92-watcher-ropsten-01.omg.network/",
   watcher_info_url: "https://stress-e043a92-watcher-info-ropsten-01.omg.network/"

--- a/priv/perf/config/test.exs
+++ b/priv/perf/config/test.exs
@@ -1,6 +1,6 @@
 use Mix.Config
 
 config :load_test,
-  child_chain_url: System.get_env("CHILD_CHAIN_URL") || "http://localhost:9656",
-  watcher_security_url: System.get_env("WATCHER_SECURITY_URL") || "http://localhost:7434",
-  watcher_info_url: System.get_env("WATCHER_INFO_URL") || "http://localhost:7534"
+  child_chain_url: "http://localhost:9656",
+  watcher_security_url: "http://localhost:7434",
+  watcher_info_url: "http://localhost:7534"


### PR DESCRIPTION
:clipboard: Add associated issues, tickets, docs URL here.

## Overview

Override more on Tesla middleware for stable client.

## Changes

- use Jason instead of Poison
- change the header to "perf" on Tesla here.
- add retry and retry logic to the Tesla client to keep the test alive against transient error. It is by default using exponential backoff logic ✨
- setup connection pool (`:perf_pool`) in `Application.start/2` and use the pool in Tesla client
- update README

### References

- Jason vs Poison: https://github.com/phoenixframework/phoenix/issues/2693#issuecomment-388881650
- Tesla Middleware: https://hexdocs.pm/tesla/Tesla.Middleware.Retry.html#content
- Hackney connection pool: https://github.com/benoitc/hackney#use-the-default-pool
- Setting up `opts` for hackney: https://github.com/teamon/tesla/wiki/0.x-to-1.0-Migration-Guide#adapter-options-need-to-be-wrapped-in-adapter-key

## Testing

The setup is mainly tested/POC in `omg-load-test` repo with overriding the generated client.
`OMG.Perf.LoadTest.WatcherInfo` is run with 1000 concurrency and was able to continuously generate load for hours.

```
  plug Tesla.Middleware.Headers, [{"user-agent", "Elixir"}]
  plug Tesla.Middleware.EncodeJson, engine: Poison
  plug Tesla.Middleware.Opts, [adapter: [recv_timeout: 30_000, pool: :mypool]]
  plug Tesla.Middleware.Retry,
    delay: 500,
    max_retries: 10,
    max_delay: 45_000,
    should_retry: fn
      {:ok, %{status: status} = resp} when status in [400, 500, 502] -> 
        Logger.error("tesla middleware log - retry with status error: #{inspect({:ok, resp})}")
        true
      {:ok, resp} -> 
        Logger.debug("tesla middleware log: #{inspect({:ok, resp})}")
        false
      {:error, resp} -> 
        Logger.error("tesla middleware log - retry with error: #{inspect({:error, resp})}")
        true
      resp ->
        Logger.error("tesla middleware log - retry with unknown: #{inspect(resp)}")
        true
    end
```

See load from datadog: [here](https://app.datadoghq.com/apm/service/web/request?env=stress-e043a92-ropsten-01&paused=false&start=1583459095197&end=1583473495197)

With the retry from Tesla here, it does not even trigger `retry_on_error` from Chaperon session. (I put some `retry_on_error` on the higher level but it seems not triggered at all, for `retry_on_error` see: https://github.com/omisego/omg-load-testing/pull/37)

Also, the smoke test here to ensure it is not breaking.