### PR TITLE
fix: circleci to return the original start-services result after logging the failure

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -418,7 +418,7 @@ jobs:
           name: Start daemon services
           command: |
             cd priv/cabbage
-            make start_daemon_services || docker-compose logs
+            make start_daemon_services || (START_RESULT=$?; docker-compose logs; return $START_RESULT;)
       - run:
           name: Print docker states
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -418,7 +418,7 @@ jobs:
           name: Start daemon services
           command: |
             cd priv/cabbage
-            make start_daemon_services || (START_RESULT=$?; docker-compose logs; return $START_RESULT;)
+            make start_daemon_services || (START_RESULT=$?; docker-compose logs; exit $START_RESULT;)
       - run:
           name: Print docker states
           command: |

--- a/priv/cabbage/Makefile
+++ b/priv/cabbage/Makefile
@@ -12,7 +12,7 @@ start_daemon_services:
 	cd ../../ && \
 	SNAPSHOT=SNAPSHOT_MIX_EXIT_PERIOD_SECONDS_120 make init_test && \
 	cd priv/cabbage/ && \
-	docker-compose -f ../../docker-compose.yml -f docker-compose-cabbage.yml up -d
+	docker-compose -f ../../docker-compose.yml -f docker-compose-cabbage.ym up -d
 
 generate-security_critical_api_specs:
 	priv/openapitools/openapi-generator-cli generate -i ../../apps/omg_watcher_rpc/priv/swagger/security_critical_api_specs.yaml -g elixir -o apps/watcher_security_critical_api

--- a/priv/cabbage/Makefile
+++ b/priv/cabbage/Makefile
@@ -12,7 +12,7 @@ start_daemon_services:
 	cd ../../ && \
 	SNAPSHOT=SNAPSHOT_MIX_EXIT_PERIOD_SECONDS_120 make init_test && \
 	cd priv/cabbage/ && \
-	docker-compose -f ../../docker-compose.yml -f docker-compose-cabbage.ym up -d
+	docker-compose -f ../../docker-compose.yml -f docker-compose-cabbage.yml up -d
 
 generate-security_critical_api_specs:
 	priv/openapitools/openapi-generator-cli generate -i ../../apps/omg_watcher_rpc/priv/swagger/security_critical_api_specs.yaml -g elixir -o apps/watcher_security_critical_api


### PR DESCRIPTION
https://github.com/omisego/elixir-omg/pull/1450#issuecomment-611920723

## Overview

Fix the issue where a logging command is invoked after `make start_daemon_services` failure, which causes the return status to be of the logging command and so CircleCI thinks the step passes.

## Changes

Updated circleci config to capture the start services result and return it after logging.

## Testing

Tested on CircleCI: https://app.circleci.com/pipelines/github/omisego/elixir-omg/6449/workflows/67b5c631-d037-43e8-b863-473c34a08e47/jobs/54984 Error shown as expected:

```
ERROR: .FileNotFoundError: [Errno 2] No such file or directory: './docker-compose-cabbage.ym'
Makefile:12: recipe for target 'start_daemon_services' failed
make: *** [start_daemon_services] Error 1
Attaching to 

Exited with code exit status 2
CircleCI received exit code 2
```