### PR TITLE
feat: add child chain metrics for transaction submissions, successes and failures

### DIFF
--- a/apps/omg_child_chain/lib/child_chain.ex
+++ b/apps/omg_child_chain/lib/child_chain.ex
@@ -29,11 +29,11 @@ defmodule OMG.ChildChain do
   alias OMG.State
   alias OMG.State.Transaction
 
-  @type submit_error() :: Transaction.Recovered.recover_tx_error() | State.exec_error() | :transaction_not_supported
+  @type submit_result() :: {:ok, submit_success()} | {:error, submit_error()}
+  @typep submit_success() :: %{txhash: Transaction.tx_hash(), blknum: pos_integer, txindex: non_neg_integer}
+  @typep submit_error() :: Transaction.Recovered.recover_tx_error() | State.exec_error() | :transaction_not_supported
 
-  @spec submit(transaction :: binary) ::
-          {:ok, %{txhash: Transaction.tx_hash(), blknum: pos_integer, txindex: non_neg_integer}}
-          | {:error, submit_error()}
+  @spec submit(transaction :: binary) :: submit_result()
   def submit(transaction) do
     result =
       with {:ok, recovered_tx} <- Transaction.Recovered.recover_from(transaction),

--- a/apps/omg_child_chain/lib/omg_child_chain/api/alarm.ex
+++ b/apps/omg_child_chain/lib/omg_child_chain/api/alarm.ex
@@ -14,7 +14,7 @@
 
 defmodule OMG.ChildChain.API.Alarm do
   @moduledoc """
-  Watcher alarm API
+  Child Chain API for retrieving alarms.
   """
 
   alias OMG.Status.Alert.Alarm

--- a/apps/omg_child_chain/lib/omg_child_chain/api/configuration.ex
+++ b/apps/omg_child_chain/lib/omg_child_chain/api/configuration.ex
@@ -14,7 +14,7 @@
 
 defmodule OMG.ChildChain.API.Configuration do
   @moduledoc """
-  Watcher API for retrieving configuration
+  Child Chain API for retrieving configurations.
   """
 
   alias OMG.Configuration

--- a/apps/omg_child_chain/lib/omg_child_chain/api/transaction.ex
+++ b/apps/omg_child_chain/lib/omg_child_chain/api/transaction.ex
@@ -20,20 +20,20 @@ defmodule OMG.ChildChain.API.Transaction do
   alias OMG.ChildChain
 
   @spec submit(binary()) :: ChildChain.submit_result()
-  def submit(txbytes, child_chain \\ ChildChain, telemetry \\ :telemetry) do
-    :ok = telemetry.execute([:submit, __MODULE__], %{})
+  def submit(txbytes, child_chain \\ ChildChain) do
+    :ok = :telemetry.execute([:submit, __MODULE__], %{})
 
     result = child_chain.submit(txbytes)
-    _ = send_result_to_telemetry(result, telemetry)
+    _ = send_telemetry(result)
 
     result
   end
 
-  defp send_result_to_telemetry({:ok, _}, telemetry) do
-    :ok = telemetry.execute([:submit_success, __MODULE__], %{})
+  defp send_telemetry({:ok, _}) do
+    :ok = :telemetry.execute([:submit_success, __MODULE__], %{})
   end
 
-  defp send_result_to_telemetry({:error, _}, telemetry) do
-    :ok = telemetry.execute([:submit_failed, __MODULE__], %{})
+  defp send_telemetry({:error, _}) do
+    :ok = :telemetry.execute([:submit_failed, __MODULE__], %{})
   end
 end

--- a/apps/omg_child_chain/lib/omg_child_chain/api/transaction.ex
+++ b/apps/omg_child_chain/lib/omg_child_chain/api/transaction.ex
@@ -1,0 +1,39 @@
+# Copyright 2019-2020 OmiseGO Pte Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defmodule OMG.ChildChain.API.Transaction do
+  @moduledoc """
+  Child Chain API for submitting transactions. This module performs the necessary operations
+  on the transaction submission that are not strictly part of the core submission logic.
+  """
+  alias OMG.ChildChain
+
+  @spec submit(binary()) :: ChildChain.submit_result()
+  def submit(txbytes, child_chain \\ ChildChain, telemetry \\ :telemetry) do
+    :ok = telemetry.execute([:submit, __MODULE__], %{})
+
+    result = child_chain.submit(txbytes)
+    _ = send_result_to_telemetry(result, telemetry)
+
+    result
+  end
+
+  defp send_result_to_telemetry({:ok, _}, telemetry) do
+    :ok = telemetry.execute([:submit_success, __MODULE__], %{})
+  end
+
+  defp send_result_to_telemetry({:error, _}, telemetry) do
+    :ok = telemetry.execute([:submit_failed, __MODULE__], %{})
+  end
+end

--- a/apps/omg_child_chain/lib/omg_child_chain/application.ex
+++ b/apps/omg_child_chain/lib/omg_child_chain/application.ex
@@ -47,7 +47,18 @@ defmodule OMG.ChildChain.Application do
         &OMG.ChildChain.BlockQueue.Measure.handle_event/4,
         nil
       ],
-      ["measure-state", OMG.State.Measure.supported_events(), &OMG.State.Measure.handle_event/4, nil]
+      [
+        "measure-state",
+        OMG.State.Measure.supported_events(),
+        &OMG.State.Measure.handle_event/4,
+        nil
+      ],
+      [
+        "measure-transaction-submission",
+        OMG.ChildChain.Measure.supported_events(),
+        &OMG.ChildChain.Measure.handle_event/4,
+        nil
+      ]
     ]
 
     Enum.each(handlers, fn handler ->

--- a/apps/omg_child_chain/lib/omg_child_chain/measure.ex
+++ b/apps/omg_child_chain/lib/omg_child_chain/measure.ex
@@ -1,0 +1,43 @@
+# Copyright 2019-2020 OmiseGO Pte Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defmodule OMG.ChildChain.Measure do
+  @moduledoc """
+  Collects business metrics and sends to Datadog.
+  """
+  import OMG.Status.Metric.Event, only: [name: 1]
+
+  alias OMG.Status.Metric.Datadog
+  alias OMG.ChildChain.API.Transaction, as: TransactionAPI
+
+  @supported_events [
+    [:submit, TransactionAPI],
+    [:submit_success, TransactionAPI],
+    [:submit_failed, TransactionAPI]
+  ]
+
+  def supported_events(), do: @supported_events
+
+  def handle_event([:submit, TransactionAPI], _measurements, _metadata, _config) do
+    _ = Datadog.increment(name(:transaction_submission), 1)
+  end
+
+  def handle_event([:submit_success, TransactionAPI], _, _metadata, _config) do
+    _ = Datadog.increment(name(:transaction_submission_success), 1)
+  end
+
+  def handle_event([:submit_failed, TransactionAPI], _, _metadata, _config) do
+    _ = Datadog.increment(name(:transaction_submission_failed), 1)
+  end
+end

--- a/apps/omg_child_chain/lib/omg_child_chain/measure.ex
+++ b/apps/omg_child_chain/lib/omg_child_chain/measure.ex
@@ -18,8 +18,8 @@ defmodule OMG.ChildChain.Measure do
   """
   import OMG.Status.Metric.Event, only: [name: 1]
 
-  alias OMG.Status.Metric.Datadog
   alias OMG.ChildChain.API.Transaction, as: TransactionAPI
+  alias OMG.Status.Metric.Datadog
 
   @supported_events [
     [:submit, TransactionAPI],

--- a/apps/omg_child_chain/test/omg_child_chain/api/transaction_test.exs
+++ b/apps/omg_child_chain/test/omg_child_chain/api/transaction_test.exs
@@ -1,0 +1,55 @@
+# Copyright 2019-2020 OmiseGO Pte Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defmodule OMG.ChildChain.API.TransactionTest do
+  use ExUnit.Case, async: true
+  alias OMG.ChildChain.API.Transaction
+
+  @child_chain __MODULE__.MockChildChain
+  @telemetry __MODULE__.MockTelemetry
+
+  describe "submit/1" do
+    test "emits a :submit and :submit_success telemetry event on a successful submission" do
+      {:ok, _} = Transaction.submit(<<1, 1, 1>>, @child_chain, @telemetry)
+
+      assert_receive({:telemetry_emitted, [:submit, Transaction]})
+      assert_receive({:telemetry_emitted, [:submit_success, Transaction]})
+    end
+
+    test "emits a :submit and :submit_failed telemetry event on a failed submission" do
+      {:error, _} = Transaction.submit(<<0, 0, 0>>, @child_chain, @telemetry)
+
+      assert_receive({:telemetry_emitted, [:submit, Transaction]})
+      assert_receive({:telemetry_emitted, [:submit_failed, Transaction]})
+    end
+  end
+
+  defmodule MockChildChain do
+    @doc """
+    Returns a successful or failed response depending on the txbyte received.
+    """
+    def submit(<<1, 1, 1>>), do: {:ok, %{some: "data"}}
+    def submit(<<0, 0, 0>>), do: {:error, :some_error}
+  end
+
+  defmodule MockTelemetry do
+    @doc """
+    Responds to an execute/2 call by sending `{:telemtry_emitted, _}` to the mailbox.
+    """
+    def execute(event, _) do
+      send(self(), {:telemetry_emitted, event})
+      :ok
+    end
+  end
+end

--- a/apps/omg_child_chain/test/omg_child_chain/api/transaction_test.exs
+++ b/apps/omg_child_chain/test/omg_child_chain/api/transaction_test.exs
@@ -14,8 +14,8 @@
 
 defmodule OMG.ChildChain.API.TransactionTest do
   use ExUnit.Case, async: true
-  alias OMG.ChildChain.API.Transaction
   alias __MODULE__.MockChildChain
+  alias OMG.ChildChain.API.Transaction
 
   setup do
     handler_id = {__MODULE__, :rand.uniform(100)}

--- a/apps/omg_child_chain_rpc/lib/omg_child_chain_rpc/web/controllers/transaction.ex
+++ b/apps/omg_child_chain_rpc/lib/omg_child_chain_rpc/web/controllers/transaction.ex
@@ -16,15 +16,15 @@ defmodule OMG.ChildChainRPC.Web.Controller.Transaction do
   @moduledoc """
   Provides endpoint action to submit transaction to the Child Chain.
   """
-
   use OMG.ChildChainRPC.Web, :controller
+  alias OMG.ChildChain.API.Transaction, as: TransactionAPI
+
   # check for health before calling action
   plug(OMG.ChildChainRPC.Web.Plugs.Health)
-  alias OMG.ChildChain
 
   def submit(conn, params) do
     with {:ok, txbytes} <- expect(params, "transaction", :hex),
-         {:ok, details} <- ChildChain.submit(txbytes) do
+         {:ok, details} <- TransactionAPI.submit(txbytes) do
       api_response(details, conn, :submit)
     end
   end

--- a/apps/omg_status/lib/omg_status/metric/event.ex
+++ b/apps/omg_status/lib/omg_status/metric/event.ex
@@ -13,6 +13,10 @@
 # limitations under the License.
 
 defmodule OMG.Status.Metric.Event do
+  @moduledoc """
+  A centralised repository of all emitted event types with description.
+  """
+
   @services [
     :challenges_responds_processor,
     :competitor_processor,
@@ -29,9 +33,21 @@ defmodule OMG.Status.Metric.Event do
     :piggyback_processor,
     :block_queue
   ]
-  @moduledoc """
-    A centralised repository of all emitted event types with description.
+
+  @doc """
+  Child Chain API's received transaction submission.
   """
+  def name(:transaction_submission), do: "transaction_submission"
+
+  @doc """
+  Child Chain API's successful processing of transaction submission.
+  """
+  def name(:transaction_submission_success), do: "transaction_submission_success"
+
+  @doc """
+  Child Chain API's failed processing of transaction submission.
+  """
+  def name(:transaction_submission_failed), do: "transaction_submission_failed"
 
   @doc """
   Childchain OMG.State mempool transactions

--- a/apps/omg_watcher/lib/omg_watcher/api/transaction.ex
+++ b/apps/omg_watcher/lib/omg_watcher/api/transaction.ex
@@ -19,7 +19,6 @@ defmodule OMG.Watcher.API.Transaction do
 
   alias OMG.State.Transaction
   alias OMG.Utxo
-
   alias OMG.Watcher.HttpRPC.Client
 
   require Utxo


### PR DESCRIPTION
## Overview

Add metrics for child chain's transaction submissions received, successfully processed and failed to process.

## Changes

- Add `OMG.ChildChain.API.Transaction` in between `OMG.ChildChainRPC.Web.Controller.Transaction` and `OMG.ChildChain` to emit telemetry events
- Add `OMG.ChildChain.Measure` to start receiving the telemetry events and report it to the metrics collector (Statix/Datadog)

## Testing

```shell
mix test test/omg_child_chain/api/transaction_test.exs
```

Once deployed, each `/transaction.submit` to the child chain should affect the following metrics:
- **Successful submission:**
    - `transaction_submission` metric increases by 1
    - `transaction_submission_success` metric increases by 1
- **Failed submission:**
    - `transaction_submission` metric increases by 1
    - `transaction_submission_failed` metric increases by 1
