### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,10 +119,10 @@ MIX_ENV=test iex -S mix run --no-start
 
 # Working with API Spec's
 
-This repo contains `gh-pages` branch intended to host [Swagger-based](https://developer.omisego.co/elixir-omg/) API specification.
+This repo contains `gh-pages` branch intended to host [Swagger-based](https://docs.omg.network/elixir-omg/) API specification.
 Branch `gh-pages` is totally diseparated from other development branches and contains just Slate generated page's files.
 
-See [gh-pages README](https://github.com/omisego/elixir-omg/blob/gh-pages/docs/api_specs/README.md) for more details.
+See [gh-pages README](https://github.com/omisego/elixir-omg/tree/gh-pages) for more details.
 
 # More details about the design and arhitecture
 


### PR DESCRIPTION
# Overview
Recent domain changes require an update of all APIs references. All Swagger docs have moved from `developer.omisego.co` to `docs.omg.network` domain. For some reason, `gh-pages README` reference also was affected.

## Changes
Fixed the following references:
- [`gh-pages README`](https://github.com/omisego/elixir-omg/blob/gh-pages/README.md) 
- [Swagger API specs](https://docs.omg.network/elixir-omg/) 

