### PR TITLE
keep authority_addr naming for phash2 for backwards compatibility

### DIFF
--- a/apps/omg_eth/lib/omg_eth/application.ex
+++ b/apps/omg_eth/lib/omg_eth/application.ex
@@ -52,7 +52,8 @@ defmodule OMG.Eth.Application do
     contracts_hash =
       Configuration.contracts()
       |> Map.put(:txhash_contract, Configuration.txhash_contract())
-      |> Map.put(:authority_addr, Configuration.authority_address()) #authority_addr to keep backwards compatibility
+      # authority_addr to keep backwards compatibility
+      |> Map.put(:authority_addr, Configuration.authority_address())
       |> :erlang.phash2()
 
     case DB.get_single_value(:omg_eth_contracts) do

--- a/apps/omg_eth/lib/omg_eth/application.ex
+++ b/apps/omg_eth/lib/omg_eth/application.ex
@@ -52,7 +52,7 @@ defmodule OMG.Eth.Application do
     contracts_hash =
       Configuration.contracts()
       |> Map.put(:txhash_contract, Configuration.txhash_contract())
-      |> Map.put(:authority_address, Configuration.authority_address())
+      |> Map.put(:authority_addr, Configuration.authority_address()) #authority_addr to keep backwards compatibility
       |> :erlang.phash2()
 
     case DB.get_single_value(:omg_eth_contracts) do

--- a/apps/omg_eth/test/omg_eth/application_test.exs
+++ b/apps/omg_eth/test/omg_eth/application_test.exs
@@ -38,7 +38,8 @@ defmodule OMG.Eth.ApplicationTest do
       contracts_hash =
         Configuration.contracts()
         |> Map.put(:txhash_contract, Configuration.txhash_contract())
-        |> Map.put(:authority_address, Configuration.authority_address())
+        # authority_addr to keep backwards compatibility
+        |> Map.put(:authority_addr, Configuration.authority_address())
         |> :erlang.phash2()
 
       assert DB.get_single_value(:omg_eth_contracts) == {:ok, contracts_hash}
@@ -48,7 +49,8 @@ defmodule OMG.Eth.ApplicationTest do
       contracts_hash =
         Configuration.contracts()
         |> Map.put(:txhash_contract, Configuration.txhash_contract())
-        |> Map.put(:authority_address, Configuration.authority_address())
+        # authority_addr to keep backwards compatibility
+        |> Map.put(:authority_addr, Configuration.authority_address())
         |> :erlang.phash2()
 
       assert DB.get_single_value(:omg_eth_contracts) == {:ok, contracts_hash}


### PR DESCRIPTION
We used to call this `authority_addr` but it was changed in the elixir bump PR. but since hash is being calculated from the whole map, keys need to match as well.

https://github.com/omisego/elixir-omg/commit/e8d71a946061982b3087b7e8637f1fcb1490e78e#diff-e41e0520c4a94ce982c5ce2346cd7d27L55