### PR TITLE
fix: lint_version compatibility with bash

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -199,7 +199,8 @@ jobs:
       - run:
           command: |
             if [ -n "$CIRCLE_TAG" ]; then
-              _tagged_version_ignoring_pre="${${CIRCLE_TAG#*v}%%-pre.*}"
+              _tagged_version="${CIRCLE_TAG#*v}"
+              _tagged_version_ignoring_pre="${_tagged_version%%-pre.*}"
               _filed_version="$(head -n 1 ./VERSION | sed 's/^[ \t]*//;s/[ \t]*$//')"
 
               if [ "$_tagged_version_ignoring_pre" != "$_filed_version" ]; then


### PR DESCRIPTION
Blocks #1499

## Overview

Bash doesn't support nested parameter expansion [[1]](https://stackoverflow.com/questions/917260/can-var-parameter-expansion-expressions-be-nested-in-bash) [[2]](https://stackoverflow.com/questions/6724056/can-parameter-expansion-be-nested-in-bash) [[3]](https://unix.stackexchange.com/questions/186942/multiple-variable-expansion-modifiers-in-the-same-expression), which currently breaks #1499. This PR breaks them into multiline.

This error was originally raised in v0.4 branch so targeting this PR to v0.4. It'll be merged into master as part of #1499.

## Changes

Updated lint_version circleci job to break down the version step by step.

## Testing

CircleCI tagged builds should pass.
