### PR TITLE
fix: API links

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@ This `gh-pages` branch is intended specifically to contain GH Project's page.
 
 
 * Child chain API
-[Master](https://developer.omisego.co/elixir-omg/docs-ui/?urls.primaryName=master%2Foperator_api_specs) | [0.4](https://developer.omisego.co/elixir-omg/docs-ui/?urls.primaryName=0.4%2Foperator_api_specs) | [0.3](https://developer.omisego.co/elixir-omg/docs-ui/?urls.primaryName=0.3%2Foperator_api_specs) | [0.2](https://developer.omisego.co/elixir-omg/docs-ui/?urls.primaryName=0.2%2Foperator_api_specs)
+[Master](https://docs.omg.network/elixir-omg/docs-ui/?urls.primaryName=master%2Foperator_api_specs) | [0.4](https://docs.omg.network/elixir-omg/docs-ui/?urls.primaryName=0.4%2Foperator_api_specs) | [0.3](https://docs.omg.network/elixir-omg/docs-ui/?urls.primaryName=0.3%2Foperator_api_specs) | [0.2](https://docs.omg.network/elixir-omg/docs-ui/?urls.primaryName=0.2%2Foperator_api_specs)
 
 * Watcher's Security-critical API
-[Master](https://developer.omisego.co/elixir-omg/docs-ui/?urls.primaryName=master%2Fsecurity_critical_api_specs) | [0.4](https://developer.omisego.co/elixir-omg/docs-ui/?urls.primaryName=0.4%2Fsecurity_critical_api_specs) | [0.3](https://developer.omisego.co/elixir-omg/docs-ui/?urls.primaryName=0.3%2Fsecurity_critical_api_specs) | [0.2](https://developer.omisego.co/elixir-omg/docs-ui/?urls.primaryName=0.2%2Fsecurity_critical_api_specs)
+[Master](https://docs.omg.network/elixir-omg/docs-ui/?urls.primaryName=master%2Fsecurity_critical_api_specs) | [0.4](https://docs.omg.network/elixir-omg/docs-ui/?urls.primaryName=0.4%2Fsecurity_critical_api_specs) | [0.3](https://docs.omg.network/elixir-omg/docs-ui/?urls.primaryName=0.3%2Fsecurity_critical_api_specs) | [0.2](https://docs.omg.network/elixir-omg/docs-ui/?urls.primaryName=0.2%2Fsecurity_critical_api_specs)
 
 * Watcher's informational API
-[Master](https://developer.omisego.co/elixir-omg/docs-ui/?urls.primaryName=master%2Finfo_api_specs) | [0.4](https://developer.omisego.co/elixir-omg/docs-ui/?urls.primaryName=0.4%2Finfo_api_specs) | [0.3](https://developer.omisego.co/elixir-omg/docs-ui/?urls.primaryName=0.3%2Finfo_api_specs) | [0.2](https://developer.omisego.co/elixir-omg/docs-ui/?urls.primaryName=0.2%2Finfo_api_specs)
+[Master](https://docs.omg.network/elixir-omg/docs-ui/?urls.primaryName=master%2Finfo_api_specs) | [0.4](https://docs.omg.network/elixir-omg/docs-ui/?urls.primaryName=0.4%2Finfo_api_specs) | [0.3](https://docs.omg.network/elixir-omg/docs-ui/?urls.primaryName=0.3%2Finfo_api_specs) | [0.2](https://docs.omg.network/elixir-omg/docs-ui/?urls.primaryName=0.2%2Finfo_api_specs)


### PR DESCRIPTION
## Overview

Recent domain changes require an update of all APIs references. All Swagger docs have moved from `developer.omisego.co` to `docs.omg.network` domain.

## Changes

- Replaced outdated domain with `docs.omg.network` for all API specifications.