### PR TITLE
Making Child-chain work with fee feed

### DIFF
--- a/apps/omg/test/support/test_helper.ex
+++ b/apps/omg/test/support/test_helper.ex
@@ -183,15 +183,16 @@ defmodule OMG.TestHelper do
   defp parse_fees(fees) do
     fees
     |> Enum.map(fn {"0x" <> _ = token, fee} ->
-      {token, %{
-        amount: fee.amount,
-        subunit_to_unit: fee.subunit_to_unit,
-        pegged_amount: fee.pegged_amount,
-        pegged_currency: fee.pegged_currency,
-        pegged_subunit_to_unit: fee.pegged_subunit_to_unit,
-        symbol: "token",
-        type: "fixed"
-      }}
+      {token,
+       %{
+         amount: fee.amount,
+         subunit_to_unit: fee.subunit_to_unit,
+         pegged_amount: fee.pegged_amount,
+         pegged_currency: fee.pegged_currency,
+         pegged_subunit_to_unit: fee.pegged_subunit_to_unit,
+         symbol: "token",
+         type: "fixed"
+       }}
     end)
     |> Map.new()
   end

--- a/apps/omg/test/support/test_helper.ex
+++ b/apps/omg/test/support/test_helper.ex
@@ -181,17 +181,19 @@ defmodule OMG.TestHelper do
   end
 
   defp parse_fees(fees) do
-    Enum.map(fees, fn {"0x" <> _ = token, fee} ->
-      %{
-        token: token,
+    fees
+    |> Enum.map(fn {"0x" <> _ = token, fee} ->
+      {token, %{
         amount: fee.amount,
         subunit_to_unit: fee.subunit_to_unit,
         pegged_amount: fee.pegged_amount,
         pegged_currency: fee.pegged_currency,
         pegged_subunit_to_unit: fee.pegged_subunit_to_unit,
-        updated_at: fee.updated_at
-      }
+        symbol: "token",
+        type: "fixed"
+      }}
     end)
+    |> Map.new()
   end
 
   defp get_private_keys(inputs),

--- a/apps/omg/test/support/test_helper.ex
+++ b/apps/omg/test/support/test_helper.ex
@@ -172,7 +172,7 @@ defmodule OMG.TestHelper do
   def write_fee_file(content, file_path) do
     path =
       case file_path do
-        nil -> "#{:code.priv_dir(:omg_child_chain)}/test_fees_file-#{DateTime.to_unix(DateTime.utc_now())}"
+        nil -> "#{:code.priv_dir(:omg_child_chain)}/test_fees_file-#{System.monotonic_time()}"
         _ -> file_path
       end
 

--- a/apps/omg/test/support/test_helper.ex
+++ b/apps/omg/test/support/test_helper.ex
@@ -190,6 +190,7 @@ defmodule OMG.TestHelper do
          pegged_amount: fee.pegged_amount,
          pegged_currency: fee.pegged_currency,
          pegged_subunit_to_unit: fee.pegged_subunit_to_unit,
+         updated_at: fee.updated_at,
          symbol: "token",
          type: "fixed"
        }}

--- a/apps/omg_child_chain/lib/omg_child_chain/fees/json_fee_parser.ex
+++ b/apps/omg_child_chain/lib/omg_child_chain/fees/json_fee_parser.ex
@@ -39,7 +39,7 @@ defmodule OMG.ChildChain.Fees.JSONFeeParser do
     with {:ok, json} <- Jason.decode(file_content), do: parse(json)
   end
 
-  def parse(json) when is_map(json) or is_list(json) do
+  def parse(json) when is_map(json) do
     {errors, fee_specs} = Enum.reduce(json, {[], %{}}, &reduce_json/2)
 
     errors

--- a/apps/omg_child_chain/lib/omg_child_chain/fees/json_single_spec_parser.ex
+++ b/apps/omg_child_chain/lib/omg_child_chain/fees/json_single_spec_parser.ex
@@ -51,6 +51,7 @@ defmodule OMG.ChildChain.Fees.JSONSingleSpecParser do
            "pegged_amount" => pegged_amount,
            "pegged_currency" => pegged_currency,
            "pegged_subunit_to_unit" => pegged_subunit_to_unit,
+           "updated_at" => updated_at,
            "type" => fee_type
          }}
       ) do
@@ -63,6 +64,7 @@ defmodule OMG.ChildChain.Fees.JSONSingleSpecParser do
          {:ok, pegged_subunit_to_unit} <-
            validate_optional_positive_amount(pegged_subunit_to_unit, :invalid_pegged_subunit_to_unit),
          :ok <- validate_pegged_fields(pegged_currency, pegged_amount, pegged_subunit_to_unit),
+         {:ok, updated_at} <- validate_updated_at(updated_at),
          {:ok, fee_type} <- validate_fee_type(fee_type) do
       {:ok,
        %{
@@ -73,7 +75,7 @@ defmodule OMG.ChildChain.Fees.JSONSingleSpecParser do
          pegged_currency: pegged_currency,
          pegged_subunit_to_unit: pegged_subunit_to_unit,
          type: fee_type,
-         updated_at: nil
+         updated_at: updated_at
        }}
     end
   end
@@ -99,6 +101,13 @@ defmodule OMG.ChildChain.Fees.JSONSingleSpecParser do
   end
 
   defp validate_pegged_fields(_, _, _), do: {:error, :invalid_pegged_fields}
+
+  defp validate_updated_at(updated_at) do
+    case DateTime.from_iso8601(updated_at) do
+      {:ok, %DateTime{} = date_time, _} -> {:ok, date_time}
+      _ -> {:error, :invalid_timestamp}
+    end
+  end
 
   defp decode_address("0x" <> data), do: decode_address(data)
 

--- a/apps/omg_child_chain/lib/omg_child_chain/fees/json_single_spec_parser.ex
+++ b/apps/omg_child_chain/lib/omg_child_chain/fees/json_single_spec_parser.ex
@@ -36,20 +36,24 @@ defmodule OMG.ChildChain.Fees.JSONSingleSpecParser do
           | :bad_address_encoding
           # pegged fields must either be all nil or all not nil
           | :invalid_pegged_fields
+          # at the moment only "fixed" fee type is supported
+          | :unsupported_fee_type
 
   @doc """
   Parses and validates a single fee spec
   """
-  @spec parse(map()) :: {:ok, map()} | {:error, parsing_error()}
-  def parse(%{
-        "amount" => fee,
-        "token" => token,
-        "subunit_to_unit" => subunit_to_unit,
-        "pegged_amount" => pegged_amount,
-        "pegged_currency" => pegged_currency,
-        "pegged_subunit_to_unit" => pegged_subunit_to_unit,
-        "updated_at" => updated_at
-      }) do
+  @spec parse({binary(), map()}) :: {:ok, map()} | {:error, parsing_error()}
+  def parse(
+        {token,
+         %{
+           "amount" => fee,
+           "subunit_to_unit" => subunit_to_unit,
+           "pegged_amount" => pegged_amount,
+           "pegged_currency" => pegged_currency,
+           "pegged_subunit_to_unit" => pegged_subunit_to_unit,
+           "type" => fee_type
+         }}
+      ) do
     # defensive code against user input
     with {:ok, fee} <- validate_positive_amount(fee, :invalid_fee),
          {:ok, addr} <- decode_address(token),
@@ -59,7 +63,7 @@ defmodule OMG.ChildChain.Fees.JSONSingleSpecParser do
          {:ok, pegged_subunit_to_unit} <-
            validate_optional_positive_amount(pegged_subunit_to_unit, :invalid_pegged_subunit_to_unit),
          :ok <- validate_pegged_fields(pegged_currency, pegged_amount, pegged_subunit_to_unit),
-         {:ok, updated_at} <- validate_updated_at(updated_at) do
+         {:ok, fee_type} <- validate_fee_type(fee_type) do
       {:ok,
        %{
          token: addr,
@@ -68,7 +72,8 @@ defmodule OMG.ChildChain.Fees.JSONSingleSpecParser do
          pegged_amount: pegged_amount,
          pegged_currency: pegged_currency,
          pegged_subunit_to_unit: pegged_subunit_to_unit,
-         updated_at: updated_at
+         type: fee_type,
+         updated_at: nil
        }}
     end
   end
@@ -113,4 +118,7 @@ defmodule OMG.ChildChain.Fees.JSONSingleSpecParser do
         {:error, :bad_address_encoding}
     end
   end
+
+  defp validate_fee_type("fixed"), do: {:ok, :fixed}
+  defp validate_fee_type(_), do: {:error, :unsupported_fee_type}
 end

--- a/apps/omg_child_chain/lib/omg_child_chain/fees/json_single_spec_parser.ex
+++ b/apps/omg_child_chain/lib/omg_child_chain/fees/json_single_spec_parser.ex
@@ -100,13 +100,6 @@ defmodule OMG.ChildChain.Fees.JSONSingleSpecParser do
 
   defp validate_pegged_fields(_, _, _), do: {:error, :invalid_pegged_fields}
 
-  defp validate_updated_at(updated_at) do
-    case DateTime.from_iso8601(updated_at) do
-      {:ok, %DateTime{} = date_time, _} -> {:ok, date_time}
-      _ -> {:error, :invalid_timestamp}
-    end
-  end
-
   defp decode_address("0x" <> data), do: decode_address(data)
 
   defp decode_address(data) do

--- a/apps/omg_child_chain/test/omg_child_chain/fees/feed_adapter_test.exs
+++ b/apps/omg_child_chain/test/omg_child_chain/fees/feed_adapter_test.exs
@@ -35,13 +35,13 @@ defmodule OMG.ChildChain.Fees.FeedAdapterTest do
 
   @initial_price 100
   @fee %{
-    token: @eth_hex,
     amount: @initial_price,
     pegged_amount: 1,
     subunit_to_unit: 1_000_000_000_000_000_000,
     pegged_currency: "USD",
     pegged_subunit_to_unit: 100,
-    updated_at: DateTime.from_unix!(1_546_336_800)
+    symbol: "ETH",
+    type: :fixed
   }
 
   describe "get_fee_specs/2" do
@@ -101,7 +101,7 @@ defmodule OMG.ChildChain.Fees.FeedAdapterTest do
     end
   end
 
-  defp make_fee_specs(amount), do: %{@payment_tx_type => [Map.put(@fee, :amount, amount)]}
+  defp make_fee_specs(amount), do: %{@payment_tx_type => %{@eth_hex => Map.put(@fee, :amount, amount)}}
 
   defp parse_specs(map), do: map |> Jason.encode!() |> JSONFeeParser.parse()
 

--- a/apps/omg_child_chain/test/omg_child_chain/fees/feed_adapter_test.exs
+++ b/apps/omg_child_chain/test/omg_child_chain/fees/feed_adapter_test.exs
@@ -40,6 +40,7 @@ defmodule OMG.ChildChain.Fees.FeedAdapterTest do
     subunit_to_unit: 1_000_000_000_000_000_000,
     pegged_currency: "USD",
     pegged_subunit_to_unit: 100,
+    updated_at: DateTime.from_unix!(1_546_336_800),
     symbol: "ETH",
     type: :fixed
   }

--- a/apps/omg_child_chain/test/omg_child_chain/fees/file_adapter_test.exs
+++ b/apps/omg_child_chain/test/omg_child_chain/fees/file_adapter_test.exs
@@ -35,7 +35,7 @@ defmodule OMG.ChildChain.FileAdapterTest do
         subunit_to_unit: 1_000_000_000_000_000_000,
         pegged_currency: "USD",
         pegged_subunit_to_unit: 100,
-        updated_at: nil,
+        updated_at: DateTime.from_unix!(1_546_336_800),
         type: :fixed
       }
     }

--- a/apps/omg_child_chain/test/omg_child_chain/fees/file_adapter_test.exs
+++ b/apps/omg_child_chain/test/omg_child_chain/fees/file_adapter_test.exs
@@ -35,7 +35,8 @@ defmodule OMG.ChildChain.FileAdapterTest do
         subunit_to_unit: 1_000_000_000_000_000_000,
         pegged_currency: "USD",
         pegged_subunit_to_unit: 100,
-        updated_at: DateTime.from_unix!(1_546_336_800)
+        updated_at: nil,
+        type: :fixed
       }
     }
   }

--- a/apps/omg_child_chain/test/omg_child_chain/fees/json_fee_parser_test.exs
+++ b/apps/omg_child_chain/test/omg_child_chain/fees/json_fee_parser_test.exs
@@ -34,7 +34,8 @@ defmodule OMG.ChildChain.Fees.JSONFeeParserTest do
                 "subunit_to_unit": 1000000000000000000,
                 "pegged_amount": null,
                 "pegged_currency": null,
-                "pegged_subunit_to_unit": null
+                "pegged_subunit_to_unit": null,
+                "updated_at": "2019-01-01T10:10:00+00:00"
               },
               "0x11B7592274B344A6be0Ace7E5D5dF4348473e2fa": {
                 "type": "fixed",
@@ -43,7 +44,8 @@ defmodule OMG.ChildChain.Fees.JSONFeeParserTest do
                 "subunit_to_unit": 1000000000000000000,
                 "pegged_amount": null,
                 "pegged_currency": null,
-                "pegged_subunit_to_unit": null
+                "pegged_subunit_to_unit": null,
+                "updated_at": "2019-01-01T10:10:00+00:00"
               },
               "0x942f123b3587EDe66193aa52CF2bF9264C564F87": {
                 "type": "fixed",
@@ -52,7 +54,8 @@ defmodule OMG.ChildChain.Fees.JSONFeeParserTest do
                 "subunit_to_unit": 1000000000000000000,
                 "pegged_amount": null,
                 "pegged_currency": null,
-                "pegged_subunit_to_unit": null
+                "pegged_subunit_to_unit": null,
+                "updated_at": "2019-01-01T10:10:00+00:00"
               }
             },
             "2": {
@@ -63,7 +66,8 @@ defmodule OMG.ChildChain.Fees.JSONFeeParserTest do
                 "subunit_to_unit": 1000000000000000000,
                 "pegged_amount": null,
                 "pegged_currency": null,
-                "pegged_subunit_to_unit": null
+                "pegged_subunit_to_unit": null,
+                "updated_at": "2019-01-01T10:10:00+00:00"
               }
             }
           }
@@ -71,6 +75,7 @@ defmodule OMG.ChildChain.Fees.JSONFeeParserTest do
 
       assert {:ok, tx_type_map} = JSONFeeParser.parse(json)
       assert tx_type_map[1][@eth][:amount] == 43_000_000_000_000
+      assert tx_type_map[1][@eth][:updated_at] == "2019-01-01T10:10:00+00:00" |> DateTime.from_iso8601() |> elem(1)
 
       assert tx_type_map[1][Base.decode16!("942f123b3587EDe66193aa52CF2bF9264C564F87", case: :mixed)][:amount] ==
                8_600_000_000_000_000

--- a/apps/omg_child_chain/test/omg_child_chain/fees/json_fee_parser_test.exs
+++ b/apps/omg_child_chain/test/omg_child_chain/fees/json_fee_parser_test.exs
@@ -25,59 +25,60 @@ defmodule OMG.ChildChain.Fees.JSONFeeParserTest do
   describe "parse/1" do
     test "successfuly parses valid data" do
       json = ~s(
-        {
-          "1": [
-            {
-              "token": "0x0000000000000000000000000000000000000000",
-              "amount": 2,
-              "subunit_to_unit": 1000000000000000000,
-              "pegged_amount": 1,
-              "pegged_currency": "USD",
-              "pegged_subunit_to_unit": 100,
-              "updated_at": "2019-01-01T10:10:00+00:00"
-            },
-            {
-              "token": "0xd26114cd6ee289accf82350c8d8487fedb8a0c07",
-              "amount": 1,
-              "subunit_to_unit": 1000000000000000000,
-              "pegged_amount": 1,
-              "pegged_currency": "USD",
-              "pegged_subunit_to_unit": 100,
-              "updated_at": "2019-01-01T10:10:00+00:00"
-            },
-            {
-              "token": "0xa74476443119a942de498590fe1f2454d7d4ac0d",
-              "amount": 4,
-              "subunit_to_unit": 1000000000000000000,
-              "pegged_amount": 1,
-              "pegged_currency": "USD",
-              "pegged_subunit_to_unit": 100,
-              "updated_at": "2019-01-01T10:10:00+00:00"
-            }
-          ],
-        "2": [
           {
-            "token": "0x0000000000000000000000000000000000000000",
-            "amount": 4,
-            "subunit_to_unit": 1000000000000000000,
-            "pegged_amount": 1,
-            "pegged_currency": "USD",
-            "pegged_subunit_to_unit": 100,
-            "updated_at": "2019-01-01T10:10:00+00:00"
+            "1": {
+              "0x0000000000000000000000000000000000000000": {
+                "type": "fixed",
+                "symbol": "ETH",
+                "amount": 43000000000000,
+                "subunit_to_unit": 1000000000000000000,
+                "pegged_amount": null,
+                "pegged_currency": null,
+                "pegged_subunit_to_unit": null
+              },
+              "0x11B7592274B344A6be0Ace7E5D5dF4348473e2fa": {
+                "type": "fixed",
+                "symbol": "FEE",
+                "amount": 1000000000000000000,
+                "subunit_to_unit": 1000000000000000000,
+                "pegged_amount": null,
+                "pegged_currency": null,
+                "pegged_subunit_to_unit": null
+              },
+              "0x942f123b3587EDe66193aa52CF2bF9264C564F87": {
+                "type": "fixed",
+                "symbol": "OMG",
+                "amount": 8600000000000000,
+                "subunit_to_unit": 1000000000000000000,
+                "pegged_amount": null,
+                "pegged_currency": null,
+                "pegged_subunit_to_unit": null
+              }
+            },
+            "2": {
+              "0x0000000000000000000000000000000000000000": {
+                "type": "fixed",
+                "symbol": "ETH",
+                "amount": 41000000000000,
+                "subunit_to_unit": 1000000000000000000,
+                "pegged_amount": null,
+                "pegged_currency": null,
+                "pegged_subunit_to_unit": null
+              }
+            }
           }
-        ]
-        }
       )
 
       assert {:ok, tx_type_map} = JSONFeeParser.parse(json)
-      assert tx_type_map[1][@eth][:amount] == 2
-      assert tx_type_map[1][Base.decode16!("d26114cd6ee289accf82350c8d8487fedb8a0c07", case: :mixed)][:amount] == 1
-      assert tx_type_map[1][Base.decode16!("a74476443119a942de498590fe1f2454d7d4ac0d", case: :mixed)][:amount] == 4
-      assert tx_type_map[2][@eth][:amount] == 4
-    end
+      assert tx_type_map[1][@eth][:amount] == 43_000_000_000_000
 
-    test "successfuly parses an empty fee spec list" do
-      assert {:ok, %{}} = JSONFeeParser.parse("[]")
+      assert tx_type_map[1][Base.decode16!("942f123b3587EDe66193aa52CF2bF9264C564F87", case: :mixed)][:amount] ==
+               8_600_000_000_000_000
+
+      assert tx_type_map[1][Base.decode16!("11B7592274B344A6be0Ace7E5D5dF4348473e2fa", case: :mixed)][:amount] ==
+               1_000_000_000_000_000_000
+
+      assert tx_type_map[2][@eth][:amount] == 41_000_000_000_000
     end
 
     test "successfuly parses an empty fee spec map" do
@@ -86,9 +87,10 @@ defmodule OMG.ChildChain.Fees.JSONFeeParserTest do
 
     test "returns an `invalid_tx_type` error when given a non integer tx type" do
       json = ~s({
-        "non_integer_key": [
-          {
-            "token": "0x0000000000000000000000000000000000000000",
+        "non_integer_key": {
+          "0x0000000000000000000000000000000000000000": {
+            "type": "fixed",
+            "symbol": "ETH",
             "amount": 4,
             "subunit_to_unit": 1000000000000000000,
             "pegged_amount": 1,
@@ -97,35 +99,36 @@ defmodule OMG.ChildChain.Fees.JSONFeeParserTest do
             "updated_at": "2019-01-01T10:10:00+00:00",
             "error_reason": "Non integer key results with :invalid_tx_type error"
           }
-        ]
+        }
       })
 
       assert {:error, [{:error, :invalid_tx_type, "non_integer_key", 0}]} == JSONFeeParser.parse(json)
     end
 
     test "returns an `invalid_json_format` error when json is not in the correct format" do
-      # json is a list
-      json = ~s([{
-        "1": [
-          {
-            "token": "0x0000000000000000000000000000000000000000",
-            "amount": 1,
+      json = ~s({
+        "1": {
+          "0x0000000000000000000000000000000000000000": {
+            "type": "fixed",
+            "symbol": "ETH",
             "subunit_to_unit": 1000000000000000000,
             "pegged_amount": 1,
             "pegged_currency": "USD",
             "pegged_subunit_to_unit": 100,
-            "updated_at": "2019-01-01T10:10:00+00:00"
+            "updated_at": "2019-01-01T10:10:00+00:00",
+            "error_reason": "Missing `amount` key in fee specs"
           }
-        ]
-      }])
-      assert {:error, [{:error, :invalid_json_format, nil, nil}]} = JSONFeeParser.parse(json)
+        }
+      })
+      assert {:error, [{:error, :invalid_fee_spec, _, _}]} = JSONFeeParser.parse(json)
     end
 
-    test "returns a `duplicate_token` error when tokens are duplicated for the same tx type" do
+    test "`duplicate_token` is not detected by the parser, first occurance takes precedence" do
       json = ~s({
-        "1": [
-          {
-            "token": "0x0000000000000000000000000000000000000000",
+        "1": {
+          "0x0000000000000000000000000000000000000000": {
+            "type": "fixed",
+            "symbol": "ETH",
             "amount": 1,
             "subunit_to_unit": 1000000000000000000,
             "pegged_amount": 1,
@@ -133,8 +136,9 @@ defmodule OMG.ChildChain.Fees.JSONFeeParserTest do
             "pegged_subunit_to_unit": 100,
             "updated_at": "2019-01-01T10:10:00+00:00"
           },
-          {
-            "token": "0x0000000000000000000000000000000000000000",
+          "0x0000000000000000000000000000000000000000": {
+            "type": "fixed",
+            "symbol": "ETH",
             "amount": 2,
             "subunit_to_unit": 1000000000000000000,
             "pegged_amount": 1,
@@ -142,9 +146,9 @@ defmodule OMG.ChildChain.Fees.JSONFeeParserTest do
             "pegged_subunit_to_unit": 100,
             "updated_at": "2019-01-01T10:10:00+00:00"
           }
-        ]
+        }
       })
-      assert {:error, [{:error, :duplicate_token, 1, 2}]} = JSONFeeParser.parse(json)
+      assert {:ok, %{1 => %{@eth => %{amount: 1}}}} = JSONFeeParser.parse(json)
     end
   end
 end

--- a/apps/omg_child_chain/test/omg_child_chain/fees/json_single_spec_parser_test.exs
+++ b/apps/omg_child_chain/test/omg_child_chain/fees/json_single_spec_parser_test.exs
@@ -26,6 +26,7 @@ defmodule OMG.ChildChain.Fees.JSONSingleSpecParserTest do
     "pegged_amount" => 1,
     "pegged_currency" => "USD",
     "pegged_subunit_to_unit" => 100,
+    "updated_at" => "2019-01-01T10:10:00+00:00",
     "symbol" => "ETH",
     "type" => "fixed"
   }
@@ -40,8 +41,8 @@ defmodule OMG.ChildChain.Fees.JSONSingleSpecParserTest do
                 pegged_amount: 1,
                 pegged_currency: "USD",
                 pegged_subunit_to_unit: 100,
-                type: :fixed,
-                updated_at: nil
+                updated_at: "2019-01-01T10:10:00+00:00" |> DateTime.from_iso8601() |> elem(1),
+                type: :fixed
               }} == JSONSingleSpecParser.parse({@eth_hex, @valid_spec})
     end
 
@@ -60,8 +61,8 @@ defmodule OMG.ChildChain.Fees.JSONSingleSpecParserTest do
                 pegged_amount: nil,
                 pegged_currency: nil,
                 pegged_subunit_to_unit: nil,
-                type: :fixed,
-                updated_at: nil
+                updated_at: "2019-01-01T10:10:00+00:00" |> DateTime.from_iso8601() |> elem(1),
+                type: :fixed
               }} == JSONSingleSpecParser.parse({@eth_hex, spec})
     end
 
@@ -151,10 +152,10 @@ defmodule OMG.ChildChain.Fees.JSONSingleSpecParserTest do
       assert {:error, :invalid_subunit_to_unit} == JSONSingleSpecParser.parse({@eth_hex, spec})
     end
 
-    # test "returns an `invalid_timestamp` error when given an invalid binary datetime" do
-    #   spec = Map.put(@valid_spec, "updated_at", "invalid_date")
+    test "returns an `invalid_timestamp` error when given an invalid binary datetime" do
+      spec = Map.put(@valid_spec, "updated_at", "invalid_date")
 
-    #   assert {:error, :invalid_timestamp} == JSONSingleSpecParser.parse({ @eth_hex,spec })
-    # end
+      assert {:error, :invalid_timestamp} == JSONSingleSpecParser.parse({@eth_hex, spec})
+    end
   end
 end

--- a/apps/omg_child_chain/test/omg_child_chain/fees/json_single_spec_parser_test.exs
+++ b/apps/omg_child_chain/test/omg_child_chain/fees/json_single_spec_parser_test.exs
@@ -19,15 +19,15 @@ defmodule OMG.ChildChain.Fees.JSONSingleSpecParserTest do
   alias OMG.Eth
 
   @eth Eth.zero_address()
-
+  @eth_hex "0x" <> Base.encode16(@eth)
   @valid_spec %{
-    "token" => "0x" <> Base.encode16(@eth),
     "amount" => 1,
     "subunit_to_unit" => 1_000_000_000_000_000_000,
     "pegged_amount" => 1,
     "pegged_currency" => "USD",
     "pegged_subunit_to_unit" => 100,
-    "updated_at" => "2019-01-01T10:10:00+00:00"
+    "symbol" => "ETH",
+    "type" => "fixed"
   }
 
   describe "parse/1" do
@@ -40,8 +40,9 @@ defmodule OMG.ChildChain.Fees.JSONSingleSpecParserTest do
                 pegged_amount: 1,
                 pegged_currency: "USD",
                 pegged_subunit_to_unit: 100,
-                updated_at: "2019-01-01T10:10:00+00:00" |> DateTime.from_iso8601() |> elem(1)
-              }} == JSONSingleSpecParser.parse(@valid_spec)
+                type: :fixed,
+                updated_at: nil
+              }} == JSONSingleSpecParser.parse({@eth_hex, @valid_spec})
     end
 
     test "accepts a nil value for all pegged fields" do
@@ -59,104 +60,101 @@ defmodule OMG.ChildChain.Fees.JSONSingleSpecParserTest do
                 pegged_amount: nil,
                 pegged_currency: nil,
                 pegged_subunit_to_unit: nil,
-                updated_at: "2019-01-01T10:10:00+00:00" |> DateTime.from_iso8601() |> elem(1)
-              }} == JSONSingleSpecParser.parse(spec)
+                type: :fixed,
+                updated_at: nil
+              }} == JSONSingleSpecParser.parse({@eth_hex, spec})
     end
 
     test "returns an `invalid_pegged_fields` error when given a nil pegged_amount alone" do
       spec = Map.put(@valid_spec, "pegged_amount", nil)
 
-      assert {:error, :invalid_pegged_fields} == JSONSingleSpecParser.parse(spec)
+      assert {:error, :invalid_pegged_fields} == JSONSingleSpecParser.parse({@eth_hex, spec})
     end
 
     test "returns an `invalid_pegged_fields` error when given a nil pegged_currency alone" do
       spec = Map.put(@valid_spec, "pegged_currency", nil)
 
-      assert {:error, :invalid_pegged_fields} == JSONSingleSpecParser.parse(spec)
+      assert {:error, :invalid_pegged_fields} == JSONSingleSpecParser.parse({@eth_hex, spec})
     end
 
     test "returns an `invalid_pegged_fields` error when given a nil pegged_subunit_to_unit alone" do
       spec = Map.put(@valid_spec, "pegged_subunit_to_unit", nil)
 
-      assert {:error, :invalid_pegged_fields} == JSONSingleSpecParser.parse(spec)
+      assert {:error, :invalid_pegged_fields} == JSONSingleSpecParser.parse({@eth_hex, spec})
     end
 
     test "returns an `invalid_fee_spec` error when given an invalid map" do
       spec = %{"invalid_key" => "something"}
 
-      assert {:error, :invalid_fee_spec} == JSONSingleSpecParser.parse(spec)
+      assert {:error, :invalid_fee_spec} == JSONSingleSpecParser.parse({@eth_hex, spec})
     end
 
     test "returns an `invalid_fee` error when given a negative fee" do
       spec = Map.put(@valid_spec, "amount", -1)
 
-      assert {:error, :invalid_fee} == JSONSingleSpecParser.parse(spec)
+      assert {:error, :invalid_fee} == JSONSingleSpecParser.parse({@eth_hex, spec})
     end
 
     test "returns an `invalid_fee` error when given a zero fee" do
       spec = Map.put(@valid_spec, "amount", 0)
 
-      assert {:error, :invalid_fee} == JSONSingleSpecParser.parse(spec)
+      assert {:error, :invalid_fee} == JSONSingleSpecParser.parse({@eth_hex, spec})
     end
 
     test "returns a `bad_address_encoding` error when given an invalid token" do
-      spec = Map.put(@valid_spec, "token", "Not a token")
-
-      assert {:error, :bad_address_encoding} == JSONSingleSpecParser.parse(spec)
+      assert {:error, :bad_address_encoding} == JSONSingleSpecParser.parse({"Not a token", @valid_spec})
     end
 
     test "returns a `bad_address_encoding` error when given a token with a length != 20 bytes" do
-      spec = Map.put(@valid_spec, "token", "0x0123456789abCdeF")
-
-      assert {:error, :bad_address_encoding} == JSONSingleSpecParser.parse(spec)
+      assert {:error, :bad_address_encoding} == JSONSingleSpecParser.parse({"0x0123456789abCdeF", @valid_spec})
     end
 
     test "returns an `invalid_pegged_amount` error when given a negative pegged_amount" do
       spec = Map.put(@valid_spec, "pegged_amount", -1)
 
-      assert {:error, :invalid_pegged_amount} == JSONSingleSpecParser.parse(spec)
+      assert {:error, :invalid_pegged_amount} == JSONSingleSpecParser.parse({@eth_hex, spec})
     end
 
     test "returns an `invalid_pegged_amount` error when given zero pegged_amount" do
       spec = Map.put(@valid_spec, "pegged_amount", 0)
 
-      assert {:error, :invalid_pegged_amount} == JSONSingleSpecParser.parse(spec)
+      assert {:error, :invalid_pegged_amount} == JSONSingleSpecParser.parse({@eth_hex, spec})
     end
 
     test "returns an `invalid_pegged_currency` error when given a non binary pegged_currency" do
       spec = Map.put(@valid_spec, "pegged_currency", 12)
 
-      assert {:error, :invalid_pegged_currency} == JSONSingleSpecParser.parse(spec)
+      assert {:error, :invalid_pegged_currency} == JSONSingleSpecParser.parse({@eth_hex, spec})
     end
 
     test "returns an `invalid_pegged_subunit_to_unit` error when given a negative pegged_subunit_to_unit" do
       spec = Map.put(@valid_spec, "pegged_subunit_to_unit", -1)
 
-      assert {:error, :invalid_pegged_subunit_to_unit} == JSONSingleSpecParser.parse(spec)
+      assert {:error, :invalid_pegged_subunit_to_unit} == JSONSingleSpecParser.parse({@eth_hex, spec})
     end
 
     test "returns an `invalid_pegged_subunit_to_unit` error when given a zero pegged_subunit_to_unit" do
       spec = Map.put(@valid_spec, "pegged_subunit_to_unit", 0)
 
-      assert {:error, :invalid_pegged_subunit_to_unit} == JSONSingleSpecParser.parse(spec)
+      assert {:error, :invalid_pegged_subunit_to_unit} == JSONSingleSpecParser.parse({@eth_hex, spec})
     end
 
     test "returns an `invalid_subunit_to_unit` error when given a negative subunit_to_unit" do
       spec = Map.put(@valid_spec, "subunit_to_unit", -1)
 
-      assert {:error, :invalid_subunit_to_unit} == JSONSingleSpecParser.parse(spec)
+      assert {:error, :invalid_subunit_to_unit} == JSONSingleSpecParser.parse({@eth_hex, spec})
     end
 
     test "returns an `invalid_subunit_to_unit` error when given a zero subunit_to_unit" do
       spec = Map.put(@valid_spec, "subunit_to_unit", 0)
 
-      assert {:error, :invalid_subunit_to_unit} == JSONSingleSpecParser.parse(spec)
+      assert {:error, :invalid_subunit_to_unit} == JSONSingleSpecParser.parse({@eth_hex, spec})
     end
 
-    test "returns an `invalid_timestamp` error when given an invalid binary datetime" do
-      spec = Map.put(@valid_spec, "updated_at", "invalid_date")
+    # test "returns an `invalid_timestamp` error when given an invalid binary datetime" do
+    #   spec = Map.put(@valid_spec, "updated_at", "invalid_date")
 
-      assert {:error, :invalid_timestamp} == JSONSingleSpecParser.parse(spec)
-    end
+    #   assert {:error, :invalid_timestamp} == JSONSingleSpecParser.parse({ @eth_hex,spec })
+    # end
   end
 end

--- a/apps/omg_child_chain/test/omg_child_chain/integration/fee_server_test.exs
+++ b/apps/omg_child_chain/test/omg_child_chain/integration/fee_server_test.exs
@@ -39,14 +39,16 @@ defmodule OMG.ChildChain.Integration.FeeServerTest do
         pegged_amount: 1,
         subunit_to_unit: 1_000_000_000_000_000_000,
         pegged_currency: "USD",
-        pegged_subunit_to_unit: 100
+        pegged_subunit_to_unit: 100,
+        updated_at: DateTime.from_unix!(1_546_336_800)
       },
       @not_eth_hex => %{
         amount: 2,
         pegged_amount: 1,
         subunit_to_unit: 1_000_000_000_000_000_000,
         pegged_currency: "USD",
-        pegged_subunit_to_unit: 100
+        pegged_subunit_to_unit: 100,
+        updated_at: DateTime.from_unix!(1_546_336_800)
       }
     },
     2 => %{
@@ -55,7 +57,8 @@ defmodule OMG.ChildChain.Integration.FeeServerTest do
         pegged_amount: 1,
         subunit_to_unit: 1_000_000_000_000_000_000,
         pegged_currency: "USD",
-        pegged_subunit_to_unit: 100
+        pegged_subunit_to_unit: 100,
+        updated_at: DateTime.from_unix!(1_546_336_800)
       }
     }
   }
@@ -68,8 +71,8 @@ defmodule OMG.ChildChain.Integration.FeeServerTest do
         subunit_to_unit: 1_000_000_000_000_000_000,
         pegged_currency: "USD",
         pegged_subunit_to_unit: 100,
-        type: :fixed,
-        updated_at: nil
+        updated_at: DateTime.from_unix!(1_546_336_800),
+        type: :fixed
       },
       @not_eth => %{
         amount: 2,
@@ -77,8 +80,8 @@ defmodule OMG.ChildChain.Integration.FeeServerTest do
         subunit_to_unit: 1_000_000_000_000_000_000,
         pegged_currency: "USD",
         pegged_subunit_to_unit: 100,
-        type: :fixed,
-        updated_at: nil
+        updated_at: DateTime.from_unix!(1_546_336_800),
+        type: :fixed
       }
     },
     2 => %{
@@ -88,8 +91,8 @@ defmodule OMG.ChildChain.Integration.FeeServerTest do
         subunit_to_unit: 1_000_000_000_000_000_000,
         pegged_currency: "USD",
         pegged_subunit_to_unit: 100,
-        type: :fixed,
-        updated_at: nil
+        updated_at: DateTime.from_unix!(1_546_336_800),
+        type: :fixed
       }
     }
   }
@@ -124,8 +127,8 @@ defmodule OMG.ChildChain.Integration.FeeServerTest do
         pegged_amount: 2,
         pegged_currency: "SOMETHING",
         pegged_subunit_to_unit: 1000,
-        type: :fixed,
-        updated_at: nil
+        updated_at: DateTime.from_unix!(1_546_336_800),
+        type: :fixed
       }
 
       assert {:ok, @parsed_fees} == FeeServer.current_fees()
@@ -170,7 +173,9 @@ defmodule OMG.ChildChain.Integration.FeeServerTest do
         subunit_to_unit: 100,
         pegged_amount: 2,
         pegged_currency: "SOMETHING",
-        pegged_subunit_to_unit: 1000
+        pegged_subunit_to_unit: 1000,
+        updated_at: DateTime.from_unix!(1_546_336_800),
+        type: :fixed
       }
 
       {:started, _log, exit_fn} = start_fee_server(file_path)
@@ -194,7 +199,8 @@ defmodule OMG.ChildChain.Integration.FeeServerTest do
         pegged_amount: 2,
         pegged_currency: "SOMETHING",
         pegged_subunit_to_unit: 1000,
-        updated_at: DateTime.from_unix!(1_546_423_200)
+        updated_at: DateTime.from_unix!(1_546_423_200),
+        type: :fixed
       }
 
       {:started, _log, exit_fn} = start_fee_server(file_path)
@@ -224,7 +230,7 @@ defmodule OMG.ChildChain.Integration.FeeServerTest do
         pegged_currency: nil,
         pegged_subunit_to_unit: nil,
         type: :fixed,
-        updated_at: nil
+        updated_at: DateTime.from_unix!(1_546_423_200)
       }
 
       new_fee_2 = %{
@@ -234,7 +240,7 @@ defmodule OMG.ChildChain.Integration.FeeServerTest do
         pegged_currency: nil,
         pegged_subunit_to_unit: nil,
         type: :fixed,
-        updated_at: nil
+        updated_at: DateTime.from_unix!(1_546_423_200)
       }
 
       {:started, _log, exit_fn} = start_fee_server(file_path)

--- a/apps/omg_child_chain/test/omg_child_chain/integration/fee_server_test.exs
+++ b/apps/omg_child_chain/test/omg_child_chain/integration/fee_server_test.exs
@@ -39,16 +39,14 @@ defmodule OMG.ChildChain.Integration.FeeServerTest do
         pegged_amount: 1,
         subunit_to_unit: 1_000_000_000_000_000_000,
         pegged_currency: "USD",
-        pegged_subunit_to_unit: 100,
-        updated_at: DateTime.from_unix!(1_546_336_800)
+        pegged_subunit_to_unit: 100
       },
       @not_eth_hex => %{
         amount: 2,
         pegged_amount: 1,
         subunit_to_unit: 1_000_000_000_000_000_000,
         pegged_currency: "USD",
-        pegged_subunit_to_unit: 100,
-        updated_at: DateTime.from_unix!(1_546_336_800)
+        pegged_subunit_to_unit: 100
       }
     },
     2 => %{
@@ -57,8 +55,7 @@ defmodule OMG.ChildChain.Integration.FeeServerTest do
         pegged_amount: 1,
         subunit_to_unit: 1_000_000_000_000_000_000,
         pegged_currency: "USD",
-        pegged_subunit_to_unit: 100,
-        updated_at: DateTime.from_unix!(1_546_336_800)
+        pegged_subunit_to_unit: 100
       }
     }
   }
@@ -71,7 +68,8 @@ defmodule OMG.ChildChain.Integration.FeeServerTest do
         subunit_to_unit: 1_000_000_000_000_000_000,
         pegged_currency: "USD",
         pegged_subunit_to_unit: 100,
-        updated_at: DateTime.from_unix!(1_546_336_800)
+        type: :fixed,
+        updated_at: nil
       },
       @not_eth => %{
         amount: 2,
@@ -79,7 +77,8 @@ defmodule OMG.ChildChain.Integration.FeeServerTest do
         subunit_to_unit: 1_000_000_000_000_000_000,
         pegged_currency: "USD",
         pegged_subunit_to_unit: 100,
-        updated_at: DateTime.from_unix!(1_546_336_800)
+        type: :fixed,
+        updated_at: nil
       }
     },
     2 => %{
@@ -89,7 +88,8 @@ defmodule OMG.ChildChain.Integration.FeeServerTest do
         subunit_to_unit: 1_000_000_000_000_000_000,
         pegged_currency: "USD",
         pegged_subunit_to_unit: 100,
-        updated_at: DateTime.from_unix!(1_546_336_800)
+        type: :fixed,
+        updated_at: nil
       }
     }
   }
@@ -124,7 +124,8 @@ defmodule OMG.ChildChain.Integration.FeeServerTest do
         pegged_amount: 2,
         pegged_currency: "SOMETHING",
         pegged_subunit_to_unit: 1000,
-        updated_at: DateTime.from_unix!(1_546_423_200)
+        type: :fixed,
+        updated_at: nil
       }
 
       assert {:ok, @parsed_fees} == FeeServer.current_fees()
@@ -169,8 +170,7 @@ defmodule OMG.ChildChain.Integration.FeeServerTest do
         subunit_to_unit: 100,
         pegged_amount: 2,
         pegged_currency: "SOMETHING",
-        pegged_subunit_to_unit: 1000,
-        updated_at: DateTime.from_unix!(1_546_423_200)
+        pegged_subunit_to_unit: 1000
       }
 
       {:started, _log, exit_fn} = start_fee_server(file_path)
@@ -223,7 +223,8 @@ defmodule OMG.ChildChain.Integration.FeeServerTest do
         pegged_amount: nil,
         pegged_currency: nil,
         pegged_subunit_to_unit: nil,
-        updated_at: DateTime.from_unix!(1_546_423_200)
+        type: :fixed,
+        updated_at: nil
       }
 
       new_fee_2 = %{
@@ -232,7 +233,8 @@ defmodule OMG.ChildChain.Integration.FeeServerTest do
         pegged_amount: nil,
         pegged_currency: nil,
         pegged_subunit_to_unit: nil,
-        updated_at: DateTime.from_unix!(1_546_423_200)
+        type: :fixed,
+        updated_at: nil
       }
 
       {:started, _log, exit_fn} = start_fee_server(file_path)

--- a/apps/omg_child_chain/test/omg_child_chain/integration/fixtures.exs
+++ b/apps/omg_child_chain/test/omg_child_chain/integration/fixtures.exs
@@ -30,18 +30,19 @@ defmodule OMG.ChildChain.Integration.Fixtures do
 
   deffixture fee_file(token) do
     # ensuring that the child chain handles the token (esp. fee-wise)
-    enc_eth = Encoding.to_hex(OMG.Eth.zero_address())
+    eth_hex = Encoding.to_hex(OMG.Eth.zero_address())
 
     {:ok, file_path} =
       TestHelper.write_fee_file(%{
         @payment_tx_type => %{
-          enc_eth => %{
+          eth_hex => %{
             amount: 1,
             pegged_amount: 1,
             subunit_to_unit: 1_000_000_000_000_000_000,
             pegged_currency: "USD",
             pegged_subunit_to_unit: 100,
-            updated_at: DateTime.utc_now()
+            symbol: "ETH",
+            type: :fixed
           },
           token => %{
             amount: 2,
@@ -49,7 +50,8 @@ defmodule OMG.ChildChain.Integration.Fixtures do
             subunit_to_unit: 1_000_000_000_000_000_000,
             pegged_currency: "USD",
             pegged_subunit_to_unit: 100,
-            updated_at: DateTime.utc_now()
+            symbol: "OMG",
+            type: :fixed
           }
         }
       })

--- a/apps/omg_child_chain/test/omg_child_chain/integration/fixtures.exs
+++ b/apps/omg_child_chain/test/omg_child_chain/integration/fixtures.exs
@@ -41,6 +41,7 @@ defmodule OMG.ChildChain.Integration.Fixtures do
             subunit_to_unit: 1_000_000_000_000_000_000,
             pegged_currency: "USD",
             pegged_subunit_to_unit: 100,
+            updated_at: DateTime.utc_now(),
             symbol: "ETH",
             type: :fixed
           },
@@ -50,6 +51,7 @@ defmodule OMG.ChildChain.Integration.Fixtures do
             subunit_to_unit: 1_000_000_000_000_000_000,
             pegged_currency: "USD",
             pegged_subunit_to_unit: 100,
+            updated_at: DateTime.utc_now(),
             symbol: "OMG",
             type: :fixed
           }

--- a/apps/omg_child_chain/test/omg_child_chain/support/fee_specs.json
+++ b/apps/omg_child_chain/test/omg_child_chain/support/fee_specs.json
@@ -1,11 +1,13 @@
 {
-    "1": [{
-        "token": "0x0000000000000000000000000000000000000000",
-        "amount": 1,
-        "subunit_to_unit": 1000000000000000000,
-        "pegged_amount": null,
-        "pegged_currency": null,
-        "pegged_subunit_to_unit": null,
-        "updated_at": "2019-01-01T10:10:00+00:00"
-    }]
+    "1": {
+        "0x0000000000000000000000000000000000000000": {
+            "amount": 1,
+            "subunit_to_unit": 1000000000000000000,
+            "pegged_amount": null,
+            "pegged_currency": null,
+            "pegged_subunit_to_unit": null,
+            "symbol": "ETH",
+            "type": "fixed"
+        }
+    }
 }

--- a/apps/omg_child_chain/test/omg_child_chain/support/fee_specs.json
+++ b/apps/omg_child_chain/test/omg_child_chain/support/fee_specs.json
@@ -6,6 +6,7 @@
             "pegged_amount": null,
             "pegged_currency": null,
             "pegged_subunit_to_unit": null,
+            "updated_at": "2019-01-01T10:10:00+00:00",
             "symbol": "ETH",
             "type": "fixed"
         }

--- a/bin/variables_test_barebone
+++ b/bin/variables_test_barebone
@@ -19,13 +19,10 @@ export ETHEREUM_HEIGHT_CHECK_INTERVAL_MS=800
 export ETHEREUM_EVENTS_CHECK_INTERVAL_MS=800
 export ETHEREUM_STALLED_SYNC_THRESHOLD_MS=20000
 export FEE_CLAIMER_ADDRESS=0x3b9f4c1dd26e0be593373b1d36cee2008cbeb837
-
-export FEE_ADAPTER=feed
-export FEE_BUFFER_DURATION_MS=60000
-export FEE_FEED_URL=http://127.0.0.1:4000/api/v1
-export FEE_CHANGE_TOLERANCE_PERCENT=12
-export STORED_FEE_UPDATE_INTERVAL_MINUTES=5
-
+export FEE_ADAPTER=file
+# Fee specs file path needs to be an absolute path as the childchain will start deep in the _build subdirectory
+export FEE_SPECS_FILE_PATH=$(pwd)/priv/dev-artifacts/fee_specs.dev.json
+export DD_HOSTNAME=localhost
 export DD_DISABLED=true
 export LOGGER_BACKEND=console
 export RELEASE_COOKIE=development

--- a/bin/variables_test_barebone
+++ b/bin/variables_test_barebone
@@ -19,10 +19,13 @@ export ETHEREUM_HEIGHT_CHECK_INTERVAL_MS=800
 export ETHEREUM_EVENTS_CHECK_INTERVAL_MS=800
 export ETHEREUM_STALLED_SYNC_THRESHOLD_MS=20000
 export FEE_CLAIMER_ADDRESS=0x3b9f4c1dd26e0be593373b1d36cee2008cbeb837
-export FEE_ADAPTER=file
-# Fee specs file path needs to be an absolute path as the childchain will start deep in the _build subdirectory
-export FEE_SPECS_FILE_PATH=$(pwd)/priv/dev-artifacts/fee_specs.dev.json
-export DD_HOSTNAME=localhost
+
+export FEE_ADAPTER=feed
+export FEE_BUFFER_DURATION_MS=60000
+export FEE_FEED_URL=http://127.0.0.1:4000/api/v1
+export FEE_CHANGE_TOLERANCE_PERCENT=12
+export STORED_FEE_UPDATE_INTERVAL_MINUTES=5
+
 export DD_DISABLED=true
 export LOGGER_BACKEND=console
 export RELEASE_COOKIE=development

--- a/priv/dev-artifacts/fee_specs.dev.json
+++ b/priv/dev-artifacts/fee_specs.dev.json
@@ -6,6 +6,7 @@
             "pegged_currency": null,
             "pegged_subunit_to_unit": null,
             "subunit_to_unit": 1000000000000000000,
+            "updated_at": "2019-01-01T10:10:00+00:00",
             "symbol": "ETH",
             "type": "fixed"
         }

--- a/priv/dev-artifacts/fee_specs.dev.json
+++ b/priv/dev-artifacts/fee_specs.dev.json
@@ -1,11 +1,13 @@
 {
-    "1": [{
-        "token": "0x0000000000000000000000000000000000000000",
-        "amount": 1,
-        "subunit_to_unit": 1000000000000000000,
-        "pegged_amount": null,
-        "pegged_currency": null,
-        "pegged_subunit_to_unit": null,
-        "updated_at": "2019-01-01T10:10:00+00:00"
-    }]
+    "1": {
+        "0x0000000000000000000000000000000000000000": {
+            "amount": 1,
+            "pegged_amount": null,
+            "pegged_currency": null,
+            "pegged_subunit_to_unit": null,
+            "subunit_to_unit": 1000000000000000000,
+            "symbol": "ETH",
+            "type": "fixed"
+        }
+    }
 }


### PR DESCRIPTION
I was preparing demo to show Child-chain & Fee Service integration. I discovered that ch-ch can parse slightly different fee rules format that FeeService publishes.

I made just the needed changes to make ch-ch understand rules from feed.
I made tests green.

Also fee rules from FeeService does not fully complies to what was [agreed before](https://github.com/omisego/feat-fee/issues/18), :writing_hand: ~~so I've created an [issue](https://github.com/omisego/feefeed/issues/20)~~ Fee feed response has been adapted in [this PR](https://github.com/omisego/feefeed/pull/21)

:clipboard: Add associated issues, tickets, docs URL here.
- [fee rules format](https://github.com/omisego/feat-fee/issues/18)
- [Fee service's issue](https://github.com/omisego/feefeed/issues/20)

## Overview

I just made the needed changes to make ch-ch understand feed format, and made the tests green.

## Changes

`JSONFeeParser` & `JSONSingleSpecParser` adapted to FeeService returned json structure.

## Testing

Fixing the current tests
