### PR TITLE
Move db storage out of docker containers

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -411,6 +411,10 @@ jobs:
       image: ubuntu-1604:201903-01
     steps:
       - checkout
+      - run:
+          name: Setup data dir
+          command: |
+            [ -d data ] || mkdir data && chmod 777 data
       - run: make docker-child_chain
       - run: make docker-watcher
       - run: make docker-watcher_info

--- a/Makefile
+++ b/Makefile
@@ -356,7 +356,7 @@ docker-stop-cluster-with-datadog:
 	docker-compose -f docker-compose.yml -f docker-compose.dev.yml down
 
 docker-nuke:
-	docker-compose down --remove-orphans
+	docker-compose down --remove-orphans --volumes
 	docker system prune --all
 	$(MAKE) clean
 	$(MAKE) init-contracts

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -72,7 +72,7 @@ services:
       - APP_ENV=local_docker_development
       - DD_HOSTNAME=datadog
       - DD_DISABLED=true
-      - DB_PATH=/app/.omg/data
+      - DB_PATH=/data
       - ETHEREUM_EVENTS_CHECK_INTERVAL_MS=800
       - ETHEREUM_STALLED_SYNC_THRESHOLD_MS=20000
       - FEE_CLAIMER_ADDRESS=0x3b9f4c1dd26e0be593373b1d36cee2008cbeb837
@@ -85,6 +85,8 @@ services:
       - "9656:9656"
     expose:
       - "9656"
+    volumes:
+      - ./data:/data
     healthcheck:
       test: curl childchain:9656
       interval: 30s
@@ -109,7 +111,7 @@ services:
       - APP_ENV=local_docker_development
       - DD_HOSTNAME=datadog
       - DD_DISABLED=true
-      - DB_PATH=/app/.omg/data
+      - DB_PATH=/data
       - ETHEREUM_EVENTS_CHECK_INTERVAL_MS=800
       - ETHEREUM_STALLED_SYNC_THRESHOLD_MS=20000
       - ETHEREUM_BLOCK_TIME_SECONDS=1
@@ -123,6 +125,8 @@ services:
       - "7434:7434"
     expose:
       - "7434"
+    volumes:
+      - ./data:/data
     healthcheck:
       test: curl watcher:7434
       interval: 30s
@@ -148,7 +152,7 @@ services:
       - APP_ENV=local_docker_development
       - DD_HOSTNAME=datadog
       - DD_DISABLED=true
-      - DB_PATH=/app/.omg/data
+      - DB_PATH=/data
       - ETHEREUM_EVENTS_CHECK_INTERVAL_MS=800
       - ETHEREUM_BLOCK_TIME_SECONDS=1
       - EXIT_PROCESSOR_SLA_MARGIN=5520
@@ -161,6 +165,8 @@ services:
       - "7534:7534"
     expose:
       - "7534"
+    volumes:
+      - ./data:/data
     healthcheck:
       test: curl watcher_info:7534
       interval: 30s


### PR DESCRIPTION
## Overview

Previously when running docker-compose, the rocksdb data dir was stored inside the `childchain`, `watcher` and `watcher_info` docker containers, which meant that they were lost every time the container was restarted, so the services were out of sync with local geth, which meant that any time you had to start a new chain and redeploy the contracts again on every restart.

Moving the rocksdb data dir out of the container makes it persistent, so that the services can be restarted and they will pick up where they left off. 

## Changes

- In docker-compose.yaml, mount `/data` as a volume and use it as the rocksdb data dir for `childchain`, `watcher` and `watcher_info`. Same pattern as the `geth` container.
