### PR TITLE
who monitors the monitor

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -186,7 +186,7 @@ jobs:
             _counter=$(mix credo --only Credo.Check.Readability.SinglePipe | grep -c "Use a function call when a pipeline is only one function long")
             echo "Current Credo.Check.Readability.SinglePipe occurrences:"
             echo $_counter
-            if [ $_counter -gt 367 ]; then
+            if [ $_counter -gt 359 ]; then
               echo "Have you been naughty or nice? Find out if Santa knows."
               exit 1
             fi

--- a/apps/omg/lib/omg/root_chain_coordinator.ex
+++ b/apps/omg/lib/omg/root_chain_coordinator.ex
@@ -105,11 +105,6 @@ defmodule OMG.RootChainCoordinator do
     {:noreply, state}
   end
 
-  def handle_info({:DOWN, _ref, :process, pid, _}, state) do
-    {:ok, state} = Core.check_out(state, pid)
-    {:noreply, state}
-  end
-
   def handle_call({:check_in, synced_height, service_name}, {pid, _ref}, state) do
     _ = Logger.debug("#{inspect(service_name)} checks in on height #{inspect(synced_height)}")
 

--- a/apps/omg/test/omg/root_chain_coordinator/core_test.exs
+++ b/apps/omg/test/omg/root_chain_coordinator/core_test.exs
@@ -58,12 +58,6 @@ defmodule OMG.RootChainCoordinator.CoreTest do
     assert %{sync_height: 10} = Core.get_synced_info(state, depositor_pid)
     assert %{sync_height: 1} = Core.get_synced_info(state, exiter_pid)
 
-    assert {:ok, state} = Core.check_out(state, depositor_pid)
-    assert :nosync = Core.get_synced_info(state, depositor_pid)
-    assert :nosync = Core.get_synced_info(state, exiter_pid)
-    assert :nosync = Core.get_synced_info(state, :depositor)
-    assert :nosync = Core.get_synced_info(state, :exiter)
-
     depositor_pid2 = :c.pid(0, 3, 0)
     assert {:ok, state} = Core.check_in(state, depositor_pid2, 2, :depositor)
     assert %{sync_height: 10} = Core.get_synced_info(state, depositor_pid2)


### PR DESCRIPTION
If you want to receive exit signals from processes you need to monitor them. I don't see any code implying that RootChainCoordinator monitors Ethereum Event Listeners and these two chunks of code would ever get called. So I'm removing them.