### PR TITLE
feat: add event type when consumer is spending utxos

### DIFF
--- a/apps/omg_watcher_info/lib/omg_watcher_info/db/eth_event.ex
+++ b/apps/omg_watcher_info/lib/omg_watcher_info/db/eth_event.ex
@@ -112,7 +112,7 @@ defmodule OMG.WatcherInfo.DB.EthEvent do
   Uses a list of encoded `Utxo.Position`s to insert the exits (if not already inserted before)
   """
   @spec insert_exits!([non_neg_integer()], available_event_type_t()) :: :ok
-  def insert_exits!(exits, event_type \\ :standard_exit) do
+  def insert_exits!(exits, event_type) do
     exits
     |> Stream.map(&utxo_exit_from_exit_event/1)
     |> Enum.each(&insert_exit!(&1, event_type))

--- a/apps/omg_watcher_info/lib/omg_watcher_info/db/txoutput.ex
+++ b/apps/omg_watcher_info/lib/omg_watcher_info/db/txoutput.ex
@@ -112,13 +112,20 @@ defmodule OMG.WatcherInfo.DB.TxOutput do
         txoutput in __MODULE__,
         left_join: ethevent in assoc(txoutput, :ethevents),
         # select txoutputs by owner that have neither been spent nor have a corresponding ethevents exit events
-        where: txoutput.owner == ^owner and is_nil(txoutput.spending_txhash) and (is_nil(ethevent) or fragment("
+        where:
+          txoutput.owner == ^owner and is_nil(txoutput.spending_txhash) and
+            (is_nil(ethevent) or
+               fragment(
+                 "
  NOT EXISTS (SELECT 1
              FROM ethevents_txoutputs AS etfrag
              JOIN ethevents AS efrag ON
                       etfrag.root_chain_txhash_event=efrag.root_chain_txhash_event
-                      AND efrag.event_type IN (?)
-                      AND etfrag.child_chain_utxohash = ?)", "standard_exit", txoutput.child_chain_utxohash)),
+                      AND efrag.event_type = ANY(?)
+                      AND etfrag.child_chain_utxohash = ?)",
+                 ["standard_exit", "in_flight_exit"],
+                 txoutput.child_chain_utxohash
+               )),
         group_by: txoutput.currency,
         select: {txoutput.currency, sum(txoutput.amount)}
       )

--- a/apps/omg_watcher_info/lib/omg_watcher_info/db/txoutput.ex
+++ b/apps/omg_watcher_info/lib/omg_watcher_info/db/txoutput.ex
@@ -213,13 +213,20 @@ defmodule OMG.WatcherInfo.DB.TxOutput do
       preload: [:ethevents],
       left_join: ethevent in assoc(txoutput, :ethevents),
       # select txoutputs by owner that have neither been spent nor have a corresponding ethevents exit events
-      where: txoutput.owner == ^address and is_nil(txoutput.spending_txhash) and (is_nil(ethevent) or fragment("
+      where:
+        txoutput.owner == ^address and is_nil(txoutput.spending_txhash) and
+          (is_nil(ethevent) or
+             fragment(
+               "
 NOT EXISTS (SELECT 1
            FROM ethevents_txoutputs AS etfrag
            JOIN ethevents AS efrag ON
                     etfrag.root_chain_txhash_event=efrag.root_chain_txhash_event
-                    AND efrag.event_type IN (?)
-                    AND etfrag.child_chain_utxohash = ?)", "standard_exit", txoutput.child_chain_utxohash)),
+                    AND efrag.event_type = ANY(?)
+                    AND etfrag.child_chain_utxohash = ?)",
+               ["standard_exit", "in_flight_exit"],
+               txoutput.child_chain_utxohash
+             )),
       order_by: [asc: :blknum, asc: :txindex, asc: :oindex]
     )
   end

--- a/apps/omg_watcher_info/lib/omg_watcher_info/exit_consumer.ex
+++ b/apps/omg_watcher_info/lib/omg_watcher_info/exit_consumer.ex
@@ -31,13 +31,13 @@ defmodule OMG.WatcherInfo.ExitConsumer do
 
   def init(args) do
     topic = Keyword.fetch!(args, :topic)
-    event_type = Keyword.fetch!(args, :event_type)
     bus_module = Keyword.get(args, :bus_module, @default_bus_module)
+    state = %{event_type: Keyword.fetch!(args, :event_type)}
 
     :ok = bus_module.subscribe(topic, link: true)
 
     _ = Logger.info("Started #{inspect(__MODULE__)}, listen to #{inspect(topic)}")
-    {:ok, %{event_type: event_type}}
+    {:ok, state}
   end
 
   def handle_info({:internal_event_bus, :data, data}, state) do

--- a/apps/omg_watcher_info/lib/omg_watcher_info/exit_consumer.ex
+++ b/apps/omg_watcher_info/lib/omg_watcher_info/exit_consumer.ex
@@ -31,16 +31,17 @@ defmodule OMG.WatcherInfo.ExitConsumer do
 
   def init(args) do
     topic = Keyword.fetch!(args, :topic)
+    event_type = Keyword.fetch!(args, :event_type)
     bus_module = Keyword.get(args, :bus_module, @default_bus_module)
 
     :ok = bus_module.subscribe(topic, link: true)
 
     _ = Logger.info("Started #{inspect(__MODULE__)}, listen to #{inspect(topic)}")
-    {:ok, %{}}
+    {:ok, %{event_type: event_type}}
   end
 
   def handle_info({:internal_event_bus, :data, data}, state) do
-    _ = EthEvent.insert_exits!(data)
+    _ = EthEvent.insert_exits!(data, state.event_type)
     {:noreply, state}
   end
 end

--- a/apps/omg_watcher_info/lib/omg_watcher_info/exit_consumer.ex
+++ b/apps/omg_watcher_info/lib/omg_watcher_info/exit_consumer.ex
@@ -30,17 +30,25 @@ defmodule OMG.WatcherInfo.ExitConsumer do
   use GenServer
 
   def init(args) do
-    topic = Keyword.fetch!(args, :topic)
     bus_module = Keyword.get(args, :bus_module, @default_bus_module)
-    state = %{event_type: Keyword.fetch!(args, :event_type)}
 
-    :ok = bus_module.subscribe(topic, link: true)
+    state = %{
+      topic: Keyword.fetch!(args, :topic),
+      event_type: Keyword.fetch!(args, :event_type)
+    }
 
-    _ = Logger.info("Started #{inspect(__MODULE__)}, listen to #{inspect(topic)}")
+    :ok = bus_module.subscribe(state.topic, link: true)
+
+    _ = Logger.info("Started #{inspect(__MODULE__)}, listen to #{inspect(state.topic)}")
     {:ok, state}
   end
 
   def handle_info({:internal_event_bus, :data, data}, state) do
+    _ =
+      Logger.debug(
+        "Received event from #{inspect(state.topic)} typeof #{inspect(state.event_type)} Data:\n#{inspect(data)}"
+      )
+
     _ = EthEvent.insert_exits!(data, state.event_type)
     {:noreply, state}
   end

--- a/apps/omg_watcher_info/lib/omg_watcher_info/supervisor.ex
+++ b/apps/omg_watcher_info/lib/omg_watcher_info/supervisor.ex
@@ -64,19 +64,19 @@ defmodule OMG.WatcherInfo.Supervisor do
       {OMG.WatcherInfo.BlockApplicationConsumer, []},
       {OMG.WatcherInfo.DepositConsumer, []},
       Supervisor.child_spec(
-        {OMG.WatcherInfo.ExitConsumer, [topic: {:root_chain, "ExitStarted"}]},
+        {OMG.WatcherInfo.ExitConsumer, [topic: {:root_chain, "ExitStarted"}, event_type: :standard_exit]},
         id: :std_exit_consumer
       ),
       Supervisor.child_spec(
-        {OMG.WatcherInfo.ExitConsumer, [topic: {:watcher, "InFlightExitStarted"}]},
+        {OMG.WatcherInfo.ExitConsumer, [topic: {:watcher, "InFlightExitStarted"}, event_type: :in_flight_exit]},
         id: :ife_exit_consumer
       ),
       Supervisor.child_spec(
-        {OMG.WatcherInfo.ExitConsumer, [topic: {:watcher, "InFlightTxOutputPiggybacked"}]},
+        {OMG.WatcherInfo.ExitConsumer, [topic: {:watcher, "InFlightTxOutputPiggybacked"}, event_type: :in_flight_exit]},
         id: :ife_exit_output_piggybacked_consumer
       ),
       Supervisor.child_spec(
-        {OMG.WatcherInfo.ExitConsumer, [topic: {:watcher, "InFlightExitOutputWithdrawn"}]},
+        {OMG.WatcherInfo.ExitConsumer, [topic: {:watcher, "InFlightExitOutputWithdrawn"}, event_type: :in_flight_exit]},
         id: :ife_exit_processed_consumer
       )
     ]

--- a/apps/omg_watcher_info/test/omg_watcher_info/db/eth_event_test.exs
+++ b/apps/omg_watcher_info/test/omg_watcher_info/db/eth_event_test.exs
@@ -255,14 +255,17 @@ defmodule OMG.WatcherInfo.DB.EthEventTest do
     assert length(utxos) == 1
 
     assert :ok =
-             DB.EthEvent.insert_exits!([
-               %{
-                 call_data: %{utxo_pos: expected_utxo_encoded_position},
-                 root_chain_txhash: expected_exit_root_chain_txhash,
-                 log_index: expected_log_index,
-                 eth_height: expected_exit_eth_height
-               }
-             ])
+             DB.EthEvent.insert_exits!(
+               [
+                 %{
+                   call_data: %{utxo_pos: expected_utxo_encoded_position},
+                   root_chain_txhash: expected_exit_root_chain_txhash,
+                   log_index: expected_log_index,
+                   eth_height: expected_exit_eth_height
+                 }
+               ],
+               :standard_exit
+             )
 
     %{data: utxos_after_exit} = DB.TxOutput.get_utxos(address: expected_owner)
     assert Enum.empty?(utxos_after_exit)
@@ -299,7 +302,7 @@ defmodule OMG.WatcherInfo.DB.EthEventTest do
       }
     ]
 
-    assert :ok = DB.EthEvent.insert_exits!(exits)
+    assert :ok = DB.EthEvent.insert_exits!(exits, :in_flight_exit)
   end
 
   @tag fixtures: [:alice, :initial_blocks]

--- a/apps/omg_watcher_info/test/omg_watcher_info/exit_consumer_test.exs
+++ b/apps/omg_watcher_info/test/omg_watcher_info/exit_consumer_test.exs
@@ -25,6 +25,7 @@ defmodule OMG.WatcherInfo.ExitConsumerTest do
 
   require Utxo
 
+  @eth OMG.Eth.zero_address()
   @root_chain_txhash1 <<11::256>>
   @root_chain_txhash2 <<12::256>>
 
@@ -93,6 +94,21 @@ defmodule OMG.WatcherInfo.ExitConsumerTest do
       send_events_and_wait_until_processed(event_data)
 
       assert alice.addr |> get_utxos_pos() |> none_in(spent_utxos_pos)
+    end
+
+    @tag fixtures: [:alice, :initial_blocks]
+    test "receiving IFE output piggybacked event is reflected in balance", %{alice: alice} do
+      %{creating_txhash: txhash, oindex: oindex, amount: exiting_amount} = alice.addr |> get_utxos_for() |> hd()
+      [%{currency: @eth, amount: initial_balance}] = DB.TxOutput.get_balance(alice.addr)
+
+      event_data = [
+        %{log_index: 2, root_chain_txhash: @root_chain_txhash2, call_data: %{txhash: txhash, oindex: oindex}}
+      ]
+
+      send_events_and_wait_until_processed(event_data)
+
+      expected_balance = initial_balance - exiting_amount
+      assert [%{currency: @eth, amount: expected_balance}] == DB.TxOutput.get_balance(alice.addr)
     end
 
     @tag fixtures: [:alice, :initial_blocks]

--- a/apps/omg_watcher_info/test/omg_watcher_info/exit_consumer_test.exs
+++ b/apps/omg_watcher_info/test/omg_watcher_info/exit_consumer_test.exs
@@ -32,7 +32,7 @@ defmodule OMG.WatcherInfo.ExitConsumerTest do
     {:ok, _} =
       GenServer.start_link(
         ExitConsumer,
-        [topic: :watcher_test_topic, bus_module: __MODULE__.FakeBus],
+        [topic: :watcher_test_topic, bus_module: __MODULE__.FakeBus, event_type: :in_flight_exit],
         name: TestExitConsumer
       )
 

--- a/apps/omg_watcher_info/test/omg_watcher_info/exit_consumer_test.exs
+++ b/apps/omg_watcher_info/test/omg_watcher_info/exit_consumer_test.exs
@@ -102,7 +102,12 @@ defmodule OMG.WatcherInfo.ExitConsumerTest do
       [%{currency: @eth, amount: initial_balance}] = DB.TxOutput.get_balance(alice.addr)
 
       event_data = [
-        %{log_index: 2, root_chain_txhash: @root_chain_txhash2, call_data: %{txhash: txhash, oindex: oindex}}
+        %{
+          log_index: 2,
+          eth_height: 2,
+          root_chain_txhash: @root_chain_txhash2,
+          call_data: %{txhash: txhash, oindex: oindex}
+        }
       ]
 
       send_events_and_wait_until_processed(event_data)


### PR DESCRIPTION
Addresses #1520 needed for 0.4.9 😑 

## Overview

Reporting appropriate event type from Watcher-Info's exit consumer.

## Changes

Pushing appropriate event type to the `ExitConsumer` so the correct type of the spending event can be persisted in Postgres DB.

## Testing

Exit consumer tests cover the change.
