### PR TITLE
feat: update max_gas_price to 85_000_000

### DIFF
--- a/apps/omg_child_chain/lib/omg_child_chain/block_queue/gas_price_adjustment.ex
+++ b/apps/omg_child_chain/lib/omg_child_chain/block_queue/gas_price_adjustment.ex
@@ -20,7 +20,7 @@ defmodule OMG.ChildChain.BlockQueue.GasPriceAdjustment do
   defstruct eth_gap_without_child_blocks: 2,
             gas_price_lowering_factor: 0.9,
             gas_price_raising_factor: 2.0,
-            max_gas_price: 20_000_000_000,
+            max_gas_price: 85_000_000_000,
             last_block_mined: nil
 
   @type t() :: %__MODULE__{


### PR DESCRIPTION
Relates to #1523

## Overview

Increase the hardcoded max gas price to 85 gwei. Ideally should make it configurable but this should work for the time being.

## Changes

- Increase max_gas_price to 85_000_000

## Testing

Block submission should be successful in timely manner.