### PR TITLE
fix: MemoryMonitor breaking on OS that does not provide buffered and cached memory data

### DIFF
--- a/apps/omg_status/lib/omg_status/monitor/memory_monitor.ex
+++ b/apps/omg_status/lib/omg_status/monitor/memory_monitor.ex
@@ -133,8 +133,8 @@ defmodule OMG.Status.Monitor.MemoryMonitor do
     %{
       total: Keyword.fetch!(data, :total_memory),
       free: Keyword.fetch!(data, :free_memory),
-      buffered: Keyword.fetch!(data, :buffered_memory),
-      cached: Keyword.fetch!(data, :cached_memory)
+      buffered: Keyword.get(data, :buffered_memory, 0),
+      cached: Keyword.get(data, :cached_memory, 0)
     }
   end
 

--- a/apps/omg_status/test/omg_status/monitor/memory_monitor_test.exs
+++ b/apps/omg_status/test/omg_status/monitor/memory_monitor_test.exs
@@ -58,6 +58,11 @@ defmodule OMG.Status.Monitor.MemoryMonitorTest do
     assert_receive :got_clear_alarm
   end
 
+  test "works with :buffered_memory and :cached_memory values are not provided", context do
+    set_memsup(total_memory: 1000, free_memory: 100)
+    assert_receive :got_raise_alarm
+  end
+
   defp set_memsup(memory_data) do
     :sys.replace_state(__MODULE__.Memsup, fn _ -> memory_data end)
   end


### PR DESCRIPTION
Closes #1484

## Overview

This PR skips buffered and cached memory in memory usage calculation if the running OS does not provide them.

## Changes

- Consider buffered and cached memory as 0 if not provided.

## Testing

```
mix test test/omg_status/monitor/memory_monitor_test.exs
```

Running elixir-omg on MacOS should no longer crash the monitor