### PR TITLE
Prevent split/merge creation in /transaction.create

### DIFF
--- a/apps/omg_watcher_rpc/lib/web/controllers/fallback.ex
+++ b/apps/omg_watcher_rpc/lib/web/controllers/fallback.ex
@@ -65,6 +65,10 @@ defmodule OMG.WatcherRPC.Web.Controller.Fallback do
       code: "transaction.create:empty_transaction",
       description: "Requested payment transfers no funds."
     },
+    self_transaction_not_supported: %{
+      code: "transaction.create:self_transaction_not_supported",
+      description: "This endpoint cannot be used to create merge or split transactions."
+    },
     missing_signature: %{
       code: "submit_typed:missing_signature",
       description:

--- a/apps/omg_watcher_rpc/lib/web/controllers/transaction.ex
+++ b/apps/omg_watcher_rpc/lib/web/controllers/transaction.ex
@@ -76,7 +76,8 @@ defmodule OMG.WatcherRPC.Web.Controller.Transaction do
   def create(conn, params) do
     with {:ok, order} <- Validator.Order.parse(params),
          {:ok, order} <- OrderFeeFetcher.add_fee_to_order(order) do
-      InfoApiTransaction.create(order)
+      order
+      |> InfoApiTransaction.create()
       |> InfoApiTransaction.include_typed_data()
       |> api_response(conn, :create)
     end

--- a/apps/omg_watcher_rpc/test/omg_watcher_rpc/web/controllers/transaction_test.exs
+++ b/apps/omg_watcher_rpc/test/omg_watcher_rpc/web/controllers/transaction_test.exs
@@ -1295,6 +1295,24 @@ defmodule OMG.WatcherRPC.Web.Controller.TransactionTest do
                )
     end
 
+    @tag fixtures: [:alice, :more_utxos]
+    test "returns an error when requester is equal to all the ouputs owner", %{alice: alice} do
+      params = %{
+        "owner" => Encoding.to_hex(alice.addr),
+        "payments" => [
+          %{"amount" => 1, "currency" => @eth_hex, "owner" => Encoding.to_hex(alice.addr)},
+          %{"amount" => 1, "currency" => @eth_hex, "owner" => Encoding.to_hex(alice.addr)}
+        ],
+        "fee" => %{"currency" => @default_fee_currency}
+      }
+
+      assert %{
+               "object" => "error",
+               "code" => "transaction.create:self_transaction_not_supported",
+               "description" => "This endpoint cannot be used to build merge or split transactions."
+             } == WatcherHelper.no_success?("transaction.create", params)
+    end
+
     defp balance_in_token(address, token) do
       currency = Encoding.to_hex(token)
 

--- a/apps/omg_watcher_rpc/test/omg_watcher_rpc/web/controllers/transaction_test.exs
+++ b/apps/omg_watcher_rpc/test/omg_watcher_rpc/web/controllers/transaction_test.exs
@@ -1309,7 +1309,7 @@ defmodule OMG.WatcherRPC.Web.Controller.TransactionTest do
       assert %{
                "object" => "error",
                "code" => "transaction.create:self_transaction_not_supported",
-               "description" => "This endpoint cannot be used to build merge or split transactions."
+               "description" => "This endpoint cannot be used to create merge or split transactions."
              } == WatcherHelper.no_success?("transaction.create", params)
     end
 


### PR DESCRIPTION
## Overview

Since the introduction of fees (and the overpaying error), merges cannot be created properly via `/transaction.create`. Since merges are free, but the `/transaction.create` generates transactions with fees included, it's currently returning paid merges which are rejected by the childchain.

`/transation.create` is currently returning invalid txs to the users.

To counter that, we thought about a few options, like trying to detect merges and not setting fees for them. Unfortunately, due to the way this endpoint works (only specifying outputs and selecting UTXOs for inputs), it's really hard to deduce if the user wants to do a merge or a split. 

Therefore, we've decided to prevent the creation of merges and splits via `/transaction.create` entirely, simply by checking that the `owner` address and all the output addresses are the same. 

## Changes

Describe your changes and implementation choices. More details make PRs easier to review.

- Return a new error (`transaction.create:self_transaction_not_supported`) if a user attempts to generate a merge or a split via `/transaction.create`.

## Testing

/
