### PR TITLE
fix: require origin for contract event consumer topic

### DIFF
--- a/apps/omg_child_chain/lib/omg_child_chain/datadog_event/contract_event_consumer.ex
+++ b/apps/omg_child_chain/lib/omg_child_chain/datadog_event/contract_event_consumer.ex
@@ -27,17 +27,21 @@ defmodule OMG.ChildChain.DatadogEvent.ContractEventConsumer do
   Mandatory params are in Keyword form:
   - :publisher is Module that implements a function `event/3` (title, message, option). It's purpose is to forward
   events to a collector (for example, Datadog)
-  - :event is a OMG.Bus topic from which this process recieves data and sends them to the publisher and onwards
+  - :topic is a OMG.Bus topic from which this process recieves data and sends them to the publisher and onwards
   - :release is the mode this current process is runing under (for example, currently we support watcher, child chain or watcher info)
   - :current_version is semver of the current code
   """
   # sobelow_skip ["DOS.StringToAtom"]
   @spec prepare_child(keyword()) :: %{id: atom(), start: tuple()}
   def prepare_child(opts) do
-    topic = Keyword.fetch!(opts, :topic)
+    id =
+      case Keyword.fetch!(opts, :topic) do
+        {origin, topic_name} -> "#{origin}:#{topic_name}_worker"
+        other -> "#{other}_worker"
+      end
 
     %{
-      id: String.to_atom("#{topic}_worker"),
+      id: String.to_atom(id),
       start: {__MODULE__, :start_link, [opts]},
       shutdown: :brutal_kill,
       type: :worker

--- a/apps/omg_child_chain/lib/omg_child_chain/datadog_event/contract_event_consumer.ex
+++ b/apps/omg_child_chain/lib/omg_child_chain/datadog_event/contract_event_consumer.ex
@@ -34,14 +34,10 @@ defmodule OMG.ChildChain.DatadogEvent.ContractEventConsumer do
   # sobelow_skip ["DOS.StringToAtom"]
   @spec prepare_child(keyword()) :: %{id: atom(), start: tuple()}
   def prepare_child(opts) do
-    id =
-      case Keyword.fetch!(opts, :topic) do
-        {origin, topic_name} -> "#{origin}:#{topic_name}_worker"
-        other -> "#{other}_worker"
-      end
+    {:root_chain, topic_name} = Keyword.fetch!(opts, :topic)
 
     %{
-      id: String.to_atom(id),
+      id: String.to_atom("root_chain:#{topic_name}_worker"),
       start: {__MODULE__, :start_link, [opts]},
       shutdown: :brutal_kill,
       type: :worker

--- a/apps/omg_child_chain/test/omg_child_chain/datadog_event/contract_event_consumer_test.exs
+++ b/apps/omg_child_chain/test/omg_child_chain/datadog_event/contract_event_consumer_test.exs
@@ -41,7 +41,7 @@ defmodule OMG.ChildChain.DatadogEvent.ContractEventConsumerTest do
     :ok
   end
 
-  test "prepare_child sets a proper name" do
+  test "prepare_child sets a proper id" do
     topic = {:root_chain, "blocks"}
     %{id: id} = ContractEventConsumer.prepare_child(topic: topic)
     assert id == String.to_atom("root_chain:blocks_worker")

--- a/apps/omg_child_chain/test/omg_child_chain/datadog_event/contract_event_consumer_test.exs
+++ b/apps/omg_child_chain/test/omg_child_chain/datadog_event/contract_event_consumer_test.exs
@@ -41,6 +41,12 @@ defmodule OMG.ChildChain.DatadogEvent.ContractEventConsumerTest do
     :ok
   end
 
+  test "prepare_child sets a proper name" do
+    topic = {:root_chain, "blocks"}
+    %{id: id} = ContractEventConsumer.prepare_child(topic: topic)
+    assert id == String.to_atom("root_chain:blocks_worker")
+  end
+
   test "if a event message put on omg bus is consumed by the event consumer and published on the publisher interface" do
     topic = self() |> :erlang.pid_to_list() |> to_string()
     sig = "#{topic}(bytes32)"

--- a/apps/omg_child_chain/test/omg_child_chain/datadog_event/contract_event_consumer_test.exs
+++ b/apps/omg_child_chain/test/omg_child_chain/datadog_event/contract_event_consumer_test.exs
@@ -31,7 +31,7 @@ defmodule OMG.ChildChain.DatadogEvent.ContractEventConsumerTest do
 
     start_supervised(
       ContractEventConsumer.prepare_child(
-        topic: "#{pid}",
+        topic: {:root_chain, "#{pid}"},
         release: "child_chain",
         current_version: "test-123",
         publisher: __MODULE__.DatadogEventMock
@@ -41,28 +41,20 @@ defmodule OMG.ChildChain.DatadogEvent.ContractEventConsumerTest do
     :ok
   end
 
-  test "prepare_child sets a proper id" do
-    topic = {:root_chain, "blocks"}
-    %{id: id} = ContractEventConsumer.prepare_child(topic: topic)
-    assert id == String.to_atom("root_chain:blocks_worker")
-  end
-
   test "if a event message put on omg bus is consumed by the event consumer and published on the publisher interface" do
-    topic = self() |> :erlang.pid_to_list() |> to_string()
-    sig = "#{topic}(bytes32)"
+    topic_name = self() |> :erlang.pid_to_list() |> to_string()
+    sig = "#{topic_name}(bytes32)"
     data = [%{event_signature: sig}]
-    event = %OMG.Bus.Event{topic: topic, event: :data, payload: data}
-    OMG.Bus.direct_local_broadcast(event)
+    {:root_chain, topic_name} |> OMG.Bus.Event.new(:data, data) |> OMG.Bus.direct_local_broadcast()
 
     assert_receive {:event, _, _}
   end
 
   test "if a list of event message are put on omg bus is consumed by the event consumer and published on the publisher interface" do
-    topic = self() |> :erlang.pid_to_list() |> to_string()
-    sig = "#{topic}(bytes32)"
+    topic_name = self() |> :erlang.pid_to_list() |> to_string()
+    sig = "#{topic_name}(bytes32)"
     data = [%{event_signature: sig}, %{event_signature: sig}]
-    event = %OMG.Bus.Event{topic: topic, event: :data, payload: data}
-    OMG.Bus.direct_local_broadcast(event)
+    {:root_chain, topic_name} |> OMG.Bus.Event.new(:data, data) |> OMG.Bus.direct_local_broadcast()
 
     assert_receive {:event, _, _}
   end

--- a/apps/omg_watcher/lib/omg_watcher/datadog_event/contract_event_consumer.ex
+++ b/apps/omg_watcher/lib/omg_watcher/datadog_event/contract_event_consumer.ex
@@ -30,14 +30,10 @@ defmodule OMG.Watcher.DatadogEvent.ContractEventConsumer do
   # sobelow_skip ["DOS.StringToAtom"]
   @spec prepare_child(keyword()) :: %{id: atom(), start: tuple()}
   def prepare_child(opts \\ []) do
-    id =
-      case Keyword.fetch!(opts, :topic) do
-        {origin, topic_name} -> "#{origin}:#{topic_name}_worker"
-        other -> "#{other}_worker"
-      end
+    {:root_chain, topic_name} = Keyword.fetch!(opts, :topic)
 
     %{
-      id: String.to_atom(id),
+      id: String.to_atom("root_chain:#{topic_name}_worker"),
       start: {__MODULE__, :start_link, [opts]},
       shutdown: :brutal_kill,
       type: :worker

--- a/apps/omg_watcher/lib/omg_watcher/datadog_event/contract_event_consumer.ex
+++ b/apps/omg_watcher/lib/omg_watcher/datadog_event/contract_event_consumer.ex
@@ -30,10 +30,14 @@ defmodule OMG.Watcher.DatadogEvent.ContractEventConsumer do
   # sobelow_skip ["DOS.StringToAtom"]
   @spec prepare_child(keyword()) :: %{id: atom(), start: tuple()}
   def prepare_child(opts \\ []) do
-    topic = Keyword.fetch!(opts, :topic)
+    id =
+      case Keyword.fetch!(opts, :topic) do
+        {origin, topic_name} -> "#{origin}:#{topic_name}_worker"
+        other -> "#{other}_worker"
+      end
 
     %{
-      id: String.to_atom("#{topic}_worker"),
+      id: String.to_atom(id),
       start: {__MODULE__, :start_link, [opts]},
       shutdown: :brutal_kill,
       type: :worker

--- a/apps/omg_watcher/test/omg_watcher/datadog_event/contract_event_consumer_test.exs
+++ b/apps/omg_watcher/test/omg_watcher/datadog_event/contract_event_consumer_test.exs
@@ -41,7 +41,7 @@ defmodule OMG.Watcher.DatadogEvent.ContractEventConsumerTest do
     :ok
   end
 
-  test "prepare_child sets a proper name" do
+  test "prepare_child sets a proper id" do
     topic = {:root_chain, "blocks"}
     %{id: id} = ContractEventConsumer.prepare_child(topic: topic)
     assert id == String.to_atom("root_chain:blocks_worker")

--- a/apps/omg_watcher/test/omg_watcher/datadog_event/contract_event_consumer_test.exs
+++ b/apps/omg_watcher/test/omg_watcher/datadog_event/contract_event_consumer_test.exs
@@ -41,6 +41,12 @@ defmodule OMG.Watcher.DatadogEvent.ContractEventConsumerTest do
     :ok
   end
 
+  test "prepare_child sets a proper name" do
+    topic = {:root_chain, "blocks"}
+    %{id: id} = ContractEventConsumer.prepare_child(topic: topic)
+    assert id == String.to_atom("root_chain:blocks_worker")
+  end
+
   test "if an event put on omg bus is consumed by the event consumer and published on the publisher interface" do
     topic = self() |> :erlang.pid_to_list() |> to_string()
     sig = "#{topic}(bytes32)"

--- a/apps/omg_watcher/test/omg_watcher/datadog_event/contract_event_consumer_test.exs
+++ b/apps/omg_watcher/test/omg_watcher/datadog_event/contract_event_consumer_test.exs
@@ -31,7 +31,7 @@ defmodule OMG.Watcher.DatadogEvent.ContractEventConsumerTest do
 
     start_supervised(
       ContractEventConsumer.prepare_child(
-        topic: "#{pid}",
+        topic: {:root_chain, "#{pid}"},
         release: "child_chain",
         current_version: "test-123",
         publisher: __MODULE__.DatadogEventMock
@@ -41,27 +41,19 @@ defmodule OMG.Watcher.DatadogEvent.ContractEventConsumerTest do
     :ok
   end
 
-  test "prepare_child sets a proper id" do
-    topic = {:root_chain, "blocks"}
-    %{id: id} = ContractEventConsumer.prepare_child(topic: topic)
-    assert id == String.to_atom("root_chain:blocks_worker")
-  end
-
   test "if an event put on omg bus is consumed by the event consumer and published on the publisher interface" do
-    topic = self() |> :erlang.pid_to_list() |> to_string()
-    sig = "#{topic}(bytes32)"
+    topic_name = self() |> :erlang.pid_to_list() |> to_string()
+    sig = "#{topic_name}(bytes32)"
     data = [%{event_signature: sig}]
-    event = %OMG.Bus.Event{topic: topic, event: :data, payload: data}
-    OMG.Bus.direct_local_broadcast(event)
+    {:root_chain, topic_name} |> OMG.Bus.Event.new(:data, data) |> OMG.Bus.direct_local_broadcast()
     assert_receive {:event, _, _}
   end
 
   test "if a list of events put on omg bus is consumed by the event consumer and published on the publisher interface" do
-    topic = self() |> :erlang.pid_to_list() |> to_string()
-    sig = "#{topic}(bytes32)"
+    topic_name = self() |> :erlang.pid_to_list() |> to_string()
+    sig = "#{topic_name}(bytes32)"
     data = [%{event_signature: sig}, %{event_signature: sig}]
-    event = %OMG.Bus.Event{topic: topic, event: :data, payload: data}
-    OMG.Bus.direct_local_broadcast(event)
+    {:root_chain, topic_name} |> OMG.Bus.Event.new(:data, data) |> OMG.Bus.direct_local_broadcast()
     assert_receive {:event, _, _}
   end
 


### PR DESCRIPTION
Fixes a bug in setting contract event consumer id and topic.
