### PR TITLE
observe the authority address balance on block submission

### DIFF
--- a/apps/omg_child_chain/lib/omg_child_chain/block_queue.ex
+++ b/apps/omg_child_chain/lib/omg_child_chain/block_queue.ex
@@ -216,6 +216,7 @@ defmodule OMG.ChildChain.BlockQueue do
 
         {:ok, txhash} ->
           GasAnalyzer.enqueue(txhash)
+          OMG.ChildChain.BlockQueue.Balance.balance()
           :ok
 
         :ok ->

--- a/apps/omg_child_chain/lib/omg_child_chain/block_queue.ex
+++ b/apps/omg_child_chain/lib/omg_child_chain/block_queue.ex
@@ -42,6 +42,7 @@ defmodule OMG.ChildChain.BlockQueue do
   use OMG.Utils.LoggerExt
 
   alias OMG.Block
+  alias OMG.ChildChain.BlockQueue.Balance
   alias OMG.ChildChain.BlockQueue.Core
   alias OMG.ChildChain.BlockQueue.Core.BlockSubmission
   alias OMG.ChildChain.BlockQueue.GasAnalyzer
@@ -215,8 +216,8 @@ defmodule OMG.ChildChain.BlockQueue do
           error
 
         {:ok, txhash} ->
-          GasAnalyzer.enqueue(txhash)
-          OMG.ChildChain.BlockQueue.Balance.balance()
+          _ = GasAnalyzer.enqueue(txhash)
+          _ = Balance.check()
           :ok
 
         :ok ->

--- a/apps/omg_child_chain/lib/omg_child_chain/block_queue/balance.ex
+++ b/apps/omg_child_chain/lib/omg_child_chain/block_queue/balance.ex
@@ -14,9 +14,7 @@
 
 defmodule OMG.ChildChain.BlockQueue.Balance do
   @moduledoc """
-    Takes the transaction hash and puts it in the  FIFO queue
-  for each transaction hash we're trying to get the gas we've used to submit the block and send it of as a telemetry event
-  to datadog
+    Gets authority balance, logs it and send a telemetry event.
   """
   require Logger
   defstruct authority_address: nil, rpc: Ethereumex.HttpClient
@@ -45,7 +43,7 @@ defmodule OMG.ChildChain.BlockQueue.Balance do
   def handle_cast(:check, state) do
     {:ok, hex_authority_balance} = state.rpc.eth_get_balance(state.authority_address)
     authority_balance = parse_balance(hex_authority_balance)
-    _ = Logger.info("Authority address #{state.authority_address} balance #{authority_balance} Wei.")
+    _ = Logger.info("Authority #{state.authority_address} balance #{authority_balance} Wei.")
     _ = :telemetry.execute([:authority_balance, __MODULE__], %{authority_balance: authority_balance}, %{})
     {:noreply, state}
   end

--- a/apps/omg_child_chain/lib/omg_child_chain/block_queue/balance.ex
+++ b/apps/omg_child_chain/lib/omg_child_chain/block_queue/balance.ex
@@ -1,0 +1,57 @@
+# Copyright 2019-2020 OmiseGO Pte Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defmodule OMG.ChildChain.BlockQueue.Balance do
+  @moduledoc """
+    Takes the transaction hash and puts it in the  FIFO queue
+  for each transaction hash we're trying to get the gas we've used to submit the block and send it of as a telemetry event
+  to datadog
+  """
+  require Logger
+  defstruct authority_address: nil, rpc: Ethereumex.HttpClient
+
+  def check(server \\ __MODULE__) do
+    GenServer.cast(server, :check)
+  end
+
+  def child_spec(args) do
+    %{
+      id: __MODULE__,
+      start: {__MODULE__, :start_link, [args]},
+      type: :worker
+    }
+  end
+
+  def start_link(args) do
+    GenServer.start_link(__MODULE__, args, name: Keyword.get(args, :name, __MODULE__))
+  end
+
+  def init(args) do
+    authority_address = Keyword.fetch!(args, :authority_address)
+    {:ok, %__MODULE__{authority_address: authority_address}}
+  end
+
+  def handle_cast(:check, state) do
+    {:ok, hex_authority_balance} = state.rpc.eth_get_balance(state.authority_address)
+    authority_balance = parse_balance(hex_authority_balance)
+    _ = Logger.info("Authority address #{state.authority_address} balance #{authority_balance} Wei.")
+    _ = :telemetry.execute([:authority_balance, __MODULE__], %{authority_balance: authority_balance}, %{})
+    {:noreply, state}
+  end
+
+  defp parse_balance(data) do
+    {value, ""} = data |> String.replace_prefix("0x", "") |> Integer.parse(16)
+    value
+  end
+end

--- a/apps/omg_child_chain/lib/omg_child_chain/block_queue/measure.ex
+++ b/apps/omg_child_chain/lib/omg_child_chain/block_queue/measure.ex
@@ -25,6 +25,7 @@ defmodule OMG.ChildChain.BlockQueue.Measure do
   import OMG.Status.Metric.Event, only: [name: 2, name: 1]
 
   alias OMG.ChildChain.BlockQueue
+  alias OMG.ChildChain.BlockQueue.Balance
   alias OMG.ChildChain.BlockQueue.GasAnalyzer
   alias OMG.Status.Metric.Datadog
 
@@ -46,5 +47,10 @@ defmodule OMG.ChildChain.BlockQueue.Measure do
   def handle_event([:gas, GasAnalyzer], %{gas: gas}, _, _config) do
     gwei = div(gas, 1_000_000_000)
     _ = Datadog.gauge(name(:block_subbmission), gwei)
+  end
+
+  def handle_event([:authority_balance, Balance], %{authority_balance: authority_balance}, _, _config) do
+    gwei = div(authority_balance, 1_000_000_000)
+    _ = Datadog.gauge(name(:authority_balance), gwei)
   end
 end

--- a/apps/omg_child_chain/lib/omg_child_chain/block_queue/measure.ex
+++ b/apps/omg_child_chain/lib/omg_child_chain/block_queue/measure.ex
@@ -46,7 +46,7 @@ defmodule OMG.ChildChain.BlockQueue.Measure do
 
   def handle_event([:gas, GasAnalyzer], %{gas: gas}, _, _config) do
     gwei = div(gas, 1_000_000_000)
-    _ = Datadog.gauge(name(:block_subbmission), gwei)
+    _ = Datadog.gauge(name(:block_submission), gwei)
   end
 
   def handle_event([:authority_balance, Balance], %{authority_balance: authority_balance}, _, _config) do

--- a/apps/omg_child_chain/lib/omg_child_chain/sync_supervisor.ex
+++ b/apps/omg_child_chain/lib/omg_child_chain/sync_supervisor.ex
@@ -21,6 +21,7 @@ defmodule OMG.ChildChain.SyncSupervisor do
   use OMG.Utils.LoggerExt
 
   alias OMG.ChildChain.BlockQueue
+  alias OMG.ChildChain.BlockQueue.Balance
   alias OMG.ChildChain.BlockQueue.GasAnalyzer
   alias OMG.ChildChain.ChildManager
   alias OMG.ChildChain.Configuration
@@ -55,9 +56,11 @@ defmodule OMG.ChildChain.SyncSupervisor do
     deposit_finality_margin = OMG.Configuration.deposit_finality_margin()
     child_block_interval = OMG.Eth.Configuration.child_block_interval()
     contracts = OMG.Eth.Configuration.contracts()
+    authority_address = OMG.Eth.Configuration.authority_addr()
 
     [
       {GasAnalyzer, []},
+      {Balance, [authority_address: authority_address]},
       {BlockQueue,
        [
          contract_deployment_height: contract_deployment_height,

--- a/apps/omg_child_chain/test/omg_child_chain/block_queue/balance_test.exs
+++ b/apps/omg_child_chain/test/omg_child_chain/block_queue/balance_test.exs
@@ -1,0 +1,66 @@
+# Copyright 2019-2020 OmiseGO Pte Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defmodule OMG.ChildChain.BlockQueue.BalanceTest do
+  use ExUnit.Case, async: true
+  import ExUnit.CaptureLog, only: [capture_log: 1]
+  alias OMG.ChildChain.BlockQueue.Balance
+
+  setup do
+    {:ok, balance_process} =
+      Balance.start_link(authority_address: "", name: String.to_atom("test-#{:rand.uniform(1000)}"))
+
+    handler_id = {:authority_balance_handler, :rand.uniform(100)}
+
+    on_exit(fn ->
+      :telemetry.detach(handler_id)
+    end)
+
+    {:ok, %{balance_process: balance_process, handler_id: handler_id}}
+  end
+
+  describe "handle_cast/2" do
+    test "balance gets checked after API call and telemetry handler executed", %{
+      balance_process: balance_process,
+      handler_id: handler_id
+    } do
+      # we're mocking ethereumex with our module
+      :sys.replace_state(balance_process, fn state -> Map.put(state, :rpc, __MODULE__.EthExSuccessMock) end)
+      # creating a telemetry handler in this process so that when event gets executed, a message gets sent
+      # to this process... hence the self() and parent
+      attach(handler_id, [:authority_balance, Balance], self())
+      # mimick a blockqueue wanting to submit a block to ethereum which would cause us to check the balance
+      assert capture_log(fn ->
+               Balance.check(balance_process)
+               assert_receive({:event, [:authority_balance, Balance], %{authority_balance: 291}, %{}}, 100)
+             end)
+    end
+  end
+
+  defp attach(handler_id, event, parent) do
+    :telemetry.attach(
+      handler_id,
+      event,
+      fn event, measurements, metadata, _ ->
+        send(parent, {:event, event, measurements, metadata})
+      end,
+      nil
+    )
+  end
+
+  # this module serves as a success mock of the ethereumex
+  defmodule EthExSuccessMock do
+    def eth_get_balance(_), do: {:ok, "0x123"}
+  end
+end

--- a/apps/omg_child_chain/test/omg_child_chain/ethereum_event_aggregator_test.exs
+++ b/apps/omg_child_chain/test/omg_child_chain/ethereum_event_aggregator_test.exs
@@ -234,6 +234,7 @@ defmodule OMG.ChildChain.EthereumEventAggregatorTest do
 
       from_block = 1
       to_block = 3
+
       # we need to create events that we later expect when we call the aggregator APIs
       # for example, deposit_created and deposit_created_2 are expected if the range is from 1 to 3
 

--- a/apps/omg_status/lib/omg_status/alert/alarm_printer.ex
+++ b/apps/omg_status/lib/omg_status/alert/alarm_printer.ex
@@ -22,7 +22,7 @@ defmodule OMG.Status.AlarmPrinter do
   # 5 minutes
   @max_interval 300_000
   def start_link(args) do
-    GenServer.start_link(__MODULE__, args, name: __MODULE__)
+    GenServer.start_link(__MODULE__, args, name: Keyword.get(args, :name, __MODULE__))
   end
 
   def init(args) do

--- a/apps/omg_status/lib/omg_status/metric/event.ex
+++ b/apps/omg_status/lib/omg_status/metric/event.ex
@@ -49,6 +49,11 @@ defmodule OMG.Status.Metric.Event do
   def name(:block_subbmission), do: "block_subbmission_gas"
 
   @doc """
+  Child Chain authority address balance
+  """
+  def name(:authority_balance), do: "authority_balance"
+
+  @doc """
   OMG.State balance per currency
   """
   def name(:balance), do: "balance"

--- a/apps/omg_status/lib/omg_status/metric/event.ex
+++ b/apps/omg_status/lib/omg_status/metric/event.ex
@@ -46,7 +46,7 @@ defmodule OMG.Status.Metric.Event do
   @doc """
   Child Chain Block queue gas usage metric
   """
-  def name(:block_subbmission), do: "block_subbmission_gas"
+  def name(:block_submission), do: "block_submission_gas"
 
   @doc """
   Child Chain authority address balance

--- a/apps/omg_status/lib/omg_status/release_tasks/set_tracer.ex
+++ b/apps/omg_status/lib/omg_status/release_tasks/set_tracer.ex
@@ -34,6 +34,7 @@ defmodule OMG.Status.ReleaseTasks.SetTracer do
     release = Keyword.get(args, :release)
     tags = ["application:#{release}", "app_env:#{get_app_env()}", "hostname:#{get_hostname()}"]
     :ok = Application.put_env(:statix, :tags, tags, persistent: true)
+
     # spandex_datadog setup
 
     :ok =

--- a/apps/omg_status/test/omg_status/alert/alarm_printer_test.exs
+++ b/apps/omg_status/test/omg_status/alert/alarm_printer_test.exs
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 defmodule OMG.Status.Alert.AlarmPrinterTest do
-  use ExUnit.Case, async: false
+  use ExUnit.Case, async: true
   import ExUnit.CaptureLog, only: [capture_log: 1]
 
   alias OMG.Status.AlarmPrinter
@@ -21,7 +21,8 @@ defmodule OMG.Status.Alert.AlarmPrinterTest do
   @moduletag :common
 
   setup do
-    {:ok, alarm_printer} = AlarmPrinter.start_link(alarm_module: __MODULE__.Alarm)
+    {:ok, alarm_printer} =
+      AlarmPrinter.start_link(alarm_module: __MODULE__.Alarm, name: String.to_atom("test-#{:rand.uniform(1000)}"))
 
     %{alarm_printer: alarm_printer}
   end

--- a/apps/omg_watcher/lib/omg_watcher/block_getter/supervisor.ex
+++ b/apps/omg_watcher/lib/omg_watcher/block_getter/supervisor.ex
@@ -39,6 +39,7 @@ defmodule OMG.Watcher.BlockGetter.Supervisor do
     contracts = OMG.Eth.Configuration.contracts()
 
     fee_claimer_address = Base.decode16!("DEAD000000000000000000000000000000000000")
+
     # State and Block Getter are linked, because they must restore their state to the last stored state
     # If Block Getter fails, it starts from the last checkpoint while State might have had executed some transactions
     # such a situation will cause error when trying to execute already executed transaction

--- a/apps/omg_watcher_info/lib/omg_watcher_info/deposit_consumer.ex
+++ b/apps/omg_watcher_info/lib/omg_watcher_info/deposit_consumer.ex
@@ -17,6 +17,7 @@ defmodule OMG.WatcherInfo.DepositConsumer do
   Subscribes to deposit events and inserts them to WatcherInfo.DB.
   """
   require Logger
+
   ### Client
 
   def start_link(_args) do

--- a/priv/cabbage/apps/itest/lib/contract_event.ex
+++ b/priv/cabbage/apps/itest/lib/contract_event.ex
@@ -20,6 +20,7 @@ defmodule Itest.ContractEvent do
   @subscription_id 1
 
   require Logger
+
   #
   # Client API
   #


### PR DESCRIPTION
This PR removes one of the custom bots from devops

## Overview

On block submission, this process checks the balance of the authority address, logs and send a telemetry event.
## Changes

- add a process with async balance check
- test that simple process

## Testing

mix test