### PR TITLE
fix: lint_version CI job to let pre-release versions match VERSION

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -182,11 +182,11 @@ jobs:
       - run:
           command: |
             if [ -n "$CIRCLE_TAG" ]; then
-              _tagged_version="${CIRCLE_TAG#*v}"
+              _tagged_version_ignoring_pre="${${CIRCLE_TAG#*v}%%-pre.*}"
               _filed_version="$(head -n 1 ./VERSION | sed 's/^[ \t]*//;s/[ \t]*$//')"
 
-              if [ "$_tagged_version" != "$_filed_version" ]; then
-                echo "The git tag \"${CIRCLE_TAG}\" expects the VERSION to be \"${_tagged_version}\". Got \"${_filed_version}\"."
+              if [ "$_tagged_version_ignoring_pre" != "$_filed_version" ]; then
+                echo "The git tag \"${CIRCLE_TAG}\" expects the VERSION to be \"${_tagged_version_ignoring_pre}\". Got \"${_filed_version}\"."
                 exit 1
               fi
             else


### PR DESCRIPTION
## Overview

Fixes CI lint_version [failing](https://app.circleci.com/pipelines/github/omisego/elixir-omg/6262/workflows/2d905f0d-e037-4a95-a1ae-d21331d4ec3b) when tagged with pre-release versions e.g. `v0.4.7-pre.0`.

## Changes

- Update `lint_version` CI job to exclude the pre-release section of the tag before comparing with `VERSION` file.

## Testing

- Tested against bash shell
    ```sh
    $ CIRCLE_TAG=v0.4.7
    $ echo "${${CIRCLE_TAG#*v}%%-pre.*}"
    0.4.7

    $ CIRCLE_TAG=v0.4.7-pre.0
    $ echo "${${CIRCLE_TAG#*v}%%-pre.*}"
    0.4.7

    $ CIRCLE_TAG=v0.4.7-pre.99
    $ echo "${${CIRCLE_TAG#*v}%%-pre.*}"
    0.4.7
    ```
- Future CI jobs on pre-release tags should pass `lint_version`