### PR TITLE
retry index and dequeue

### DIFF
--- a/apps/omg_child_chain/lib/omg_child_chain/block_queue/gas_analyzer.ex
+++ b/apps/omg_child_chain/lib/omg_child_chain/block_queue/gas_analyzer.ex
@@ -50,11 +50,11 @@ defmodule OMG.ChildChain.BlockQueue.GasAnalyzer do
 
   @doc """
     We receive transaction hashes from BlockQueue.
-    These hashes do not mean that transaction was already accepted. 
-    The consequence is that Because of that
-    theres a possibility the transaction will never get accepted
-    and that we need to define a constant `try_index`. `try_index` constant is the 
-    threshold limit that defines the amount of retries we're willing to fetch gas. 
+    These hashes do not mean that transaction was already accepted.
+    The consequence is that theres a possibility the transaction
+    will never get accepted and that we need to define a constant `try_index`.
+    `try_index` constant is the threshold limit that defines the amount
+    of retries we're willing to fetch gas.
     After it's reached the tx hash will be thrown away.
   """
   def handle_info(:get_gas_used, state) do

--- a/apps/omg_child_chain/lib/omg_child_chain/block_queue/gas_analyzer.ex
+++ b/apps/omg_child_chain/lib/omg_child_chain/block_queue/gas_analyzer.ex
@@ -73,7 +73,7 @@ defmodule OMG.ChildChain.BlockQueue.GasAnalyzer do
               txhash_queue
 
             {nil, _} ->
-              # we couldn't get gas but we didn't reach the treshold yet 
+              # we couldn't get gas but we didn't reach the threshold yet 
               :queue.in_r({txhash, try_index + 1}, txhash_queue)
 
             {gas, _} ->

--- a/apps/omg_child_chain/lib/omg_child_chain/block_queue/gas_analyzer.ex
+++ b/apps/omg_child_chain/lib/omg_child_chain/block_queue/gas_analyzer.ex
@@ -73,7 +73,7 @@ defmodule OMG.ChildChain.BlockQueue.GasAnalyzer do
               txhash_queue
 
             {nil, _} ->
-              # we couldn't get gas but we didn't reach the threshold yet 
+              # we couldn't get gas but we didn't reach the threshold yet
               :queue.in_r({txhash, try_index + 1}, txhash_queue)
 
             {gas, _} ->

--- a/apps/omg_child_chain/lib/omg_child_chain/block_queue/gas_analyzer.ex
+++ b/apps/omg_child_chain/lib/omg_child_chain/block_queue/gas_analyzer.ex
@@ -44,9 +44,19 @@ defmodule OMG.ChildChain.BlockQueue.GasAnalyzer do
   end
 
   def handle_cast({:enqueue, txhash}, state) do
-    {:noreply, %{state | txhash_queue: :queue.in(txhash, state.txhash_queue)}}
+    try_index = 0
+    {:noreply, %{state | txhash_queue: :queue.in({txhash, try_index}, state.txhash_queue)}}
   end
 
+  @doc """
+    We receive transaction hashes from BlockQueue.
+    These hashes do not mean that transaction was already accepted. 
+    The consequence is that Because of that
+    theres a possibility the transaction will never get accepted
+    and that we need to define a constant `try_index`. `try_index` constant is the 
+    treshold limit that defines the amount of retries we're willing to do to fetch gas. 
+    After it's reached the tx hash will be thrown away.
+  """
   def handle_info(:get_gas_used, state) do
     txhash_queue =
       case :queue.is_empty(state.txhash_queue) do
@@ -54,14 +64,21 @@ defmodule OMG.ChildChain.BlockQueue.GasAnalyzer do
           state.txhash_queue
 
         false ->
-          {{:value, txhash}, txhash_queue} = state.txhash_queue |> :queue.out()
+          {{:value, {txhash, try_index}}, txhash_queue} = :queue.out(state.txhash_queue)
           gas_used = txhash |> to_hex() |> get_gas_used(state.rpc)
 
-          case gas_used do
-            nil ->
-              :queue.in_r(txhash, txhash_queue)
+          case {gas_used, try_index} do
+            {nil, 3} ->
+              # reached the treshold, we're ommiting this txhash
+              txhash_queue
 
-            gas ->
+            {nil, _} ->
+              # we couldn't get gas but we didn't reach the treshold yet 
+              :queue.in_r({txhash, try_index + 1}, txhash_queue)
+
+            {gas, _} ->
+              # Anyway a gas station we passed
+              # We got gas and went on to get grub
               _ = :telemetry.execute([:gas, __MODULE__], %{gas: gas}, %{})
               txhash_queue
           end
@@ -71,21 +88,21 @@ defmodule OMG.ChildChain.BlockQueue.GasAnalyzer do
     {:noreply, %{state | txhash_queue: txhash_queue}}
   end
 
-  defp get_gas_used(receipt_hash, rpc) do
-    result = {rpc.eth_get_transaction_receipt(receipt_hash), rpc.eth_get_transaction_by_hash(receipt_hash)}
+  defp get_gas_used(txhash, rpc) do
+    result = {rpc.eth_get_transaction_receipt(txhash), rpc.eth_get_transaction_by_hash(txhash)}
 
     case result do
       {{:ok, %{"gasUsed" => gas_used}}, {:ok, %{"gasPrice" => gas_price}}} ->
         gas_price_value = parse_gas(gas_price)
         gas_used_value = parse_gas(gas_used)
         gas_used = gas_price_value * gas_used_value
-        _ = Logger.info("Block submitted with receipt hash #{receipt_hash} and gas used #{gas_used}wei")
+        _ = Logger.info("Block submitted with receipt hash #{txhash} and gas used #{gas_used}wei")
         gas_used
 
       {eth_get_transaction_receipt, eth_get_transaction_by_hash} ->
         _ =
-          Logger.error(
-            "Could not get gas used for receipt_hash #{receipt_hash}. Eth_get_transaction_receipt result #{
+          Logger.warn(
+            "Could not get gas used for txhash #{txhash}. Eth_get_transaction_receipt result #{
               inspect(eth_get_transaction_receipt)
             }. Eth_get_transaction_by_hash result #{inspect(eth_get_transaction_by_hash)}."
           )

--- a/apps/omg_child_chain/lib/omg_child_chain/block_queue/gas_analyzer.ex
+++ b/apps/omg_child_chain/lib/omg_child_chain/block_queue/gas_analyzer.ex
@@ -54,7 +54,7 @@ defmodule OMG.ChildChain.BlockQueue.GasAnalyzer do
     The consequence is that Because of that
     theres a possibility the transaction will never get accepted
     and that we need to define a constant `try_index`. `try_index` constant is the 
-    treshold limit that defines the amount of retries we're willing to do to fetch gas. 
+    threshold limit that defines the amount of retries we're willing to fetch gas. 
     After it's reached the tx hash will be thrown away.
   """
   def handle_info(:get_gas_used, state) do

--- a/apps/omg_child_chain/lib/omg_child_chain/block_queue/gas_analyzer.ex
+++ b/apps/omg_child_chain/lib/omg_child_chain/block_queue/gas_analyzer.ex
@@ -69,7 +69,7 @@ defmodule OMG.ChildChain.BlockQueue.GasAnalyzer do
 
           case {gas_used, try_index} do
             {nil, 3} ->
-              # reached the treshold, we're ommiting this txhash
+              # reached the threshold, we're omitting this txhash
               txhash_queue
 
             {nil, _} ->

--- a/apps/omg_child_chain/test/omg_child_chain/block_queue/gas_analyzer_test.exs
+++ b/apps/omg_child_chain/test/omg_child_chain/block_queue/gas_analyzer_test.exs
@@ -127,7 +127,7 @@ defmodule OMG.ChildChain.BlockQueue.GasAnalyzerTest do
              end)
     end
 
-    test "that the order of txhashes is preserved when they can't get processed and that when treshold is met the tx hash gets removed",
+    test "that the order of txhashes is preserved when they can't get processed and that when threshold is met the tx hash gets removed",
          %{
            gas_analyzer: gas_analyzer,
            handler_id: handler_id

--- a/apps/omg_child_chain/test/omg_child_chain/block_queue/gas_analyzer_test.exs
+++ b/apps/omg_child_chain/test/omg_child_chain/block_queue/gas_analyzer_test.exs
@@ -88,7 +88,7 @@ defmodule OMG.ChildChain.BlockQueue.GasAnalyzerTest do
                  {:event, [:gas, OMG.ChildChain.BlockQueue.GasAnalyzer], %{gas: 84_681}, %{}},
                  100
                )
-             end) =~ "[error]"
+             end)
     end
   end
 


### PR DESCRIPTION
https://github.com/omisego/elixir-omg/issues/1427
A bug was discovered when tx hash gets rejected from the pool, we would try to get gas indefinitely. 

## Overview

Adds an index to tx hash that gets queued in Gas Analyzer, and removes the tx hash after 3 retries.
## Changes

## Testing

```
mix test test/omg_child_chain/block_queue/gas_analyzer_test.exs
```