### PR TITLE
fix: configure sentry tags as maps

### DIFF
--- a/apps/omg_status/lib/omg_status/release_tasks/set_sentry.ex
+++ b/apps/omg_status/lib/omg_status/release_tasks/set_sentry.ex
@@ -47,14 +47,14 @@ defmodule OMG.Status.ReleaseTasks.SetSentry do
             environment_name: app_env,
             included_environments: [app_env],
             server_name: hostname,
-            tags: [
+            tags: %{
               application: release,
               eth_network: get_env("ETHEREUM_NETWORK"),
               eth_node: get_rpc_client_type(),
               current_version: "vsn-#{current_version}",
               app_env: "#{app_env}",
               hostname: "#{hostname}"
-            ]
+            }
           ]
         )
 

--- a/apps/omg_status/test/omg_status/release_tasks/set_sentry_test.exs
+++ b/apps/omg_status/test/omg_status/release_tasks/set_sentry_test.exs
@@ -50,14 +50,14 @@ defmodule OMG.Status.ReleaseTasks.SetSentryTest do
           environment_name: yolo,
           included_environments: [yolo],
           server_name: server_name,
-          tags: [
+          tags: %{
             application: :watcher,
             eth_network: network,
             eth_node: :geth,
             current_version: "vsn-" <> current_version,
             app_env: yolo,
             hostname: server_name
-          ]
+          }
         ]
       ]
 


### PR DESCRIPTION
Closes #1478

## Overview

Fix sentry throwing an error due to unexpected tags data type.

See https://github.com/getsentry/sentry-elixir#configuration, tags need to be passed as maps.

## Changes

- Convert sentry tags from keywords to maps

## Testing

`mix test test/omg_status/release_tasks/set_sentry_test.exs` should pass and exceptions being sent to Sentry.
